### PR TITLE
Add support for matching specifiers

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -1,0 +1,31 @@
+/*
+ * Curation Tool CSS stylesheet
+ *
+ * Copyright (C) Phyloreferencing Project, 2018
+ */
+
+/*
+ * Create a table class for a fixed size body.
+ * Based on https://stackoverflow.com/a/23518856/27310
+ */
+.table-fixed-height {
+}
+
+.table-fixed-height thead {
+    display: block;
+    width: 100%;
+}
+
+.table-fixed-height tbody {
+    display: block;
+    width: 100%;
+    height: 15em;
+    overflow-y: scroll;
+    z-index: -1;
+}
+
+.table-fixed-height tr {
+    width: 100%;
+    display: inline-table;
+    table-layout: fixed;
+}

--- a/examples/hillis_and_wilcox_2005.json
+++ b/examples/hillis_and_wilcox_2005.json
@@ -19,7 +19,6 @@
 
         "additionalNodeProperties": {
             "Rana areolata": {
-                "additionalLabels": ["Rana areolata"],
                 "hasBasisOfRecord": {
                     "locatedAt": {
                         "verbatimLocality": "KU 204370: USA: Kansas: Lyon: just S of Hartsford"
@@ -31,7 +30,6 @@
                 }
             },
             "Rana aurora": {
-                "additionalLabels": ["Rana aurora"],
                 "hasBasisOfRecord": {
                     "locatedAt": {
                         "verbatimLocality": "MVZ 188960: USA: California: Del Norte: Kings Valley Rd., 2.4 mi N Hwy. 199"
@@ -43,7 +41,6 @@
                 }
             },
             "Rana berlandieri": {
-                "additionalLabels": ["Rana berlandieri"],
                 "hasBasisOfRecord": {
                     "locatedAt": {
                         "verbatimLocality": "JSF 1136: USA: TX: Hays: San Marcos"
@@ -55,7 +52,6 @@
                 }
             },
             "Rana blairi": {
-                "additionalLabels": ["Rana blairi"],
                 "hasBasisOfRecord": {
                     "locatedAt": {
                         "verbatimLocality": "JSF 830: USA: Kansas: Douglas: Lawrence"
@@ -67,7 +63,6 @@
                 }
             },
             "Rana boylii": {
-                "additionalLabels": ["Rana boylii"],
                 "hasBasisOfRecord": {
                     "locatedAt": {
                         "verbatimLocality": "MVZ 148929: USA: California: Lake: along Butts Creek, 0.4 mi NW Napa County line"
@@ -79,7 +74,6 @@
                 }
             },
             "Rana bwana": {
-                "additionalLabels": ["Rana bwana"],
                 "hasBasisOfRecord": {
                     "locatedAt": {
                         "verbatimLocality": "QCAZ 13964: Ecuador: Prov. Loja: Río Alamor near Zapotillo"
@@ -91,7 +85,6 @@
                 }
             },
             "Rana capito": {
-                "additionalLabels": ["Rana capito"],
                 "hasBasisOfRecord": {
                     "locatedAt": {
                         "verbatimLocality": "TNHC 60195: USA: Florida: Marion: Archibold Biological Station"
@@ -103,7 +96,6 @@
                 }
             },
             "Rana cascadae": {
-                "additionalLabels": ["Rana cascadae"],
                 "hasBasisOfRecord": {
                     "locatedAt": {
                         "verbatimLocality": "MVZ 148946: USA: California: Shasta: Dersch Meadows"
@@ -115,17 +107,20 @@
                 }
             },
             "Rana catesbiana X12841": {
-                "additionalLabels": ["Rana catesbeiana"],
                 "hasBasisOfRecord": {
                     "locatedAt": {
                         "verbatimLocality": "GenBank sequence; locality unknown"
                     },
                     "GenBankID": "GB X12841",
                     "skos:closeMatch": "https://www.ncbi.nlm.nih.gov/nuccore/GB X12841"
-                }
+                },
+                "representsTaxonomicUnits": [{
+                    "scientificNames": [{
+                        "binomialName": "Rana catesbeiana"
+                    }]
+                }]
             },
             "Rana catesbiana DMH84R2": {
-                "additionalLabels": ["Rana catesbeiana"],
                 "hasBasisOfRecord": {
                     "locatedAt": {
                         "verbatimLocality": "DMH 84-R2: USA: Kansas: Douglas: Lawrence"
@@ -134,10 +129,14 @@
                     "catalogNumber": "84-R2",
                     "GenBankID": "AY779206",
                     "skos:closeMatch": "https://www.ncbi.nlm.nih.gov/nuccore/AY779206"
-                }
+                },
+                "representsTaxonomicUnits": [{
+                    "scientificNames": [{
+                        "binomialName": "Rana catesbeiana"
+                    }]
+                }]
             },
             "Rana chiricahuensis KU 194442": {
-                "additionalLabels": ["Rana chiricahuensis"],
                 "hasBasisOfRecord": {
                     "locatedAt": {
                         "verbatimLocality": "KU 194442: Mexico: Durango: Río Chico at Mexico Hwy. 40"
@@ -146,10 +145,14 @@
                     "catalogNumber": "194442",
                     "GenBankID": "AY779225",
                     "skos:closeMatch": "https://www.ncbi.nlm.nih.gov/nuccore/AY779225"
-                }
+                },
+                "representsTaxonomicUnits": [{
+                    "scientificNames": [{
+                        "binomialName": "Rana chiricahuensis"
+                    }]
+                }]
             },
             "Rana chiricahuensis KU 194419": {
-                "additionalLabels": ["Rana chiricahuensis"],
                 "hasBasisOfRecord": {
                     "locatedAt": {
                         "verbatimLocality": "KU 194419: USA: Arizona: Apache: Apache National Forest: Three Forks"
@@ -158,10 +161,14 @@
                     "catalogNumber": "194419",
                     "GenBankID": "AY779226",
                     "skos:closeMatch": "https://www.ncbi.nlm.nih.gov/nuccore/AY779226"
-                }
+                },
+                "representsTaxonomicUnits": [{
+                    "scientificNames": [{
+                        "binomialName": "Rana chiricahuensis"
+                    }]
+                }]
             },
             "Rana clamitans": {
-                "additionalLabels": ["Rana clamitans"],
                 "hasBasisOfRecord": {
                     "locatedAt": {
                         "verbatimLocality": "JSF 1118: USA: Missouri: Montgomery: 3 km W Danville"
@@ -173,7 +180,6 @@
                 }
             },
             "Rana dunni": {
-                "additionalLabels": ["Rana dunni"],
                 "hasBasisOfRecord": {
                     "locatedAt": {
                         "verbatimLocality": "KU 194527: Mexico: Michoacan: Tintzuntzan, Lago Patzcuaro"
@@ -185,7 +191,6 @@
                 }
             },
             "Rana forreri": {
-                "additionalLabels": ["Rana forreri"],
                 "hasBasisOfRecord": {
                     "locatedAt": {
                         "verbatimLocality": "KU 194581: Mexico: Sinaloa: 37.9 km S Escuinapa"
@@ -197,7 +202,6 @@
                 }
             },
             "Rana grylio": {
-                "additionalLabels": ["Rana grylio"],
                 "hasBasisOfRecord": {
                     "locatedAt": {
                         "verbatimLocality": "MVZ 175945: USA: Florida: Leon: Tall Timbers Research Station, Lake Iamonia"
@@ -209,7 +213,6 @@
                 }
             },
             "Rana heckscheri": {
-                "additionalLabels": ["Rana heckscheri"],
                 "hasBasisOfRecord": {
                     "locatedAt": {
                         "verbatimLocality": "MVZ 164908: USA: Florida: Gadsen-Leon: Overflow creek of Ochlocknee River at Hwy. S-12"
@@ -221,7 +224,6 @@
                 }
             },
             "Rana juliani": {
-                "additionalLabels": ["Rana juliani"],
                 "hasBasisOfRecord": {
                     "locatedAt": {
                         "verbatimLocality": "TNHC 60324: Belize: Cayo District: Little Vaqueros Creek"
@@ -233,7 +235,6 @@
                 }
             },
             "Rana luteiventris MVZ225749": {
-                "additionalLabels": ["Rana luteiventris"],
                 "hasBasisOfRecord": {
                     "locatedAt": {
                         "verbatimLocality": "MVZ 225749: USA: Washington: Pend Oreille: Colville Natl. Forest; Flowery Trail Road, 6.1 mi E 49 Degrees Ski area"
@@ -242,10 +243,14 @@
                     "catalogNumber": "225749",
                     "GenBankID": "AY779193",
                     "skos:closeMatch": "https://www.ncbi.nlm.nih.gov/nuccore/AY779193"
-                }
+                },
+                "representsTaxonomicUnits": [{
+                    "scientificNames": [{
+                        "binomialName": "Rana luteiventris"
+                    }]
+                }]
             },
             "Rana luteiventris MVZ191016": {
-                "additionalLabels": ["Rana luteiventris"],
                 "hasBasisOfRecord": {
                     "locatedAt": {
                         "verbatimLocality": "MVZ 191016: USA: Montana: Lincoln: Dry Creek at Hwy. 56"
@@ -254,10 +259,14 @@
                     "catalogNumber": "191016",
                     "GenBankID": "AY779194",
                     "skos:closeMatch": "https://www.ncbi.nlm.nih.gov/nuccore/AY779194"
-                }
+                },
+                "representsTaxonomicUnits": [{
+                    "scientificNames": [{
+                        "binomialName": "Rana luteiventris"
+                    }]
+                }]
             },
             "Rana macroglossa": {
-                "additionalLabels": ["Rana macroglossa"],
                 "hasBasisOfRecord": {
                     "locatedAt": {
                         "verbatimLocality": "KU 195138: Mexico: Chiapas: 7.7 km SE San Cristobal de las Casas"
@@ -270,7 +279,6 @@
             },
             "Rana macroglossa b": {
                 "comment": "I'm assuming this is 'b', because it's listed second in the table, but there's no clear evidence one way or the other.",
-                "additionalLabels": ["Rana macroglossa"],
                 "hasBasisOfRecord": {
                     "locatedAt": {
                         "verbatimLocality": "UTA A-17185: Guatemala: Sololá: Panajachel, Lake Atitlan"
@@ -279,10 +287,14 @@
                     "catalogNumber": "A-17185",
                     "GenBankID": "AY779243",
                     "skos:closeMatch": "https://www.ncbi.nlm.nih.gov/nuccore/AY779243"
-                }
+                },
+                "representsTaxonomicUnits": [{
+                    "scientificNames": [{
+                        "binomialName": "Rana macroglossa"
+                    }]
+                }]
             },
             "Rana maculata": {
-                "additionalLabels": ["Rana maculata"],
                 "hasBasisOfRecord": {
                     "locatedAt": {
                         "verbatimLocality": "KU 195258: Mexico: Oaxaca: Colonia Rodulfo Figueroa, 19 km NW Rizo de Oro"
@@ -294,7 +306,6 @@
                 }
             },
             "Rana magnaocularis": {
-                "additionalLabels": ["Rana magnaocularis"],
                 "hasBasisOfRecord": {
                     "locatedAt": {
                         "verbatimLocality": "KU 194592: Mexico: Sonora: Arroyo Hondo, 15.2 km N Nuri"
@@ -306,7 +317,6 @@
                 }
             },
             "Rana montezumae": {
-                "additionalLabels": ["Rana montezumae"],
                 "hasBasisOfRecord": {
                     "locatedAt": {
                         "verbatimLocality": "KU 195251: Mexico: Morelos: Lagunas Zempoala"
@@ -318,7 +328,6 @@
                 }
             },
             "Rana muscosa": {
-                "additionalLabels": ["Rana muscosa"],
                 "hasBasisOfRecord": {
                     "locatedAt": {
                         "verbatimLocality": "MVZ 149006: USA: California: Mono: Meadows below Levitt Lake, W side Sonora Pass"
@@ -330,7 +339,6 @@
                 }
             },
             "Rana neovolcanica": {
-                "additionalLabels": ["Rana neovolcanica"],
                 "hasBasisOfRecord": {
                     "locatedAt": {
                         "verbatimLocality": "KU 194536: Mexico: Michoacan: Zurumbueno"
@@ -342,7 +350,6 @@
                 }
             },
             "Rana okaloosae": {
-                "additionalLabels": ["Rana okaloosae"],
                 "hasBasisOfRecord": {
                     "locatedAt": {
                         "verbatimLocality": "toe clip (released): USA:Florida: Santa Rosa: 5 km E Harold, Garnier Creek (collected by Paul Moler)"
@@ -352,7 +359,6 @@
                 }
             },
             "Rana omiltemana": {
-                "additionalLabels": ["Rana omiltemana"],
                 "hasBasisOfRecord": {
                     "locatedAt": {
                         "verbatimLocality": "KU 195179: Mexico: Guerrero: Agua de Obispo"
@@ -364,7 +370,6 @@
                 }
             },
             "Rana onca": {
-                "additionalLabels": ["Rana onca"],
                 "hasBasisOfRecord": {
                     "locatedAt": {
                         "verbatimLocality": "LVT 3542: USA: Nevada: Clark: Blue Point Spring, Lake Mead"
@@ -376,7 +381,6 @@
                 }
             },
             "Rana palmipes AMNHA118801": {
-                "additionalLabels": ["Rana palmipes"],
                 "hasBasisOfRecord": {
                     "locatedAt": {
                         "verbatimLocality": "AMNH A-118801: Venezuela: Prov. Amazonas: Neblina Base Camp on Río Mawarinuma"
@@ -385,10 +389,14 @@
                     "catalogNumber": "A-118801",
                     "GenBankID": "AY779210",
                     "skos:closeMatch": "https://www.ncbi.nlm.nih.gov/nuccore/AY779210"
-                }
+                },
+                "representsTaxonomicUnits": [{
+                    "scientificNames": [{
+                        "binomialName": "Rana palmipes"
+                    }]
+                }]
             },
             "Rana palmipes KU204425": {
-                "additionalLabels": ["Rana palmipes"],
                 "hasBasisOfRecord": {
                     "locatedAt": {
                         "verbatimLocality": "KU 202896: Ecuador: Prov. Napo: Misahuallí"
@@ -397,10 +405,14 @@
                     "catalogNumber": "202896",
                     "GenBankID": "AY779211",
                     "skos:closeMatch": "https://www.ncbi.nlm.nih.gov/nuccore/AY779211"
-                }
+                },
+                "representsTaxonomicUnits": [{
+                    "scientificNames": [{
+                        "binomialName": "Rana palmipes"
+                    }]
+                }]
             },
             "Rana palustris": {
-                "additionalLabels": ["Rana palustris"],
                 "hasBasisOfRecord": {
                     "locatedAt": {
                         "verbatimLocality": "KU 204425: USA: Indiana: Washington: Cave Creek near Campbellsburg"
@@ -412,17 +424,20 @@
                 }
             },
             "Rana pipiens Y10945": {
-                "additionalLabels": ["Rana pipiens"],
                 "hasBasisOfRecord": {
                     "locatedAt": {
                         "verbatimLocality": "GenBank sequence; locality unknown"
                     },
                     "GenBankID": "GBX12841",
                     "skos:closeMatch": "https://www.ncbi.nlm.nih.gov/nuccore/GBX12841"
-                }
+                },
+                "representsTaxonomicUnits": [{
+                    "scientificNames": [{
+                        "binomialName": "Rana pipiens"
+                    }]
+                }]
             },
             "Rana pipiens JSF1119": {
-                "additionalLabels": ["Rana pipiens"],
                 "hasBasisOfRecord": {
                     "locatedAt": {
                         "verbatimLocality": "JSF 1119: USA: Ohio: Ottawa: Little Portage State Park"
@@ -431,10 +446,14 @@
                     "catalogNumber": "1119",
                     "GenBankID": "AY779221",
                     "skos:closeMatch": "https://www.ncbi.nlm.nih.gov/nuccore/AY779221"
-                }
+                },
+                "representsTaxonomicUnits": [{
+                    "scientificNames": [{
+                        "binomialName": "Rana pipiens"
+                    }]
+                }]
             },
             "Rana psilonota": {
-                "additionalLabels": ["Rana psilonota"],
                 "hasBasisOfRecord": {
                     "locatedAt": {
                         "verbatimLocality": "KU 195119: Mexico: Jalisco: 2.4 km NW Tapalpa"
@@ -446,7 +465,6 @@
                 }
             },
             "Rana pustulosa": {
-                "additionalLabels": ["Rana pustulosa"],
                 "hasBasisOfRecord": {
                     "locatedAt": {
                         "verbatimLocality": "KU 200776: Mexico: Sinaloa: 2.1 km NE Santa Lucia"
@@ -458,7 +476,6 @@
                 }
             },
             "Rana septentrionales": {
-                "additionalLabels": ["Rana septentrionalis"],
                 "hasBasisOfRecord": {
                     "locatedAt": {
                         "verbatimLocality": "TNHC tissue collection: Canada: Ontario: Grey"
@@ -466,10 +483,14 @@
                     "ownerInstitutionCode": "TNHC tissue collection",
                     "GenBankID": "AY779200",
                     "skos:closeMatch": "https://www.ncbi.nlm.nih.gov/nuccore/AY779200"
-                }
+                },
+                "representsTaxonomicUnits": [{
+                    "scientificNames": [{
+                        "binomialName": "Rana septentrionalis"
+                    }]
+                }]
             },
             "Rana sevosa": {
-                "additionalLabels": ["Rana sevosa"],
                 "hasBasisOfRecord": {
                     "locatedAt": {
                         "verbatimLocality": "TNHC 60194: USA: Mississippi: Harrison"
@@ -481,7 +502,6 @@
                 }
             },
             "Rana sierramadrensis": {
-                "additionalLabels": ["Rana sierramadrensis"],
                 "hasBasisOfRecord": {
                     "locatedAt": {
                         "verbatimLocality": "KU 195181: Mexico: Guerrero: Agua de Obispo, 24.2 mi S Chilpancingo"
@@ -493,7 +513,6 @@
                 }
             },
             "Rana spectabilis": {
-                "additionalLabels": ["Rana spectabilis"],
                 "hasBasisOfRecord": {
                     "locatedAt": {
                         "verbatimLocality": "KU 195186: Mexico: Hidalgo: La Estanzuela (holotype)"
@@ -507,7 +526,6 @@
                 }
             },
             "Rana sphenocephela": {
-                "additionalLabels": ["Rana sphenocephala"],
                 "hasBasisOfRecord": {
                     "locatedAt": {
                         "verbatimLocality": "JSF 845: USA: Kansas: Cherokee"
@@ -516,10 +534,14 @@
                     "catalogNumber": "845",
                     "GenBankID": "AY779251",
                     "skos:closeMatch": "https://www.ncbi.nlm.nih.gov/nuccore/AY779251"
-                }
+                },
+                "representsTaxonomicUnits": [{
+                    "scientificNames": [{
+                        "binomialName": "Rana sphenocephala"
+                    }]
+                }]
             },
             "Rana sphenocephela utricularia": {
-                "additionalLabels": ["Rana sphenocephala utricularia"],
                 "hasBasisOfRecord": {
                     "locatedAt": {
                         "verbatimLocality": "USC 7448: USA: Florida: Loop Road, Big Cypress National Preserve"
@@ -528,10 +550,15 @@
                     "catalogNumber": "7448",
                     "GenBankID": "AY779252",
                     "skos:closeMatch": "https://www.ncbi.nlm.nih.gov/nuccore/AY779252"
-                }
+                },
+                "representsTaxonomicUnits": [{
+                    "scientificNames": [{
+                        "scientificName": "Rana sphenocephala utricularia",
+                        "binomialName": "Rana sphenocephala"
+                    }]
+                }]
             },
             "Rana subaquavocalis": {
-                "additionalLabels": ["Rana subaquavocalis"],
                 "hasBasisOfRecord": {
                     "locatedAt": {
                         "verbatimLocality": "James Platz Collection (specimens destroyed, DNA in TNHC tissue collection): USA: Arizona: Cochise: Ramsey Canyon"
@@ -542,7 +569,6 @@
                 }
             },
             "Rana sylvatica": {
-                "additionalLabels": ["Rana sylvatica"],
                 "hasBasisOfRecord": {
                     "locatedAt": {
                         "verbatimLocality": "MVZ 137426: USA: New York: Tompkins; Connecticut Hill, ca. 10 mi SW Ithaca"
@@ -554,7 +580,6 @@
                 }
             },
             "Rana sylvatica DMH84R43": {
-                "additionalLabels": ["Rana sylvatica"],
                 "hasBasisOfRecord": {
                     "locatedAt": {
                         "verbatimLocality": "DMH 84-R43: USA: Missouri: St. Louis: Tyson Environmental Study Area"
@@ -563,10 +588,14 @@
                     "catalogNumber": "84-R43",
                     "GenBankID": "AY779199",
                     "skos:closeMatch": "https://www.ncbi.nlm.nih.gov/nuccore/AY779199"
-                }
+                },
+                "representsTaxonomicUnits": [{
+                    "scientificNames": [{
+                        "binomialName": "Rana sylvatica"
+                    }]
+                }]
             },
             "Rana tarahumarae": {
-                "additionalLabels": ["Rana tarahumarae"],
                 "hasBasisOfRecord": {
                     "locatedAt": {
                         "verbatimLocality": "KU 194596: Mexico: Sonora: 14.4 km E Yecora"
@@ -578,7 +607,6 @@
                 }
             },
             "Rana taylori": {
-                "additionalLabels": ["Rana taylori"],
                 "hasBasisOfRecord": {
                     "locatedAt": {
                         "verbatimLocality": "TCWC 55963: Nicaragua: Zelaya: 2.5 mi NW Rama"
@@ -590,7 +618,6 @@
                 }
             },
             "Rana temporaria": {
-                "additionalLabels": ["Rana temporaria"],
                 "hasBasisOfRecord": {
                     "locatedAt": {
                         "verbatimLocality": "DMH 84-R1: Switzerland: Valais Canton: 1.8 km NNE Grand St. Bernard Pass"
@@ -602,7 +629,6 @@
                 }
             },
             "Rana tlaloci": {
-                "additionalLabels": ["Rana tlaloci"],
                 "hasBasisOfRecord": {
                     "locatedAt": {
                         "verbatimLocality": "KU 194436: Mexico: Distrito Federal: Xochimilco (paratype)"
@@ -614,7 +640,6 @@
                 }
             },
             "Rana vaillanti": {
-                "additionalLabels": ["Rana vaillanti"],
                 "hasBasisOfRecord": {
                     "locatedAt": {
                         "verbatimLocality": "KU 195299: Mexico: Oaxaca: 5.6 mi NE Tapanatepec"
@@ -626,7 +651,6 @@
                 }
             },
             "Rana vibicaria": {
-                "additionalLabels": ["Rana vibicaria"],
                 "hasBasisOfRecord": {
                     "locatedAt": {
                         "verbatimLocality": "MVZ 149033: Costa Rica: Prov. San José: El Empalme"
@@ -638,7 +662,6 @@
                 }
             },
             "Rana virgatipes": {
-                "additionalLabels": ["Rana virgatipes"],
                 "hasBasisOfRecord": {
                     "locatedAt": {
                         "verbatimLocality": "MVZ 175944: USA: Louisiana: De Soto Parish; Frierson"
@@ -650,7 +673,6 @@
                 }
             },
             "Rana warszewitshii": {
-                "additionalLabels": ["Rana warszewitschii"],
                 "hasBasisOfRecord": {
                     "locatedAt": {
                         "verbatimLocality": "JSF 1127: Panama"
@@ -659,10 +681,14 @@
                     "catalogNumber": "1127",
                     "GenBankID": "AY779209",
                     "skos:closeMatch": "https://www.ncbi.nlm.nih.gov/nuccore/AY779209"
-                }
+                },
+                "representsTaxonomicUnits": [{
+                    "scientificNames": [{
+                        "binomialName": "Rana warszewitschii"
+                    }]
+                }]
             },
             "Rana yavapaiensis": {
-                "additionalLabels": ["Rana yavapaiensis"],
                 "hasBasisOfRecord": {
                     "locatedAt": {
                         "verbatimLocality": "KU 194423: USA: Arizona: Greenlee: Apache National Forest at Juan Miller Crossing"
@@ -674,7 +700,6 @@
                 }
             },
             "Rana zweifelii": {
-                "additionalLabels": ["Rana zweifeli"],
                 "hasBasisOfRecord": {
                     "locatedAt": {
                         "verbatimLocality": "KU 195310: Mexico: Oaxaca: 1.6 mi S Cuyotepej"
@@ -683,10 +708,14 @@
                     "catalogNumber": "195310",
                     "GenBankID": "AY779219",
                     "skos:closeMatch": "https://www.ncbi.nlm.nih.gov/nuccore/AY779219"
-                }
+                },
+                "representsTaxonomicUnits": [{
+                    "scientificNames": [{
+                        "binomialName": "Rana zweifeli"
+                    }]
+                }]
             },
             "Rana sp1 QCAZ13219": {
-                "additionalLabels": ["Rana sp1"],
                 "hasBasisOfRecord": {
                     "locatedAt": {
                         "verbatimLocality": "QCAZ 13219: Ecuador: Prov. Esmeraldas: 5 km W Durango"
@@ -698,7 +727,6 @@
                 }
             },
             "Rana sp2 KU 204420": {
-                "additionalLabels": ["Rana sp2"],
                 "hasBasisOfRecord": {
                     "locatedAt": {
                         "verbatimLocality": "KU 204420: Mexico: San Luis Potosí: Rodeo"
@@ -710,7 +738,6 @@
                 }
             },
             "Rana sp3 KU 194559": {
-                "additionalLabels": ["Rana sp3"],
                 "hasBasisOfRecord": {
                     "locatedAt": {
                         "verbatimLocality": "KU 194559: Mexico: Michoacan: 11.4 km E junction Mexico Hwy. 51 and 15"
@@ -722,7 +749,6 @@
                 }
             },
             "Rana sp4 AMNH A 124167": {
-                "additionalLabels": ["Rana sp4"],
                 "hasBasisOfRecord": {
                     "locatedAt": {
                         "verbatimLocality": "AMNH A-124167: Panama: Chiriquí: 9 km SSE El Volcán"
@@ -734,7 +760,6 @@
                 }
             },
             "Rana sp5 LACM 146764": {
-                "additionalLabels": ["Rana sp5"],
                 "hasBasisOfRecord": {
                     "locatedAt": {
                         "verbatimLocality": "LACM 146764: Costa Rica: Heredia: Monte de la Cruz"
@@ -746,7 +771,6 @@
                 }
             },
             "Rana sp6 LACM 146810": {
-                "additionalLabels": ["Rana sp6"],
                 "hasBasisOfRecord": {
                     "locatedAt": {
                         "verbatimLocality": "LACM 146810: Costa Rica: Puntarenas: near mouth of Rio Barranca, 10 km E Puntarenas"
@@ -758,7 +782,6 @@
                 }
             },
             "Rana sp7 KU 194492": {
-                "additionalLabels": ["Rana sp7"],
                 "hasBasisOfRecord": {
                     "locatedAt": {
                         "verbatimLocality": "KU 194492: Mexico: Jalisco: Contla"
@@ -770,7 +793,6 @@
                 }
             },
             "Rana sp8 KU 195346": {
-                "additionalLabels": ["Rana sp8"],
                 "hasBasisOfRecord": {
                     "locatedAt": {
                         "verbatimLocality": "KU 195346: Mexico: Puebla: Río Atoyac at Mexico Hwy. 190"

--- a/examples/hillis_and_wilcox_2005.json
+++ b/examples/hillis_and_wilcox_2005.json
@@ -1045,17 +1045,17 @@
             "label": "Torrentirana",
             "cladeDefinition": "Torrentirana, new clade name. Definition: The clade stemming from the most recent common ancestor of Rana tarahumarae Boulenger 1917 and Rana sierramadrensis Taylor 1939",
             "internalSpecifiers": [{
-                "references_taxonomic_units": [{
-                    "scientific_names": [{
-                        "scientific_name": "Rana tarahumarae Boulenger 1917",
-                        "binomial_name": "Rana tarahumarae"
+                "referencesTaxonomicUnits": [{
+                    "scientificNames": [{
+                        "scientificName": "Rana tarahumarae Boulenger 1917",
+                        "binomialName": "Rana tarahumarae"
                     }]
                 }]
             }, {
-                "references_taxonomic_units": [{
-                    "scientific_names": [{
-                        "scientific_name": "Rana sierramadrensis Taylor 1939",
-                        "binomial_name": "Rana sierramadrensis"
+                "referencesTaxonomicUnits": [{
+                    "scientificNames": [{
+                        "scientificName": "Rana sierramadrensis Taylor 1939",
+                        "binomialName": "Rana sierramadrensis"
                     }]
                 }]
             }]
@@ -1063,17 +1063,17 @@
             "label": "Zweifelia",
             "cladeDefinition": "Zweifelia Dubois 1992 (converted clade name). Definition: The clade stemming from the most recent common ancestor of Rana tarahumarae Boulenger 1917 and Rana zweifeli Hillis, Frost and Webb 1984.",
             "internalSpecifiers": [{
-                "references_taxonomic_units": [{
-                    "scientific_names": [{
-                        "scientific_name": "Rana tarahumarae Boulenger 1917",
-                        "binomial_name": "Rana tarahumarae"
+                "referencesTaxonomicUnits": [{
+                    "scientificNames": [{
+                        "scientificName": "Rana tarahumarae Boulenger 1917",
+                        "binomialName": "Rana tarahumarae"
                     }]
                 }]
             }, {
-                "references_taxonomic_units": [{
-                    "scientific_names": [{
-                        "scientific_name": "Rana zweifeli Hillis, Frost and Webb 1984",
-                        "binomial_name": "Rana zweifeli"
+                "referencesTaxonomicUnits": [{
+                    "scientificNames": [{
+                        "scientificName": "Rana zweifeli Hillis, Frost and Webb 1984",
+                        "binomialName": "Rana zweifeli"
                     }]
                 }]
             }]

--- a/index.html
+++ b/index.html
@@ -428,15 +428,21 @@
                                             ><span class="glyphicon glyphicon-remove"></span>
                                         </button>
 
-                                        <!-- Match results with dropdown menu: currently not implemented -->
+                                        <!-- Match results with dropdown menu -->
+
                                         <button
                                             @click="specifier_dropdown_target = 'match_result'"
-                                            type="button" class="btn btn-warning dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                                            <span class="glyphicon glyphicon-asterisk"></span>
+                                            type="button" class="btn dropdown-toggle" :class="{ 'btn-warning': get_all_node_labels_matched_by_specifier(specifier).length == 0, 'btn-success': get_all_node_labels_matched_by_specifier(specifier).length > 0}" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                                            <span class="glyphicon" :class="{ 'glyphicon-asterisk': get_all_node_labels_matched_by_specifier(specifier).length == 0, 'glyphicon-ok': get_all_node_labels_matched_by_specifier(specifier).length > 0}"></span>
                                         </button>
                                         <ul v-if="specifier_dropdown_target == 'match_result'" class="dropdown-menu dropdown-menu-left">
                                             <li class="dropdown-header">Match result</li>
-                                            <li><a href="#" onclick="return false;"><em>Matching not implemented.</em></a></li>
+                                            <li v-if="get_all_node_labels_matched_by_specifier(specifier).length == 0">
+                                                <a href="#" onclick="return false;"><em>No matches</em></a>
+                                            </li>
+                                            <li v-for="(node_label, node_label_index) of get_all_node_labels_matched_by_specifier(specifier)">
+                                                <a href="#" onclick="return false;">{{node_label}}<a>
+                                            </li>
                                         </ul>
 
                                         <!-- Specifier type with dropdown menu: internal or external specifier -->

--- a/index.html
+++ b/index.html
@@ -174,30 +174,30 @@
             </div>
         </div>
 
-        <!-- Specifier modal: dialog box to allow editing the current specifier -->
-        <div id="specifier-modal" class="modal fade">
+        <!-- Taxonomic unit editing modal: dialog box to allow editing lists of taxonomic units -->
+        <div id="tunit-editor-modal" class="modal fade">
             <div class="modal-dialog modal-lg form-horizontal">
-                <div class="modal-content" v-if="selected_specifier">
+                <div class="modal-content" v-if="selected_tunit_list">
 
-                    <!-- Header of specifier editor modal dialog box -->
+                    <!-- Header of tunit editor modal dialog box -->
                     <div class="modal-header">
                         <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-                        <h4 class="modal-title">Editing specifier: {{get_specifier_label(selected_specifier)}}</h4>
+                        <h4 class="modal-title">Editing {{tunit_editor_target_label}}</h4>
                     </div>
 
                     <!-- Body of specifier editor modal dialog box -->
                     <div class="modal-body form-group">
                         <div class="col-md-12">
                             <p>
-                                Specifiers reference a number of taxonomic units. You will usually only need to reference a
-                                single taxonomic specifier, but this interface allows you to examine all taxonomic units that
-                                this specifier references.
+                                Each taxonomic unit can have any number of scientific names, external
+                                references and specimens. We recommend using a single taxonomic unit
+                                for each type of identifier.
                             </p>
 
-                            <form id="specifier">
+                            <form id="tunit-editor-form">
 
                                 <!-- List of taxonomic units -->
-                                <div id="specifier-tunits-panel" class="panel panel-info" style="margin-top: 1em">
+                                <div id="tunits-panel" class="panel panel-info" style="margin-top: 1em">
                                     <div class="panel-heading">Taxonomic Units</div>
                                     <div class="panel-body" v-if="!selected_tunit">
                                         <p><em>Select a taxonomic unit or create a new one.</em></p>
@@ -316,15 +316,14 @@
                                     <!-- List of taxonomic units, including the option to add new taxonomic units -->
                                     <div class="list-group">
                                         <a class="list-group-item"
-                                            v-if="selected_specifier.hasOwnProperty('referencesTaxonomicUnits')"
-                                            v-for="(tunit, tunit_index) of selected_specifier.referencesTaxonomicUnits"
+                                            v-for="(tunit, tunit_index) of selected_tunit_list"
                                             :class="{active: selected_tunit === tunit}"
                                             @click="selected_tunit = tunit"
                                             :title="get_taxonomic_unit_label(tunit)"
                                         >{{get_taxonomic_unit_label(tunit)}}</a>
                                         <a class="list-group-item"
                                             href="javascript: void(0)"
-                                            onclick="if(!vm.selected_specifier.hasOwnProperty('referencesTaxonomicUnits')) vm.selected_specifier.referencesTaxonomicUnits = []; vm.selected_specifier.referencesTaxonomicUnits.push(vm.create_empty_taxonomic_unit(vm.selected_specifier.referencesTaxonomicUnits.length + 1))"
+                                            onclick="vm.selected_tunit_list.push(vm.create_empty_taxonomic_unit(vm.selected_tunit_list.length + 1))"
                                             ><strong>Add new taxonomic unit</strong></a>
                                     </div>
 
@@ -335,7 +334,7 @@
 
                     <!-- Footer of the specifier editor modal dialog box -->
                     <div class="modal-footer">
-                        <button type="button" class="btn btn-default" data-dismiss="modal" @click="close_specifier_modal(selected_specifier)">Close</button>
+                        <button type="button" class="btn btn-default" data-dismiss="modal" @click="close_tunit_editor_modal()">Close</button>
                     </div>
                 </div>
             </div>
@@ -419,7 +418,7 @@
                                     <!-- Buttons after specifier label: edit button -->
                                     <div class="input-group-btn">
                                         <button type="button" class="btn btn-primary"
-                                            @click="start_specifier_modal(specifier)"
+                                            @click="start_tunit_editor_modal('specifier', specifier)"
                                             ><span class="glyphicon glyphicon-edit"></span></button>
                                     </div>
                                 </div>

--- a/index.html
+++ b/index.html
@@ -174,8 +174,8 @@
                                     <th>Value</th>
                                 </tr>
                                 <template
-                                    v-if="get_node_labels_for_phylogeny(phylogeny).length > 0"
-                                    v-for="(node_label, node_label_index) of get_node_labels_for_phylogeny(phylogeny)"
+                                    v-if="get_node_labels_in_phylogeny(phylogeny).length > 0"
+                                    v-for="(node_label, node_label_index) of get_node_labels_in_phylogeny(phylogeny)"
                                 >
                                     <template
                                         v-if="phylogeny.hasOwnProperty('additionalNodeProperties') && phylogeny.additionalNodeProperties.hasOwnProperty(node_label)"
@@ -195,13 +195,13 @@
                                     </template>
                                 </template>
 
-                                <template v-if="get_node_labels_for_phylogeny(phylogeny).length == 0">
+                                <template v-if="get_node_labels_in_phylogeny(phylogeny).length == 0">
                                     <tr><td style="text-align: center"><em>No labeled nodes in this phylogeny.</em></td></tr>
                                 </template>
                             </tbody>
                         </table>
 
-                        <p>This table contains {{get_node_labels_for_phylogeny(phylogeny).length}} nodes.</p>
+                        <p>This table contains {{get_node_labels_in_phylogeny(phylogeny).length}} nodes.</p>
                     </div>
                 </div>
                 <div class="panel-footer">
@@ -222,7 +222,7 @@
         <!-- Taxonomic unit editing modal: dialog box to allow editing lists of taxonomic units -->
         <div id="tunit-editor-modal" class="modal fade">
             <div class="modal-dialog modal-lg form-horizontal">
-                <div class="modal-content" v-if="selected_tunit_list">
+                <div class="modal-content" v-if="selected_tunit_list !== undefined">
 
                     <!-- Header of tunit editor modal dialog box -->
                     <div class="modal-header">

--- a/index.html
+++ b/index.html
@@ -161,9 +161,8 @@
                 <div class="panel-body">
                     <svg v-if="phylogeny_annotations_mode_for !== phylogeny" :id="'phylogeny-svg-' + phylogeny_index" :alt="get_phylogeny_as_newick('#phylogeny-svg-' + phylogeny_index, phylogeny)"></svg>
                     <div v-if="phylogeny_annotations_mode_for === phylogeny">
-                        <p>This table displays all the nodes in this phylogeny and all know annotations
-                        applied to any of these nodes. To annotate an unlabeled node, click on the node
-                        and click the "Change label" option.
+                        <p>This table displays all labeled nodes in this phylogeny and all known annotations
+                        applied to any of those nodes. A feature to change node labels is currently in development.
                         </p>
 
                         <table class="table table-bordered table-hover table-striped table-fixed-height" style="width: 100%">
@@ -173,8 +172,11 @@
                                     <th>Property</th>
                                     <th>Value</th>
                                 </tr>
+                                <template v-if="get_node_labels_in_phylogeny(phylogeny).length == 0">
+                                    <tr><td style="text-align: center"><em>No labeled nodes in this phylogeny.</em></td></tr>
+                                </template>
                                 <template
-                                    v-if="get_node_labels_in_phylogeny(phylogeny).length > 0"
+                                    v-else
                                     v-for="(node_label, node_label_index) of get_node_labels_in_phylogeny(phylogeny)"
                                 >
                                     <template
@@ -183,7 +185,7 @@
                                         <tr v-for="prop_name of Object.keys(phylogeny.additionalNodeProperties[node_label])">
                                             <td>{{node_label}}</td>
                                             <td>{{prop_name}}</td>
-                                            <td><textarea rows="4" style="width: 100%">{{JSON.stringify(phylogeny.additionalNodeProperties[node_label][prop_name])}}</textarea></td>
+                                            <td><textarea readonly rows="4" style="width: 100%">{{JSON.stringify(phylogeny.additionalNodeProperties[node_label][prop_name])}}</textarea></td>
                                         </tr>
                                     </template>
 
@@ -193,10 +195,6 @@
                                             <td colspan="2"><em>No node properties.</em></td>
                                         </tr>
                                     </template>
-                                </template>
-
-                                <template v-if="get_node_labels_in_phylogeny(phylogeny).length == 0">
-                                    <tr><td style="text-align: center"><em>No labeled nodes in this phylogeny.</em></td></tr>
                                 </template>
                             </tbody>
                         </table>
@@ -213,7 +211,7 @@
                         >{{get_phylogeny_as_newick('#phylogeny-svg-' + phylogeny_index, phylogeny)}}</textarea>
                     <div class="btn-group btn-group-justified" role="group" aria-label="Actions for phylogeny">
                         <a :href="'#phylogeny-' + phylogeny_index" @click="phylogeny_newick_mode_for = (phylogeny_newick_mode_for === undefined ? phylogeny : undefined)" class="btn btn-default">Edit as Newick</a>
-                        <a :href="'#phylogeny-' + phylogeny_index" @click="phylogeny_annotations_mode_for = (phylogeny_annotations_mode_for === undefined ? phylogeny : undefined)" class="btn btn-default">Edit annotations</a>
+                        <a :href="'#phylogeny-' + phylogeny_index" @click="phylogeny_annotations_mode_for = (phylogeny_annotations_mode_for === phylogeny ? undefined : phylogeny)" class="btn btn-default">Edit annotations</a>
                     </div>
                 </div>
             </div>
@@ -470,7 +468,7 @@
                                     <!-- Buttons after specifier label: edit button -->
                                     <div class="input-group-btn">
                                         <button type="button" class="btn btn-primary"
-                                            @click="start_tunit_editor_modal('specifier', specifier)"
+                                            @click="start_tunit_editor_modal('specifier', get_specifier_label(specifier), specifier)"
                                             ><span class="glyphicon glyphicon-edit"></span></button>
                                     </div>
                                 </div>

--- a/index.html
+++ b/index.html
@@ -23,6 +23,7 @@
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
     <link rel="stylesheet" href="https://code.jquery.com/ui/1.12.1/themes/base/jquery-ui.css">
     <link rel="stylesheet" href="https://veg.github.io/phylotree.js/phylotree.css">
+    <link rel="stylesheet" href="./css/main.css">
 
     <!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->
     <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->
@@ -165,29 +166,29 @@
                         and click the "Change label" option.
                         </p>
 
-                        <table class="sortable" style="width: 100%">
+                        <table class="table table-bordered table-hover table-striped table-fixed-height" style="width: 100%">
                             <thead>
                                 <tr>
                                     <th>Label</th>
-                                    <th class="sorttable_nosort">Annotation property</th>
-                                    <th class="sorttable_nosort">Annotation value</th>
+                                    <th>Property</th>
+                                    <th>Value</th>
                                 </tr>
                             </thead>
                             <tbody>
-                                <tr>
-                                    <td>Rana areolata</td>
+                                <tr
+                                    v-if="get_node_labels_for_phylogeny(phylogeny).length > 0"
+                                    v-for="(node_label, node_label_index) of get_node_labels_for_phylogeny(phylogeny)"
+                                >
+                                    <td>{{node_label}}</td>
                                     <td><input style="width: 100%" value="additionalLabels">
                                     Any additional labels for this node.
                                     </td>
                                     <td><input style="width: 100%" value="Rana areolata"></td>
                                 </tr>
-                                <tr>
-                                    <td>Rana areolata</td>
-                                    <td><input value="hasBasisOfRecord.locatedAt.verbatimLocality">
-                                    Unknown term.
-                                    </td>
-                                    <td><input value="KU 204370: USA: Kansas: Lyon: just S of Hartsford"></td>
-                                </tr>
+
+                                <template v-if="get_node_labels_for_phylogeny(phylogeny).length == 0">
+                                    <tr><td style="text-align: center"><em>No labeled nodes in this phylogeny.</em></td></tr>
+                                </template>
                             </tbody>
                         </table>
                     </div>
@@ -512,9 +513,6 @@
     <script src="http://d3js.org/d3.v3.min.js"></script>
     <script src="http://veg.github.io/phylotree.js/phylotree.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/underscore.js/1.8.3/underscore-min.js" charset="utf-8"></script>
-
-    <!-- Sortable tables -->
-    <script src="js/sorttable.js"></script>
 
     <!-- Our source code -->
     <script src="./js/curation-tool.js"></script>

--- a/index.html
+++ b/index.html
@@ -167,14 +167,12 @@
                         </p>
 
                         <table class="table table-bordered table-hover table-striped table-fixed-height" style="width: 100%">
-                            <thead>
+                            <tbody>
                                 <tr>
                                     <th>Label</th>
                                     <th>Property</th>
                                     <th>Value</th>
                                 </tr>
-                            </thead>
-                            <tbody>
                                 <tr
                                     v-if="get_node_labels_for_phylogeny(phylogeny).length > 0"
                                     v-for="(node_label, node_label_index) of get_node_labels_for_phylogeny(phylogeny)"

--- a/index.html
+++ b/index.html
@@ -158,17 +158,50 @@
             <div :id="'phylogeny-' + phylogeny_index" class="panel panel-info" v-for="(phylogeny, phylogeny_index) of testcase.phylogenies">
                 <div class="panel-heading">Phylogeny {{phylogeny_index + 1}}</div>
                 <div class="panel-body">
-                    <svg :id="'phylogeny-svg-' + phylogeny_index" :alt="get_phylogeny_as_newick('#phylogeny-svg-' + phylogeny_index, phylogeny)"></svg>
+                    <svg v-if="phylogeny_annotations_mode_for !== phylogeny" :id="'phylogeny-svg-' + phylogeny_index" :alt="get_phylogeny_as_newick('#phylogeny-svg-' + phylogeny_index, phylogeny)"></svg>
+                    <div v-if="phylogeny_annotations_mode_for === phylogeny">
+                        <p>This table displays all the nodes in this phylogeny and all know annotations
+                        applied to any of these nodes. To annotate an unlabeled node, click on the node
+                        and click the "Change label" option.
+                        </p>
+
+                        <table class="sortable" style="width: 100%">
+                            <thead>
+                                <tr>
+                                    <th>Label</th>
+                                    <th class="sorttable_nosort">Annotation property</th>
+                                    <th class="sorttable_nosort">Annotation value</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td>Rana areolata</td>
+                                    <td><input style="width: 100%" value="additionalLabels">
+                                    Any additional labels for this node.
+                                    </td>
+                                    <td><input style="width: 100%" value="Rana areolata"></td>
+                                </tr>
+                                <tr>
+                                    <td>Rana areolata</td>
+                                    <td><input value="hasBasisOfRecord.locatedAt.verbatimLocality">
+                                    Unknown term.
+                                    </td>
+                                    <td><input value="KU 204370: USA: Kansas: Lyon: just S of Hartsford"></td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </div>
                 </div>
                 <div class="panel-footer">
                     <textarea
                         class="col-md-12"
-                        v-if="selected_phylogeny === phylogeny"
+                        v-if="phylogeny_newick_mode_for === phylogeny"
                         placeholder="Enter Newick string for phylogeny here"
                         v-model.lazy="phylogeny.newick"
                         >{{get_phylogeny_as_newick('#phylogeny-svg-' + phylogeny_index, phylogeny)}}</textarea>
                     <div class="btn-group btn-group-justified" role="group" aria-label="Actions for phylogeny">
-                        <a :href="'#phylogeny-' + phylogeny_index" @click="selected_phylogeny = (selected_phylogeny == phylogeny ? undefined : phylogeny)" class="btn btn-default">Edit as Newick</a>
+                        <a :href="'#phylogeny-' + phylogeny_index" @click="phylogeny_newick_mode_for = (phylogeny_newick_mode_for === undefined ? phylogeny : undefined)" class="btn btn-default">Edit as Newick</a>
+                        <a :href="'#phylogeny-' + phylogeny_index" @click="phylogeny_annotations_mode_for = (phylogeny_annotations_mode_for === undefined ? phylogeny : undefined)" class="btn btn-default">Edit annotations</a>
                     </div>
                 </div>
             </div>
@@ -479,6 +512,9 @@
     <script src="http://d3js.org/d3.v3.min.js"></script>
     <script src="http://veg.github.io/phylotree.js/phylotree.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/underscore.js/1.8.3/underscore-min.js" charset="utf-8"></script>
+
+    <!-- Sortable tables -->
+    <script src="js/sorttable.js"></script>
 
     <!-- Our source code -->
     <script src="./js/curation-tool.js"></script>

--- a/index.html
+++ b/index.html
@@ -173,22 +173,35 @@
                                     <th>Property</th>
                                     <th>Value</th>
                                 </tr>
-                                <tr
+                                <template
                                     v-if="get_node_labels_for_phylogeny(phylogeny).length > 0"
                                     v-for="(node_label, node_label_index) of get_node_labels_for_phylogeny(phylogeny)"
                                 >
-                                    <td>{{node_label}}</td>
-                                    <td><input style="width: 100%" value="additionalLabels">
-                                    Any additional labels for this node.
-                                    </td>
-                                    <td><input style="width: 100%" value="Rana areolata"></td>
-                                </tr>
+                                    <template
+                                        v-if="phylogeny.hasOwnProperty('additionalNodeProperties') && phylogeny.additionalNodeProperties.hasOwnProperty(node_label)"
+                                    >
+                                        <tr v-for="prop_name of Object.keys(phylogeny.additionalNodeProperties[node_label])">
+                                            <td>{{node_label}}</td>
+                                            <td>{{prop_name}}</td>
+                                            <td><textarea rows="4" style="width: 100%">{{JSON.stringify(phylogeny.additionalNodeProperties[node_label][prop_name])}}</textarea></td>
+                                        </tr>
+                                    </template>
+
+                                    <template v-else>
+                                        <tr>
+                                            <td>{{node_label}}</td>
+                                            <td colspan="2"><em>No node properties.</em></td>
+                                        </tr>
+                                    </template>
+                                </template>
 
                                 <template v-if="get_node_labels_for_phylogeny(phylogeny).length == 0">
                                     <tr><td style="text-align: center"><em>No labeled nodes in this phylogeny.</em></td></tr>
                                 </template>
                             </tbody>
                         </table>
+
+                        <p>This table contains {{get_node_labels_for_phylogeny(phylogeny).length}} nodes.</p>
                     </div>
                 </div>
                 <div class="panel-footer">

--- a/index.html
+++ b/index.html
@@ -444,23 +444,24 @@
                                                 <a href="#" onclick="return false;">{{node_label}}<a>
                                             </li>
                                         </ul>
+                                        <ul v-if="specifier_dropdown_target == 'specifier_type'" class="dropdown-menu dropdown-menu-left">
+                                            <li class="dropdown-header">Specifier type</li>
+                                            <li :class="{active: get_specifier_type(selected_phyloref, specifier) == 'Internal'}">
+                                                <a href="#" onclick="return false;"
+                                                    @click="set_specifier_type(selected_phyloref, specifier, 'Internal')"
+                                                >Internal specifier</a></li>
+                                            <li :class="{active: get_specifier_type(selected_phyloref, specifier) == 'External'}">
+                                                <a href="#" onclick="return false;"
+                                                    @click="set_specifier_type(selected_phyloref, specifier, 'External')"
+                                                >External specifier</a></li>
+                                        </ul>
 
                                         <!-- Specifier type with dropdown menu: internal or external specifier -->
                                         <button
                                             @click="specifier_dropdown_target = 'specifier_type'"
                                             type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false"
                                             > {{get_specifier_type(selected_phyloref, specifier)}} <span class="caret"></span></button>
-                                        <ul v-if="specifier_dropdown_target == 'specifier_type'" class="dropdown-menu dropdown-menu-left">
-                                            <li class="dropdown-header">Specifier type</li>
-                                            <li :class="{active: get_specifier_type(selected_phyloref, specifier) == 'Internal'}">
-                                                <a :href="'#specifier_' + specifier_index"
-                                                    @click="set_specifier_type(selected_phyloref, specifier, 'Internal')"
-                                                >Internal specifier</a></li>
-                                            <li :class="{active: get_specifier_type(selected_phyloref, specifier) == 'External'}">
-                                                <a :href="'#specifier_' + specifier_index"
-                                                    @click="set_specifier_type(selected_phyloref, specifier, 'External')"
-                                                >External specifier</a></li>
-                                        </ul>
+
                                     </div>
 
                                     <!-- Specifier label -->

--- a/js/curation-tool.js
+++ b/js/curation-tool.js
@@ -41,7 +41,11 @@ var vm = new Vue({
         selected_tunit_list: undefined,
         selected_tunit: undefined,
 
-        // Taxonomic unit editor modal tweaks
+        // Phylogeny view modes
+        phylogeny_newick_mode_for: undefined,
+        phylogeny_annotations_mode_for: undefined,
+
+        // Taxonomic unit editor modal elements
         tunit_editor_target_label: "(unlabeled)",
 
         // Display the delete buttons on the specifiers.

--- a/js/curation-tool.js
+++ b/js/curation-tool.js
@@ -476,7 +476,7 @@ var vm = new Vue({
             var parsed = d3.layout.newick_parser(newick);
             if(parsed.hasOwnProperty('json')) {
                 var add_node_and_children_to_node_labels = function(node) {
-                    console.log("Recursing into: " + JSON.stringify(node));
+                    // console.log("Recursing into: " + JSON.stringify(node));
 
                     if(node.hasOwnProperty('name') && node.name != '')
                         node_labels.add(node.name);
@@ -490,6 +490,13 @@ var vm = new Vue({
 
                 // Recurse away!
                 add_node_and_children_to_node_labels(parsed.json);
+            }
+
+            // Names from additionalNodeProperties
+            if(phylogeny.hasOwnProperty('additionalNodeProperties')) {
+                for(key of Object.keys(phylogeny.additionalNodeProperties)) {
+                    node_labels.add(key);
+                }
             }
 
             return Array.from(node_labels);

--- a/js/curation-tool.js
+++ b/js/curation-tool.js
@@ -532,29 +532,14 @@ var vm = new Vue({
                 additionalNodeProperties = phylogeny.additionalNodeProperties[node_label];
             }
 
-            // There are three sources of taxonomic units:
-            //  1.  There might be explicit taxonomic units in the
-            //      representsTaxonomicUnits property. If so, these override all
-            //      others.
+            // If there are explicit taxonomic units in the
+            // representsTaxonomicUnits property, we need to use those.
             if(additionalNodeProperties.hasOwnProperty('representsTaxonomicUnits')) {
                 return additionalNodeProperties.representsTaxonomicUnits;
             }
 
-            // If that doesn't work, we can try two other possibilities:
-            //  2.  We can try to extract scientific names from the node label.
-            //  3.  If there are additional node labels in additionalNodeProperties,
-            //      we can try to extract names from any of them.
-
-            // Collect any additional labels that have been specified for this node.
-            let labels = new Set();
-            labels.add();
-            if(additionalNodeProperties.hasOwnProperty('additionalLabels')) {
-                for(var label of additionalNodeProperties.additionalLabels) {
-                    labels.add(label.trim());
-                }
-            }
-
-            // Extract as many taxonomic units as possible from the node labels.
+            // If that doesn't work, we can try to extract scientific names from
+            // the node label.
             let tunits = [];
             for(let tunit of extract_tunits_from_node_label(node_label.trim())) {
                 tunits.push(tunit);

--- a/js/curation-tool.js
+++ b/js/curation-tool.js
@@ -523,7 +523,9 @@ var vm = new Vue({
             // from the label -- so if the label is creating an incorrect
             // taxonomic unit, you will need to rename the label.
 
-            let labels = new Set(node_label);
+            // TODO: delete additional labels and replace with proper taxonomic units.
+            let labels = new Set();
+            labels.add(node_label);
             if(additionalNodeProperties.hasOwnProperty('additionalLabels')) {
                 for(var label of additionalNodeProperties.additionalLabels) {
                     labels.add(label);
@@ -946,16 +948,20 @@ function render_tree(node_expr, phylogeny, newick) {
                         return "Taxonomic unit: " + vm.get_taxonomic_unit_label(tunit);
                     },
                     function() {
+                        // TODO: deduplicate this code with the one below.
                         // console.log("Edit taxonomic units activated with: ", node);
 
-                        if(!phylogeny.hasOwnProperty('representsTaxonomicUnits'))
-                            Vue.set(phylogeny, 'representsTaxonomicUnits', {});
-                        if(!phylogeny.representsTaxonomicUnits.hasOwnProperty(node.name))
-                            Vue.set(phylogeny.representsTaxonomicUnits, node.name, vm.get_tunits_for_node_label_in_phylogeny(phylogeny, node.name));
+                        if(!phylogeny.hasOwnProperty('additionalNodeProperties'))
+                            Vue.set(phylogeny, 'additionalNodeProperties', {});
+                        if(!phylogeny.additionalNodeProperties.hasOwnProperty(node.name))
+                            Vue.set(phylogeny.additionalNodeProperties, node.name, {
+                                'representsTaxonomicUnits': vm.get_tunits_for_node_label_in_phylogeny(phylogeny, node.name)
+                            });
+
 
                         // console.log("Setting selected tunit list to: ", phylogeny.representsTaxonomicUnits[node.name]);
 
-                        vm.start_tunit_editor_modal('node', phylogeny.representsTaxonomicUnits[node.name]);
+                        vm.start_tunit_editor_modal('node', phylogeny.additionalNodeProperties[node.name]);
                     }
                 );
             }

--- a/js/curation-tool.js
+++ b/js/curation-tool.js
@@ -571,17 +571,17 @@ var vm = new Vue({
         get_node_labels_matched_by_specifier: function(specifier, phylogeny) {
             // Return a list of node labels matched by a given specifier on
             // a given phylogeny.
-            // Wrapper for does_specifier_match_node() on every node label in
+            // Wrapper for test_whether_specifier_match_node() on every node label in
             // a given phylogeny.
 
             let local_vm = this;
 
             return local_vm.get_node_labels_in_phylogeny(phylogeny).filter(function(node_label) {
-                return local_vm.does_specifier_match_node(specifier, phylogeny, node_label);
+                return local_vm.test_whether_specifier_match_node(specifier, phylogeny, node_label);
             });
         },
 
-        does_specifier_match_node: function(specifier, phylogeny, node_label) {
+        test_whether_specifier_match_node: function(specifier, phylogeny, node_label) {
             // Tests whether a specifier matches a node in a phylogeny.
 
             // Does the specifier have any taxonomic units? If not, we can't
@@ -599,9 +599,9 @@ var vm = new Vue({
             for(let tunit1 of specifier_tunits) {
                 for(let tunit2 of node_tunits) {
                     if(
-                        do_tunits_match_by_binomial_name(tunit1, tunit2) ||
-                        do_tunits_match_by_external_references(tunit1, tunit2) ||
-                        do_tunits_match_by_specimen_identifier(tunit1, tunit2)
+                        test_whether_tunits_match_by_binomial_name(tunit1, tunit2) ||
+                        test_whether_tunits_match_by_external_references(tunit1, tunit2) ||
+                        test_whether_tunits_match_by_specimen_identifier(tunit1, tunit2)
                     ) return true;
                 }
             }
@@ -617,11 +617,11 @@ var vm = new Vue({
 // methods in that class.
 
 /**
- * do_tunits_match_by_external_references(tunit1, tunit2)
+ * test_whether_tunits_match_by_external_references(tunit1, tunit2)
  *
  * Test whether two Tunits have matching external references.
  */
-function do_tunits_match_by_external_references(tunit1, tunit2) {
+function test_whether_tunits_match_by_external_references(tunit1, tunit2) {
     if(tunit1 === undefined || tunit2 === undefined) return false;
     if(tunit1.hasOwnProperty('externalReferences') && tunit2.hasOwnProperty('externalReferences')) {
         // Each external reference is a URL as a string. We will lowercase it,
@@ -638,11 +638,11 @@ function do_tunits_match_by_external_references(tunit1, tunit2) {
 }
 
 /**
- * do_scnames_match_by_binomial_name(scname1, scname2)
+ * test_whether_scnames_match_by_binomial_name(scname1, scname2)
  *
  * Test whether two scientific names match on the basis of their binomial names.
  */
-function do_scnames_match_by_binomial_name(scname1, scname2) {
+function test_whether_scnames_match_by_binomial_name(scname1, scname2) {
     // Step 1. Try matching by explicit binomial name, if one is available.
     if(scname1.hasOwnProperty('binomialName') && scname2.hasOwnProperty('binomialName')) {
         if(scname1.binomialName.trim() !== '' && scname1.binomialName.toLowerCase().trim() === scname2.binomialName.toLowerCase().trim())
@@ -661,11 +661,11 @@ function do_scnames_match_by_binomial_name(scname1, scname2) {
 }
 
 /**
- * do_tunits_match_by_binomial_name(tunit1, tunit2)
+ * test_whether_tunits_match_by_binomial_name(tunit1, tunit2)
  *
  * Test whether two Tunits match on the basis of their binomial names.
  */
-function do_tunits_match_by_binomial_name(tunit1, tunit2) {
+function test_whether_tunits_match_by_binomial_name(tunit1, tunit2) {
     //
 
     if(tunit1 === undefined || tunit2 === undefined) return false;
@@ -673,7 +673,7 @@ function do_tunits_match_by_binomial_name(tunit1, tunit2) {
         // Each external reference is a URL as a string.
         for(let scname1 of tunit1.scientificNames) {
             for(let scname2 of tunit2.scientificNames) {
-                if(do_scnames_match_by_binomial_name(scname1, scname2))
+                if(test_whether_scnames_match_by_binomial_name(scname1, scname2))
                     return true;
             }
         }
@@ -683,11 +683,11 @@ function do_tunits_match_by_binomial_name(tunit1, tunit2) {
 }
 
 /**
- * do_tunits_match_by_specimen_identifier(tunit1, tunit2)
+ * test_whether_tunits_match_by_specimen_identifier(tunit1, tunit2)
  *
  * Test whether two Tunits match on the basis of their specimen identifiers.
  */
-function do_tunits_match_by_specimen_identifier(tunit1, tunit2) {
+function test_whether_tunits_match_by_specimen_identifier(tunit1, tunit2) {
     if(tunit1 === undefined || tunit2 === undefined) return false;
     if(tunit1.hasOwnProperty('includesSpecimens') && tunit2.hasOwnProperty('includesSpecimens')) {
         // Convert specimen identifiers (if present) into a standard format and compare those.
@@ -964,7 +964,7 @@ function render_tree(node_expr, phylogeny) {
                 //  - external specifier in red
                 if(vm.selected_phyloref.hasOwnProperty('internalSpecifiers')) {
                     for(let specifier of vm.selected_phyloref.internalSpecifiers) {
-                        if(vm.does_specifier_match_node(specifier, phylogeny, data.name)) {
+                        if(vm.test_whether_specifier_match_node(specifier, phylogeny, data.name)) {
                             element.style('fill', 'green')
                                 .style('font-weight', 'bolder');
                         }
@@ -972,7 +972,7 @@ function render_tree(node_expr, phylogeny) {
                 }
                 if(vm.selected_phyloref.hasOwnProperty('externalSpecifiers')) {
                     for(let specifier of vm.selected_phyloref.externalSpecifiers) {
-                        if(vm.does_specifier_match_node(specifier, phylogeny, data.name)) {
+                        if(vm.test_whether_specifier_match_node(specifier, phylogeny, data.name)) {
                             element.style('fill', 'red')
                                 .style('font-weight', 'bolder');
                         }

--- a/js/curation-tool.js
+++ b/js/curation-tool.js
@@ -619,11 +619,24 @@ function render_tree(node_expr, newick) {
         .style_nodes(nodeStyler);
     tree(d3.layout.newick_parser(newick));
 
-    _.each(tree.get_nodes(), function(node) {
+    tree.get_nodes().forEach(function(node) {
+        // Extract internal nodes
         if(node.children && node.name.startsWith("expected_")) {
             node.internal_label = node.name.substring(9);
             // console.log(node.internal_label)
         }
+
+        // Add a custom menu to nodes.
+        d3.layout.phylotree.add_custom_menu(
+            node,
+            function(node) { return "Node mdenu"; },
+            function() {
+                console.log("Clicked: " + node);
+            },
+            d3.layout.phylotree.is_leafnode
+                // Condition when to display the menu
+                // Takes 'node' as an argument
+        );
     });
 
     tree

--- a/js/curation-tool.js
+++ b/js/curation-tool.js
@@ -609,17 +609,32 @@ function do_tunits_match_by_external_references(tunit1, tunit2) {
     return false;
 }
 
+function do_scnames_match(scname1, scname2) {
+    // Step 1. Try matching by binomial name.
+    // Maybe there is an explicit binomialName we can use.
+    if(scname1.hasOwnProperty('binomialName') && scname2.hasOwnProperty('binomialName')) {
+        if(scname1.binomialName.trim() !== '' && scname1.binomialName.toLowerCase().trim() === scname2.binomialName.toLowerCase().trim())
+            return true;
+    }
+
+    // Otherwise, try to extract the binomial name from the scientificName.
+    let binomial1 = vm.get_binomial_name(scname1);
+    let binomial2 = vm.get_binomial_name(scname2);
+
+    if(binomial1 !== undefined && binomial2 !== undefined && binomial1.trim() !== '' && binomial1.trim() === binomial2.trim())
+        return true;
+
+    return false;
+}
+
 function do_tunits_match_by_binomial_name(tunit1, tunit2) {
     if(tunit1 === undefined || tunit2 === undefined) return false;
     if(tunit1.hasOwnProperty('scientificNames') && tunit2.hasOwnProperty('scientificNames')) {
         // Each external reference is a URL as a string.
         for(let scname1 of tunit1.scientificNames) {
             for(let scname2 of tunit2.scientificNames) {
-                // For now, we only match by binomial name.
-                if(scname1.hasOwnProperty('binomialName') && scname2.hasOwnProperty('binomialName')) {
-                    if(scname1.binomialName.trim() != '' && scname1.binomialName.toLowerCase().trim() === scname2.binomialName.toLowerCase().trim())
-                        return true;
-                }
+                if(do_scnames_match(scname1, scname2))
+                    return true;
             }
         }
     }


### PR DESCRIPTION
Adds support for editing taxonomic units associated with phylogeny nodes and for matching these taxonomic units with those present in specifiers, allowing specifier matching to be visualized within this interface. This pull request also contains the first round of development towards a comprehensive labeled node property editors (#9), which will be completed when this feature is needed. Adding support for taxonomic unit matching allowed us to eliminate the no-longer-needed "additionalLabels" feature, which has been removed from example files and is no longer supported by the Javascript code.

Closes #6. After review, this pull request will be merged.