### PR TITLE
Additional curation features to facilitate imports into the Curation Workflow

### DIFF
--- a/examples/fisher_et_al_2007.json
+++ b/examples/fisher_et_al_2007.json
@@ -1,12 +1,5 @@
 {
-    "@context": "../paper-context.json",
-
-    "@id": "https://doi.org/10.1639/0007-2745%282007%29110%5B46%3APOTCWA%5D2.0.CO%3B2#",
-    "@type": "phyloref:PhyloreferenceTestSuite",
-
-    "curator": "Gaurav Vaidya <gaurav@ggvaidya.com>",
-    "comments": "None.",
-
+    "title": "Phylogeny of the Calymperaceae with a rank-free systematic treatment",
     "citation": "Fisher KM, Wall DP, Yip KL, Mishler BD (2007) The Bryologist 110(1):46-73.",
     "url": "https://doi.org/10.1639/0007-2745%282007%29110%5B46%3APOTCWA%5D2.0.CO%3B2",
     "year": 2007,
@@ -17,28 +10,63 @@
 
         "additionalNodeProperties": {
             "Arthrocormus schimperi": {
-                "expectedPhyloreferenceNamed": ["Arthrocormus"]
+                "expectedPhyloreferenceNamed": ["Arthrocormus"],
+                "representsTaxonomicUnits": [{
+                    "includesSpecimens": [{
+                        "catalogNumber": "Mishler 7/24/98 (5)"
+                    }]
+                }]
             },
             "Exodictyon incrassatum": {
-                "expectedPhyloreferenceNamed": ["Exodictyon"]
+                "expectedPhyloreferenceNamed": ["Exodictyon"],
+                "representsTaxonomicUnits": [{
+                    "includesSpecimens": [{
+                        "catalogNumber": "Wall 2527, Fiji (uc)"
+                    }]
+                }]
+            },
+            "Exostratum blumii 243": {
+                "comment": "The paper does not tell us which specimen ID goes with which node, so I've assigned both specmen IDs to both nodes. -- GGV",
+                "representsTaxonomicUnits": [{
+                    "includesSpecimens": [{
+                        "catalogNumber": "Mishler 7/24/98(3)"
+                    }]
+                }, {
+                    "includesSpecimens": [{
+                        "catalogNumber": "Mishler 7/26/98(1)"
+                    }]
+                }]
+            },
+            "Exostratum blumii 245": {
+                "comment": "The paper does not tell us which specimen ID goes with which node, so I've assigned both specmen IDs to both nodes. -- GGV",
+                "representsTaxonomicUnits": [{
+                    "includesSpecimens": [{
+                        "catalogNumber": "Mishler 7/24/98(3)"
+                    }]
+                }, {
+                    "includesSpecimens": [{
+                        "catalogNumber": "Mishler 7/26/98(1)"
+                    }]
+                }]
             }
         }
     }],
 
-    "phylorefs": [
-    {
+    "phylorefs": [{
         "label": "Calymperaceae",
-        "cladeDefinition": "nomen cladi conversum, Calymperaceae ____ Hal., Synop. Musc. Frond. 1. (1849)\n\tStem-based definition:\n\tinternal specifier: Type: Syrrhopodon gardneri (Hook.) Schw____, Sp. Musc. Frond. Suppl. 2(1): 110, tab. 131, figs. ____ (1824)\n\tinternal specifier: Type: Leucophanes octoblepharoides Brid., Bryol. Univ. 1: 763. (1826)\n\texternal specifier: Type: Octoblepharum albidum Hedw., Sp. Musc. 50. (1801)\n\tImportant synapomorphies: cancellinae, central strand absent from stem\n\tIncluded terminal clades: gardneri, japonicus",
+        "cladeDefinition": "nomen cladi conversum, Calymperaceae Müll. Hal., Synop. Musc. Frond. 1. (1849)\n\tStem-based definition:\n\tinternal specifier: Type: Syrrhopodon gardneri (Hook.) Schwägr., Sp. Musc. Frond. Suppl. 2(1): 110, tab. 131, figs. 1-13. (1824)\n\tinternal specifier: Type: Leucophanes octoblepharoides Brid., Bryol. Univ. 1: 763. (1826)\n\texternal specifier: Type: Octoblepharum albidum Hedw., Sp. Musc. 50. (1801)\n\tImportant synapomorphies: cancellinae, central strand absent from stem\n\tIncluded terminal clades: gardneri, japonicus",
         "internalSpecifiers": [
             {
+                "verbatimSpecifier": "Type: Syrrhopodon gardneri (Hook.) Schwägr., Sp. Musc. Frond. Suppl. 2(1): 110, tab. 131, figs. 1–13. (1824)",
                 "referencesTaxonomicUnits": [{
                     "scientificNames": [{
-                        "scientificName": "Syrrhopodon gardneri (Hook.) _____, Sp. Musc. Frond. Suppl. 2(1): 110, tab. 131, figs. 1-13 (1824)",
+                        "scientificName": "Syrrhopodon gardneri (Hook.) Schwägr., Sp. Musc. Frond. Suppl. 2(1): 110, tab. 131, figs. 1-13 (1824)",
                         "binomialName": "Syrrhopodon gardneri"
                     }]
                 }]
             },
             {
+                "verbatimSpecifier": "Type: Leucophanes octoblepharoides Brid., Bryol. Univ. 1: 763. (1826)",
                 "referencesTaxonomicUnits": [{
                     "scientificNames": [{
                         "scientificName": "Leucophanes octoblepharoides Brid., Bryol. Univ. 1: 763. (1826)",
@@ -49,6 +77,7 @@
         ],
         "externalSpecifiers": [
             {
+                "verbatimSpecifier": "Type: Octoblepharum albidum Hedw., Sp. Musc. 50. (1801)",
                 "referencesTaxonomicUnits": [{
                     "scientificNames": [{
                         "scientificName": "Octoblepharum albidum Hedw., Sp. Musc. 50. (1801)",
@@ -63,6 +92,7 @@
         "cladeDefinition": "nomen cladi conversum, Calymperes lonchophyllum Schwägr., Tab. Exhib. Calyptr. Opercul. (3). 1814 (1813).\nStem-based definition:\ninternal specifier: Type: Calymperes lonchophyllum Schwägr., Tab. Exhib. Calyptr. Opercul. (3). 1814 (1813).\ninternal specifier: Type: Syrrhopodon mauritianus Müll. Hal. ex Ångstr., Öfv. Förh. Kongl. Svenska Vet.-Akad. 33(4): 54. (1876)\nexternal specifier: Type: Syrrhopodon croceus Mitt., J. Proc. Linn. Soc., Bot. Suppl. 1: 41. (1859) Important synapomorphies:\nperistome greatly reduced or absent\nsheathed or intramarginal elongate border cells\ncampanulate calyptrae\nspecialized gemmiferous leaves\nIncluded terminal clades: afzelii, dozyanum, erosum, hispidum, incompletum, lonchophyllum, mauritianus, moluccense, motleyi, palisotii, pseudopodianum, robinsonii, subintegrum, tahitense, tenerum, tuamotuense",
         "internalSpecifiers": [
             {
+                "verbatimSpecifier": "Type: Calymperes lonchophyllum Schwägr., Tab. Exhib. Calyptr. Opercul. (3). 1814 (1813).",
                 "referencesTaxonomicUnits": [{
                     "scientificNames": [{
                         "scientificName": "Calymperes lonchophyllum Schwägr., Tab. Exhib. Calyptr. Opercul. (3). 1814 (1813).",
@@ -71,6 +101,7 @@
                 }]
             },
             {
+                "verbatimSpecifier": "Type: Syrrhopodon mauritianus Müll. Hal. ex Ångstr., Öfv. Förh. Kongl. Svenska Vet.-Akad. 33(4): 54. (1876)",
                 "referencesTaxonomicUnits": [{
                     "scientificNames": [{
                         "scientificName": "Syrrhopodon mauritianus Müll. Hal. ex Ångstr., Öfv. Förh. Kongl. Svenska Vet.-Akad. 33(4): 54. (1876)",
@@ -81,6 +112,7 @@
         ],
         "externalSpecifiers": [
             {
+                "verbatimSpecifier": "Type: Syrrhopodon croceus Mitt., J. Proc. Linn. Soc., Bot. Suppl. 1: 41. (1859)",
                 "referencesTaxonomicUnits": [{
                     "scientificNames": [{
                         "scientificName": "Syrrhopodon croceus Mitt., J. Proc. Linn. Soc., Bot. Suppl. 1: 41. (1859)",
@@ -95,6 +127,7 @@
         "cladeDefinition": "nomen cladi conversum, Syrrhopodon gardneri (Hook.) Schwägr., Sp. Musc. Frond. Suppl. 2(1): 110, tab. 131, figs. 1–13. (1824)\nStem-based definition:\n\ninternal specifier: Type: Syrrhopodon croceus Mitt., J. Proc. Linn. Soc., Bot. Suppl. 1: 41. (1859)\ninternal specifier: Type: Leucophanes octoblepharoides Brid., Bryol. Univ. 1: 763. (1826)\nexternal specifier: Type: Syrrhopodon mauritianus Müll. Hal. ex Ångstr., Öfv. Förh. Kongl. Svenska Vet.-Akad. 33(4): 54. (1876)\nImportant synapomorphies:\n\ncucullate calyptrae\nmarginal border of elongate hyaline cells (sterome)\nIncluded terminal clades:\n\napertus, armatus, croceus, fimbriatulus, loreus, tristichus, mahensis, muelleri, perarmatus",
         "internalSpecifiers": [
             {
+                "verbatimSpecifier": "Type: Syrrhopodon croceus Mitt., J. Proc. Linn. Soc., Bot. Suppl. 1: 41. (1859)",
                 "referencesTaxonomicUnits": [{
                     "scientificNames": [{
                         "scientificName": "Syrrhopodon croceus Mitt., J. Proc. Linn. Soc., Bot. Suppl. 1: 41. (1859)",
@@ -103,6 +136,7 @@
                 }]
             },
             {
+                "verbatimSpecifier": "Type: Leucophanes octoblepharoides Brid., Bryol. Univ. 1: 763. (1826)",
                 "referencesTaxonomicUnits": [{
                     "scientificNames": [{
                         "scientificName": "Leucophanes octoblepharoides Brid., Bryol. Univ. 1: 763. (1826)",
@@ -113,6 +147,7 @@
         ],
         "externalSpecifiers": [
             {
+                "verbatimSpecifier": "Type: Syrrhopodon mauritianus Müll. Hal. ex Ångstr., Öfv. Förh. Kongl. Svenska Vet.-Akad. 33(4): 54. (1876)",
                 "referencesTaxonomicUnits": [{
                     "scientificNames": [{
                         "scientificName": "Syrrhopodon mauritianus Müll. Hal. ex Ångstr., Öfv. Förh. Kongl. Svenska Vet.-Akad. 33(4): 54. (1876)",
@@ -126,6 +161,7 @@
         "label": "Mitthyridium",
         "cladeDefinition": "nomen cladi conversum, Mitthyridium fasciculatum (Hook. & Grev.) H. Rob., Phytologia 32: 432. (1975)\nStem-based definition:\n\ninternal specifier: Type: Syrrhopodon fasciculatum Hook. & Grev., Edinb. J. Sci. 3: 225. (1825)\ninternal specifier: Type: Codonoblepharum undulatum Dozy & Molk., Ann. Sci. Nat., Bot., III, 2: 301. (1844)\nexternal specifier: Type: Syrrhopodon croceus Mitt., J. Proc. Linn. Soc., Bot. Suppl. 1: 41. (1859)\nImportant synapomorphies:\n\ncladocarpy\nmany cancellinar columns\nvery wide sterome\ncreeping habit\nIncluded terminal clades:\n\nundulatum, jungquilianum, fasciculatum, constrictum, obtusifolium",
         "internalSpecifiers": [{
+            "verbatimSpecifier": "Type: Syrrhopodon fasciculatum Hook. & Grev., Edinb. J. Sci. 3: 225. (1825)",
             "referencesTaxonomicUnits": [{
                 "scientificNames": [{
                     "scientificName": "Syrrhopodon fasciculatum Hook. & Grev., Edinb. J. Sci. 3: 225. (1825)",
@@ -133,6 +169,7 @@
                 }]
             }]
         }, {
+            "verbatimSpecifier": "Type: Syrrhopodon fasciculatum Hook. & Grev., Edinb. J. Sci. 3: 225. (1825)",
             "referencesTaxonomicUnits": [{
                 "scientificNames": [{
                     "scientificName": "Codonoblepharum undulatum Dozy & Molk., Ann. Sci. Nat., Bot., III, 2: 301. (1844)",
@@ -141,6 +178,7 @@
             }]
         }],
         "externalSpecifiers": [{
+            "verbatimSpecifier": "Type: Syrrhopodon croceus Mitt., J. Proc. Linn. Soc., Bot. Suppl. 1: 41. (1859)",
             "referencesTaxonomicUnits": [{
                 "scientificNames": [{
                     "scientificName": "Syrrhopodon croceus Mitt., J. Proc. Linn. Soc., Bot. Suppl. 1: 41. (1859)",
@@ -153,6 +191,7 @@
         "label": "Trachymitrium",
         "cladeDefinition": "nomen cladi conversum, T. ciliatum (Hook.) Brid. (= Weissia ciliata Hook.), Bryol. Univ. 1: 159. (1826)\nStem-based definition:\n\ninternal specifier: Type: Weissia ciliata Hook., Musci Exot. 2: 7. 171. (1820)\ninternal specifier: Type: Syrrhopodon involutus Schwägr., Sp. Musc. Frond. Suppl. 2, 1(2): 117. pl. 132. (1824)\nexternal specifier: Type: Syrrhopodon perarmatus Broth. & Watts, J. & Proc. Roy. Soc. New South Wales 49: 133. (1915)\nIncluded terminal clades:\n\nalbovaginatus, ciliatus, leprieurii, parasiticus, prolifer, tortilis, trachyphyllus",
         "internalSpecifiers": [{
+            "verbatimSpecifier": "Type: Syrrhopodon croceus Mitt., J. Proc. Linn. Soc., Bot. Suppl. 1: 41. (1859)",
             "referencesTaxonomicUnits": [{
                 "scientificNames": [{
                     "scientificName": "Weissia ciliata Hook., Musci Exot. 2: 7. 171. (1820)",
@@ -160,6 +199,7 @@
                 }]
             }]
         }, {
+            "verbatimSpecifier": "Type: Syrrhopodon involutus Schwägr., Sp. Musc. Frond. Suppl. 2, 1(2): 117. pl. 132. (1824)",
             "referencesTaxonomicUnits": [{
                 "scientificNames": [{
                     "scientificName": "Syrrhopodon involutus Schwägr., Sp. Musc. Frond. Suppl. 2, 1(2): 117. pl. 132. (1824)",
@@ -168,6 +208,7 @@
             }]
         }],
         "externalSpecifiers": [{
+            "verbatimSpecifier": "Type: Syrrhopodon perarmatus Broth. & Watts, J. & Proc. Roy. Soc. New South Wales 49: 133. (1915)",
             "referencesTaxonomicUnits": [{
                 "scientificNames": [{
                     "scientificName": "Syrrhopodon perarmatus Broth. & Watts, J. & Proc. Roy. Soc. New South Wales 49: 133. (1915)",
@@ -180,6 +221,7 @@
         "label": "Leucophanella",
         "cladeDefinition": "nomen cladi conversum, Syrrhopodon sect. Leucophanella Besch., Bull. Soc. Bot. France 45: 60. (1898)\nStem-based definition:\n\ninternal Specifier: Type: S. banksii Müll. Hal., Bot. Zeitung (Berlin) 16: 162. (1858)\ninternal Specifier: Type: S. involutus Schwägr., Sp. Musc. Frond. Suppl. 2, 1(2): 117. pl. 132. (1824)\ninternal Specifier: Type: S. revolutus Dozy & Molk.\nexternal Specifier: S. trachyphyllus Mont., Sylloge Gen. Sp. Cryptog. 47. (1856)\nImportant synapomorphies:\n\nCancellinae comprising 60–>90% of leaf area\nIncluded terminal clades:\n\ninvolutus, banksii",
         "internalSpecifiers": [{
+            "verbatimSpecifier": "Type: S. banksii Müll. Hal., Bot. Zeitung (Berlin) 16: 162. (1858)",
             "referencesTaxonomicUnits": [{
                 "scientificNames": [{
                     "scientificName": "Syrrhopodon banksii Müll. Hal., Bot. Zeitung (Berlin) 16: 162. (1858)",
@@ -187,6 +229,7 @@
                 }]
             }]
         }, {
+            "verbatimSpecifier": "Type: S. banksii Müll. Hal., Bot. Zeitung (Berlin) 16: 162. (1858)",
             "referencesTaxonomicUnits": [{
                 "scientificNames": [{
                     "scientificName": "Syrrhopodon involutus Schwägr., Sp. Musc. Frond. Suppl. 2, 1(2): 117. pl. 132. (1824)",
@@ -194,6 +237,7 @@
                 }]
             }]
         }, {
+            "verbatimSpecifier": "Type: S. revolutus Dozy & Molk.",
             "specifierWillNotMatch": "*Syrrhopodon revolutus* not included in phylogeny",
             "referencesTaxonomicUnits": [{
                 "scientificNames": [{
@@ -203,6 +247,7 @@
             }]
         }],
         "externalSpecifiers": [{
+            "verbatimSpecifier": "S. trachyphyllus Mont., Sylloge Gen. Sp. Cryptog. 47. (1856)",
             "referencesTaxonomicUnits": [{
                 "scientificNames": [{
                     "scientificName": "Syrrhopodon trachyphyllus Mont., Sylloge Gen. Sp. Cryptog. 47. (1856)",
@@ -215,16 +260,15 @@
         "label": "Albifolium",
         "cladeDefinition": "nomen cladi novum\n\nStem-based definition:\n\ninternal specifier: Type: Arthrocormus schimperi (Dozy & Molk.) Dozy & Molk. (=Mielichhoferia schimperi Dozy & Molk.), Musci Frond. Ined. Archip. Ind. 75. (1846)\ninternal specifier: Type: Leucophanes octoblepharoides Brid., Bryol. Univ. 1: 763. (1826)\nexternal specifier: Type: Syrrhopodon muelleri (Dozy & Molk) Sande Lac., Bryol. Jav. 2: 224. (1870)\nImportant synapomorphies:\n\nLeaf architecture / chlorocysts and hyalocysts\ncircular depressions on peristome\nIncluded clades:\n\nArthrocormus, Exodictyon, Exostratum, Leucophanes",
         "internalSpecifiers": [{
+            "verbatimSpecifier": "Type: Arthrocormus schimperi (Dozy & Molk.) Dozy & Molk. (=Mielichhoferia schimperi Dozy & Molk.), Musci Frond. Ined. Archip. Ind. 75. (1846)",
             "referencesTaxonomicUnits": [{
                 "scientificNames": [{
                     "scientificName": "Arthrocormus schimperi (Dozy & Molk.) Dozy & Molk. (=Mielichhoferia schimperi Dozy & Molk.), Musci Frond. Ined. Archip. Ind. 75. (1846)",
-                    "binomialName": "Arthrocormus schimperi",
-                    "skos:closeMatch": {
-                        "@id": "http://www.tropicos.org/Name/35179022"
-                    }
+                    "binomialName": "Arthrocormus schimperi"
                 }]
             }]
         }, {
+            "verbatimSpecifier": "Type: Leucophanes octoblepharoides Brid., Bryol. Univ. 1: 763. (1826)",
             "referencesTaxonomicUnits": [{
                 "scientificNames": [{
                     "scientificName": "Leucophanes octoblepharoides Brid., Bryol. Univ. 1: 763. (1826)",
@@ -233,6 +277,7 @@
             }]
         }],
         "externalSpecifiers": [{
+            "verbatimSpecifier": "Type: Syrrhopodon muelleri (Dozy & Molk) Sande Lac., Bryol. Jav. 2: 224. (1870)",
             "referencesTaxonomicUnits": [{
                 "scientificNames": [{
                     "scientificName": "Syrrhopodon muelleri (Dozy & Molk) Sande Lac., Bryol. Jav. 2: 224. (1870)",
@@ -245,14 +290,24 @@
         "label": "Arthrocormus",
         "cladeDefinition": "nomen cladi conversum, Arthrocormus schimperi (Dozy & Molk.) Dozy & Molk. (= Mielichhoferia schimperi Dozy & Molk.), Musci Frond. Ined. Archip. Ind. 75. (1846)\nStem-based definition:\n\ninternal specifier: Type: Arthrocormus schimperi (Dozy & Molk.) Dozy & Molk. (= Mielichhoferia schimperi Dozy & Molk.), Musci Frond. Ined. Archip. Ind. 75. (1846)\ninternal specifier: Mishler 7/24/98 (5) Queensland, Australia (UC)\nexternal specifier: Type: Exostratum blumii (Nees ex Hampe) L. Ellis, Lindbergia 11: 22. (1985)\nIncluded terminal clade:\n\nschimperi",
         "internalSpecifiers": [{
+            "verbatimSpecifier": "Type: Arthrocormus schimperi (Dozy & Molk.) Dozy & Molk. (= Mielichhoferia schimperi Dozy & Molk.), Musci Frond. Ined. Archip. Ind. 75. (1846)",
             "referencesTaxonomicUnits": [{
                 "scientificNames": [{
-                    "scientificName": "Arthrocormus schimperi (Dozy & Molk.) Dozy & Molk. (= Mielichhoferia schimperi Dozy & Molk.), Musci Frond. Ined. Archip. Ind. 75. (1846) -- Mishler 7/24/98 (5) Queensland, Australia (UC)",
+                    "scientificName": "Arthrocormus schimperi (Dozy & Molk.) Dozy & Molk. (= Mielichhoferia schimperi Dozy & Molk.), Musci Frond. Ined. Archip. Ind. 75. (1846)",
                     "binomialName": "Arthrocormus schimperi"
+                }]
+            }]
+        }, {
+            "verbatimSpecifier": "Mishler 7/24/98 (5) Queensland, Australia (UC)",
+            "referencesTaxonomicUnits": [{
+                "includesSpecimens": [{
+                    "label": "Mishler 7/24/98 (5) Queensland, Australia (UC)",
+                    "catalogNumber": "Mishler 7/24/98 (5)"
                 }]
             }]
         }],
         "externalSpecifiers": [{
+            "verbatimSpecifier": "Type: Exostratum blumii (Nees ex Hampe) L. Ellis, Lindbergia 11: 22. (1985)",
             "referencesTaxonomicUnits": [{
                 "scientificNames": [{
                     "scientificName": "Exostratum blumii (Nees ex Hampe) L. Ellis, Lindbergia 11: 22. (1985)",
@@ -265,6 +320,7 @@
         "label": "Exostratum",
         "cladeDefinition": "nomen cladi conversum, Exostratum blumii (Nees ex Hampe) L. Ellis, Lindbergia 11: 22. (1985)\nStem-based definition:\n\ninternal specifier: Type: Exostratum blumii (Nees ex Hampe) L. Ellis, Lindbergia 11: 22. (1985)\ninternal specifier: Mishler 7/24/98(3), Queensland, Australia (uc)\nexternal specifier: Type: Arthrocormus schimperi (Dozy & Molk.) Dozy & Molk. (= Mielichhoferia schimperi Dozy & Molk.), Musci Frond. Ined. Archip. Ind. 75. (1846)\nIncluded terminal clade:\n\nblumii",
         "internalSpecifiers": [{
+            "verbatimSpecifier": "Type: Exostratum blumii (Nees ex Hampe) L. Ellis, Lindbergia 11: 22. (1985)",
             "referencesTaxonomicUnits": [{
                 "scientificNames": [{
                     "scientificName": "Exostratum blumii (Nees ex Hampe) L. Ellis, Lindbergia 11: 22. (1985)",
@@ -272,17 +328,16 @@
                 }]
             }]
         }, {
+            "verbatimSpecifier": "Mishler 7/24/98(3), Queensland, Australia (uc)",
             "referencesTaxonomicUnits": [{
-                "specimens": [{
-                    "label": "Mishler 7/24/98(3), Queensland, Australia (uc)"
-                }],
-                "scientificNames": [{
-                    "scientificName": "Exostratum blumii (Nees ex Hampe) L.T. Ellis",
-                    "comment": "As per table 1 in the paper, which identifies this specimen."
+                "includesSpecimens": [{
+                    "label": "Mishler 7/24/98(3), Queensland, Australia (uc)",
+                    "catalogNumber": "Mishler 7/24/98(3)"
                 }]
             }]
         }],
         "externalSpecifiers": [{
+            "verbatimSpecifier": "Type: Arthrocormus schimperi (Dozy & Molk.) Dozy & Molk. (= Mielichhoferia schimperi Dozy & Molk.), Musci Frond. Ined. Archip. Ind. 75. (1846)",
             "referencesTaxonomicUnits": [{
                 "scientificNames": [{
                     "scientificName": "Arthrocormus schimperi (Dozy & Molk.) Dozy & Molk. (= Mielichhoferia schimperi Dozy & Molk.), Musci Frond. Ined. Archip. Ind. 75. (1846)",
@@ -296,15 +351,24 @@
         "cladeDefinition": "nomen cladi conversum, Exodictyon Cardot, Rev. Bryol. Lichénol. 26: 6. (1899), excl. parte, emend Ellis in Lindbergia 11: 16 (1985)\n\nStem-based definition:\n\ninternal specifier: Type: Exodictyon Cardot, Rev. Bryol. Lichénol. 26: 6. (1899), excl. parte, emend Ellis in Lindbergia 11: 16 (1985)\ninternal specifier: Wall 2527, Fiji (uc)\nexternal specifier: Type: Leucophanes octoblepharoides Brid., Bryol. Univ. 1: 763. (1826)\nIncluded terminal clade:\n\nincrassatum",
 
         "internalSpecifiers": [{
+            "verbatimSpecifier": "Type: Exodictyon Cardot, Rev. Bryol. Lichénol. 26: 6. (1899), excl. parte, emend Ellis in Lindbergia 11: 16 (1985)",
             "referencesTaxonomicUnits": [{
                 "scientificNames": [{
                     "scientificName": "Exodictyon Cardot, Rev. Bryol. Lichénol. 26: 6. (1899), excl. parte, emend Ellis in Lindbergia 11: 16 (1985) -- Wall 2527, Fiji (uc)",
-                    "testcase:submittedName": "Exodictyon incrassatum (Mitt.) Cardot",
-                    "binomialName": "Exodictyon incrassatum"
+                    "binomialName": "Exodictyon"
+                }]
+            }]
+        }, {
+            "verbatimSpecifier": "Wall 2527, Fiji (UC)",
+            "referencesTaxonomicUnits": [{
+                "includesSpecimens": [{
+                    "label": "Wall 2527, Fiji (UC)",
+                    "catalogNumber": "Wall 2527"
                 }]
             }]
         }],
         "externalSpecifiers": [{
+            "verbatimSpecifier": "Type: Leucophanes octoblepharoides Brid., Bryol. Univ. 1: 763. (1826)",
             "referencesTaxonomicUnits": [{
                 "scientificNames": [{
                     "scientificName": "Leucophanes octoblepharoides Brid., Bryol. Univ. 1: 763. (1826)",
@@ -318,6 +382,7 @@
         "cladeDefinition": "nomen cladi conversum, Leucophanes octoblepharoides Brid., Bryol. Univ. 1: 763. (1826)\n\nStem-based definition:\n\ninternal specifier: Type: Leucophanes octoblepharoides Brid., Bryol. Univ. 1: 763. (1826)\ninternal specifier: Type: Leucophanes seychellarum Besch., Ann. Sci. Nat., Bot., VI, 9: 337. (1880)\nexternal specifier: Wall 2527, Fiji (uc)\nIncluded terminal clades:\n\nconfertus, glaucum, octoblepharoides, seychellarum",
 
         "internalSpecifiers": [{
+            "verbatimSpecifier": "Type: Leucophanes octoblepharoides Brid., Bryol. Univ. 1: 763. (1826)",
             "referencesTaxonomicUnits": [{
                 "scientificNames": [{
                     "scientificName": "Leucophanes octoblepharoides Brid., Bryol. Univ. 1: 763. (1826)",
@@ -325,6 +390,7 @@
                 }]
             }]
         }, {
+            "verbatimSpecifier": "Type: Leucophanes seychellarum Besch., Ann. Sci. Nat., Bot., VI, 9: 337. (1880)",
             "referencesTaxonomicUnits": [{
                 "scientificNames": [{
                     "scientificName": "Leucophanes seychellarum Besch., Ann. Sci. Nat., Bot., VI, 9: 337. (1880)",
@@ -333,10 +399,11 @@
             }]
         }],
         "externalSpecifiers": [{
+            "verbatimSpecifier": "Wall 2527, Fiji (UC)",
             "referencesTaxonomicUnits": [{
-                "scientificNames": [{
-                    "scientificName": "Wall 2527, Fiji (uc) -- Exodictyon incrassatum (Mitt.) Cardot",
-                    "binomialName": "Exodictyon incrassatum"
+                "includesSpecimens": [{
+                    "label": "Wall 2527, Fiji (UC)",
+                    "catalogNumber": "Wall 2527"
                 }]
             }]
         }]

--- a/examples/hillis_and_wilcox_2005.json
+++ b/examples/hillis_and_wilcox_2005.json
@@ -1,19 +1,10 @@
 {
-    "@context": "../paper-context.json",
-
-    "@id": "https://doi.org/10.1016/j.ympev.2004.10.007#",
-    "@type": "testcase:TestSuiteFromPublication",
-
-    "curator": "Gaurav Vaidya <gaurav@ggvaidya.com>",
-    "comments": "None.",
-
+    "title": "Phylogeny of the New World true frogs (Rana)",
     "citation": "Hillis DM and Wilcox TP (2005) Molecular Phylogenetics and Evolution 34(2):299-314",
     "url": "https://doi.org/10.1016/j.ympev.2004.10.007",
     "year": 2005,
 
     "phylogenies": [{
-        "filename": "T4419.nexml"
-    }, {
         "newick": "(((('Rana luteiventris MVZ225749','Rana luteiventris MVZ191016'),'Rana boylii'),('Rana muscosa',('Rana cascadae','Rana aurora')))Amerana,'Rana temporaria',(((('Rana septentrionales',((('Rana heckscheri',('Rana catesbiana X12841','Rana catesbiana DMH84R2')),('Rana clamitans','Rana okaloosae')),'Rana grylio')),'Rana virgatipes')Aquarana,('Rana sylvatica DMH84R43','Rana sylvatica')),((((('Rana pustulosa','Rana tarahumarae'),('Rana psilonota','Rana zweifelii'))Zweifelia,'Rana sierramadrensis')Torrentirana,((('Rana palustris',('Rana areolata',('Rana capito','Rana sevosa')))Nenirana,((((('Rana magnaocularis','Rana sp7 KU 194492'),('Rana sp8 KU 195346',('Rana onca','Rana yavapaiensis'))),(('Rana sp6 LACM 146810',('Rana sp5 LACM 146764','Rana sp4 AMNH A 124167')),('Rana taylori',('Rana macroglossa','Rana macroglossa b')))),'Rana forreri'),(('Rana spectabilis',('Rana sp3 KU 194559','Rana omiltemana')),(((('Rana tlaloci','Rana neovolcanica'),'Rana berlandieri'),'Rana blairi'),('Rana sphenocephela utricularia','Rana sphenocephela'))))Scurrilirana),(((('Rana chiricahuensis KU 194419',('Rana subaquavocalis','Rana chiricahuensis KU 194442')),'Rana sp2 KU 204420'),('Rana dunni','Rana montezumae'))Lacusirana,('Rana pipiens JSF1119','Rana pipiens Y10945'))Stertirana)Pantherana),(('Rana maculata',('Rana warszewitshii','Rana vibicaria')Trypheropsis)Levirana,(('Rana bwana',('Rana sp1 QCAZ13219',('Rana palmipes KU204425','Rana palmipes AMNHA118801'))),('Rana vaillanti','Rana juliani'))Lithobates)Ranula)Sierrana)Novirana)Laurasiarana;",
         "ot:dataDeposit": "https://treebase.org/treebase-web/search/study/taxa.html?id=1269&treeid=4419",
 
@@ -812,7 +803,6 @@
             "cladeDefinition": "Laurasiarana, new clade name. Definition: The clade stemming from the most recent common ancestor of Rana temporaria Linne 1758 and Rana aurora Baird and Girard 1852.",
             "curatorComments": "The Laurasiarana expected node is not found in the TreeBase tree, so I've placed it where I think it should go.",
             "internalSpecifiers": [{
-                "verbatimSpecifier": "Rana temporaria Linne 1758",
                 "referencesTaxonomicUnits": [{
                     "scientificNames": [{
                         "scientificName": "Rana temporaria Linne 1758",
@@ -820,7 +810,6 @@
                     }]
                 }]
             }, {
-                "verbatimSpecifier": "Rana aurora Baird and Girard 1852",
                 "referencesTaxonomicUnits": [{
                     "scientificNames": [{
                         "scientificName": "Rana aurora Baird and Girard 1852",

--- a/examples/hillis_and_wilcox_2005.json
+++ b/examples/hillis_and_wilcox_2005.json
@@ -5,7 +5,7 @@
     "@type": "testcase:TestSuiteFromPublication",
 
     "curator": "Gaurav Vaidya <gaurav@ggvaidya.com>",
-    "comments": " - The Laurasiarana expected node is not found in the TreeBase tree, so I've placed it where I think it should go.",
+    "comments": "None.",
 
     "citation": "Hillis DM and Wilcox TP (2005) Molecular Phylogenetics and Evolution 34(2):299-314",
     "url": "https://doi.org/10.1016/j.ympev.2004.10.007",
@@ -810,7 +810,9 @@
         {
             "label": "Laurasiarana",
             "cladeDefinition": "Laurasiarana, new clade name. Definition: The clade stemming from the most recent common ancestor of Rana temporaria Linne 1758 and Rana aurora Baird and Girard 1852.",
+            "curatorComments": "The Laurasiarana expected node is not found in the TreeBase tree, so I've placed it where I think it should go.",
             "internalSpecifiers": [{
+                "verbatimSpecifier": "Rana temporaria Linne 1758",
                 "referencesTaxonomicUnits": [{
                     "scientificNames": [{
                         "scientificName": "Rana temporaria Linne 1758",
@@ -818,6 +820,7 @@
                     }]
                 }]
             }, {
+                "verbatimSpecifier": "Rana aurora Baird and Girard 1852",
                 "referencesTaxonomicUnits": [{
                     "scientificNames": [{
                         "scientificName": "Rana aurora Baird and Girard 1852",

--- a/index.html
+++ b/index.html
@@ -549,8 +549,10 @@
                                         <!-- Match results with dropdown menu -->
                                         <button
                                             @click="specifier_dropdown_target = 'match_result'"
-                                            type="button" class="btn dropdown-toggle" :class="{ 'btn-warning': get_all_node_labels_matched_by_specifier(specifier).length == 0, 'btn-success': get_all_node_labels_matched_by_specifier(specifier).length > 0}" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                                            <span class="glyphicon" :class="{ 'glyphicon-asterisk': get_all_node_labels_matched_by_specifier(specifier).length == 0, 'glyphicon-ok': get_all_node_labels_matched_by_specifier(specifier).length > 0}"></span>
+                                            type="button" class="btn dropdown-toggle"
+                                                :class="{ 'btn-warning': get_all_node_labels_matched_by_specifier(specifier).length == 0, 'btn-success': get_all_node_labels_matched_by_specifier(specifier).length > 0}" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                                            <span class="glyphicon"
+                                                :class="{ 'glyphicon-asterisk': get_all_node_labels_matched_by_specifier(specifier).length == 0, 'glyphicon-ok': (get_all_node_labels_matched_by_specifier(specifier).length > 0) || specifier.hasOwnProperty('specifierWillNotMatch') }"></span>
                                         </button>
                                         <ul v-if="specifier_dropdown_target == 'match_result'" class="dropdown-menu dropdown-menu-left">
                                             <li class="dropdown-header">Match result</li>

--- a/index.html
+++ b/index.html
@@ -66,17 +66,19 @@
                 </label>
 
                 <div class="btn-group" role="group">
-                    <button id="export-as-json" type="button" class="btn btn-success" onclick="$('#view-as-json').toggle(300)">Export as JSON</button>
+                    <button id="display-as-json-btn" type="button" class="btn btn-success" onclick="$('#display-as-json').toggle(300)">Display as JSON</button>
                 </div>
             </div>
         </div>
 
         <!-- Displays the test case as a JSON document -->
-        <div id="view-as-json" class="col-md-12" hidden>
+        <div id="display-as-json" class="col-md-12" hidden>
             <div class="panel panel-success">
                 <div class="panel-heading">Test case as JSON</div>
                 <div class="panel-body">
-                    <textarea id="test-content" cols="80" rows="10" v-model="testcase_as_json"></textarea>
+                    <p>The following is a representation of this PHYX in JSON. You
+                    can edit the JSON directly, or copy it elsewhere to save it.</p>
+                    <textarea id="test-content" class="form-control" cols="80" rows="10" v-model="testcase_as_json"></textarea>
                 </div>
             </div>
         </div>
@@ -92,7 +94,7 @@
                             If one is present in the PHYX file, the Curation Tool will
                             allow curators to edit it, but does not allow curators to
                             add it to a PHYX file that is missing it unless it is
-                            manually added to the PHYX file using the "Export as JSON"
+                            manually added to the PHYX file using the "Display as JSON"
                             option.
                         -->
                         <label for="testcase-id" class="col-md-1 control-label">Testcase IRI</label>

--- a/index.html
+++ b/index.html
@@ -529,7 +529,7 @@
                         </div>
 
                         <!-- List of specifiers associated with this phyloreference -->
-                        <div class="panel panel-info" style="margin-top: 1em">
+                        <div id="specifiers" class="panel panel-info" style="margin-top: 1em">
                             <div class="panel-heading">Specifiers</div>
                             <div class="panel-body">
                                 <div class="input-group"
@@ -547,7 +547,6 @@
                                         </button>
 
                                         <!-- Match results with dropdown menu -->
-
                                         <button
                                             @click="specifier_dropdown_target = 'match_result'"
                                             type="button" class="btn dropdown-toggle" :class="{ 'btn-warning': get_all_node_labels_matched_by_specifier(specifier).length == 0, 'btn-success': get_all_node_labels_matched_by_specifier(specifier).length > 0}" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
@@ -559,8 +558,22 @@
                                                 <a href="#" onclick="return false;"><em>No matches</em></a>
                                             </li>
                                             <li v-for="(node_label, node_label_index) of get_all_node_labels_matched_by_specifier(specifier)">
-                                                <a href="#" onclick="return false;">{{node_label}}<a>
+                                                <a href="#" onclick="return false;">{{node_label}}</a>
                                             </li>
+                                            <template v-if="get_all_node_labels_matched_by_specifier(specifier).length === 0">
+                                                <li class="dropdown-header">Specifier will not match</li>
+                                                <li><a href="#specifiers"
+                                                    @click="prompt_and_set_dict('Why couldn\'t this specifier be matched?', specifier, 'specifierWillNotMatch')"
+                                                    >
+                                                        <template v-if="specifier.hasOwnProperty('specifierWillNotMatch')">
+                                                            Reason <small>(click to edit)</small>: {{specifier.specifierWillNotMatch}}
+                                                        </template>
+                                                        <template v-else>
+                                                            <em>No reason given: click here to set one</em>
+                                                        </template>
+                                                    </a>
+                                                </li>
+                                            </template>
                                         </ul>
                                         <ul v-if="specifier_dropdown_target == 'specifier_type'" class="dropdown-menu dropdown-menu-left">
                                             <li class="dropdown-header">Specifier type</li>

--- a/index.html
+++ b/index.html
@@ -88,21 +88,6 @@
             <div class="panel panel-info">
                 <div class="panel-heading">Study metadata</div>
                 <div class="form-group panel-body">
-                    <template v-if="testcase.hasOwnProperty('@id')">
-                        <!--
-                            The Testcase IRI is an optional, not-recommended property.
-                            If one is present in the PHYX file, the Curation Tool will
-                            allow curators to edit it, but does not allow curators to
-                            add it to a PHYX file that is missing it unless it is
-                            manually added to the PHYX file using the "Display as JSON"
-                            option.
-                        -->
-                        <label for="testcase-id" class="col-md-1 control-label">Testcase IRI</label>
-                        <div class="col-md-10 input-group">
-                            <input id="testcase-id" type="url" class="form-control" v-model.trim="testcase['@id']" placeholder="Enter IRI that identifies this testcase">
-                        </div>
-                    </template>
-
                     <label for="title" class="col-md-1 control-label">Title</label>
                     <div class="col-md-10 input-group">
                         <input id="title" type="text" class="form-control" v-model.trim="testcase.title" placeholder="Enter study title">

--- a/index.html
+++ b/index.html
@@ -470,6 +470,64 @@
                                 ></textarea>
                         </div>
 
+                        <!-- Node(s) this phyloreference is expected to resolve to -->
+                        <label for="curator-comments" class="control-label col-md-3">Expected node resolution</label>
+                        <div class="input-group col-md-9">
+                            <!-- What if no phylogenies were loaded? -->
+                            <div
+                                v-if="testcase['phylogenies'].length == 0"
+                            >No phylogenies loaded.</div>
+
+                            <!-- If phylogenies were loaded, we need to display a selector for each phylogeny -->
+                            <div class="input-group" v-for="(phylogeny, phylogeny_index) of testcase['phylogenies']">
+                                <!-- Display the phylogeny where this node is expected to match -->
+                                <span class="input-group-addon" :title="phylogeny['description']">Phylogeny {{phylogeny_index + 1}}</span>
+
+                                <!-- Display the matching node(s) -->
+                                <template v-if="get_phyloref_expected_node_labels(phylogeny, selected_phyloref).length === 0">
+                                    <!-- We matched no nodes -->
+                                    <input readonly type="text" class="form-control" value="No nodes could be matched">
+                                </template>
+                                <template v-if="get_phyloref_expected_node_labels(phylogeny, selected_phyloref).length === 1">
+                                    <!-- We matched exactly one node -->
+                                    <input readonly type="text" class="form-control" :value="get_phyloref_expected_node_labels(phylogeny, selected_phyloref)[0]">
+                                </template>
+                                <template v-if="get_phyloref_expected_node_labels(phylogeny, selected_phyloref).length > 1">
+                                    <!-- We matched more than one node -->
+                                    <input readonly type="text" class="form-control" :value="get_phyloref_expected_node_labels(phylogeny, selected_phyloref).length + ' nodes matched: ' + get_phyloref_expected_node_labels(phylogeny, selected_phyloref).join(', ')">
+                                </template>
+
+                                <!-- Display a dropdown menu that allows the modified label to be changed. -->
+                                <div class="input-group-btn">
+                                    <button
+                                        type="button"
+                                        class="btn btn-primary dropdown-toggle"
+                                        data-toggle="dropdown"
+                                        aria-haspopup="true"
+                                        aria-expanded="false"
+                                        >Change <span class="caret"></span></button>
+                                    </button>
+                                    <ul class="dropdown-menu dropdown-menu-right">
+                                        <!-- List every labeled node in this phylogeny. -->
+                                        <li class="dropdown-header">Labeled internal nodes in this phylogeny</li>
+                                        <li
+                                            v-for="node_label of get_node_labels_in_phylogeny(phylogeny, 'internal').sort()"
+                                            :class="{active: get_phyloref_expected_node_labels(phylogeny, selected_phyloref).includes(node_label)}"
+                                        >
+                                            <a href="#selected-phyloref" @click="toggle_phyloref_expected_node_label(phylogeny, selected_phyloref, node_label)">{{node_label}}</a>
+                                        </li>
+                                        <li class="dropdown-header">Labeled terminal nodes in this phylogeny</li>
+                                        <li
+                                            v-for="node_label of get_node_labels_in_phylogeny(phylogeny, 'terminal').sort()"
+                                            :class="{active: get_phyloref_expected_node_labels(phylogeny, selected_phyloref).includes(node_label)}"
+                                        >
+                                            <a href="#selected-phyloref" @click="toggle_phyloref_expected_node_label(phylogeny, selected_phyloref, node_label)">{{node_label}}</a>
+                                        </li>
+                                    </ul>
+                                </div>
+                            </div>
+                        </div>
+
                         <!-- List of specifiers associated with this phyloreference -->
                         <div class="panel panel-info" style="margin-top: 1em">
                             <div class="panel-heading">Specifiers</div>

--- a/index.html
+++ b/index.html
@@ -86,10 +86,20 @@
             <div class="panel panel-info">
                 <div class="panel-heading">Study metadata</div>
                 <div class="form-group panel-body">
-                    <label for="testcase-id" class="col-md-1 control-label">Testcase URI</label>
-                    <div class="col-md-10 input-group">
-                        <input id="testcase-id" type="url" class="form-control" v-model.trim="testcase['@id']" placeholder="Enter URI that identifies this testcase">
-                    </div>
+                    <template v-if="testcase.hasOwnProperty('@id')">
+                        <!--
+                            The Testcase IRI is an optional, not-recommended property.
+                            If one is present in the PHYX file, the Curation Tool will
+                            allow curators to edit it, but does not allow curators to
+                            add it to a PHYX file that is missing it unless it is
+                            manually added to the PHYX file using the "Export as JSON"
+                            option.
+                        -->
+                        <label for="testcase-id" class="col-md-1 control-label">Testcase IRI</label>
+                        <div class="col-md-10 input-group">
+                            <input id="testcase-id" type="url" class="form-control" v-model.trim="testcase['@id']" placeholder="Enter IRI that identifies this testcase">
+                        </div>
+                    </template>
 
                     <label for="title" class="col-md-1 control-label">Title</label>
                     <div class="col-md-10 input-group">

--- a/index.html
+++ b/index.html
@@ -257,24 +257,21 @@
         <!-- Taxonomic unit editing modal: dialog box to allow editing lists of taxonomic units -->
         <div id="tunit-editor-modal" class="modal fade">
             <div class="modal-dialog modal-lg form-horizontal">
-                <div class="modal-content" v-if="selected_tunit_list !== undefined">
+                <div class="modal-content" v-if="selected_tunit_list_container !== undefined">
 
                     <!-- Header of tunit editor modal dialog box -->
                     <div class="modal-header">
                         <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-                        <h4 class="modal-title">Editing {{tunit_editor_target_label}}</h4>
+                        <h4 class="modal-title">Editing {{selected_tunit_list_container.type}} {{selected_tunit_list_container.label}}</h4>
                     </div>
 
                     <!-- Body of specifier editor modal dialog box -->
-                    <div class="modal-body form-group">
-                        <div class="col-md-12">
-                            <p>
-                                Each taxonomic unit can have any number of scientific names, external
-                                references and specimens. We recommend using a single taxonomic unit
-                                for each type of identifier.
-                            </p>
-
+                    <div class="modal-body col-md-12">
                             <form id="tunit-editor-form">
+                                <div v-if="selected_tunit_list_container.type == 'specifier'">
+                                    <label for="verbatim-specifier" class="control-label">Verbatim specifier</label>
+                                    <input id="verbatim-specifier" type="text" class="form-control" v-model.trim="selected_tunit_list_container.container['verbatimSpecifier']" placeholder="Enter the verbatim description of this specifier">
+                                </div>
 
                                 <!-- List of taxonomic units -->
                                 <div id="tunits-panel" class="panel panel-info" style="margin-top: 1em">
@@ -283,6 +280,11 @@
                                         <p><em>Select a taxonomic unit or create a new one.</em></p>
                                     </div>
                                     <div class="panel-body" v-if="selected_tunit">
+                                        <p>
+                                            Each taxonomic unit can have any number of scientific names, external
+                                            references and specimens. We recommend using a single taxonomic unit
+                                            for each type of identifier.
+                                        </p>
 
                                         <!-- Panel listing scientific names in this taxonomic unit -->
                                         <div class="col-md-12">
@@ -396,20 +398,19 @@
                                     <!-- List of taxonomic units, including the option to add new taxonomic units -->
                                     <div class="list-group">
                                         <a class="list-group-item"
-                                            v-for="(tunit, tunit_index) of selected_tunit_list"
+                                            v-for="(tunit, tunit_index) of selected_tunit_list_container.list"
                                             :class="{active: selected_tunit === tunit}"
                                             @click="selected_tunit = tunit"
                                             :title="get_taxonomic_unit_label(tunit)"
                                         >{{get_taxonomic_unit_label(tunit)}}</a>
                                         <a class="list-group-item"
                                             href="javascript: void(0)"
-                                            onclick="vm.selected_tunit_list.push(vm.create_empty_taxonomic_unit(vm.selected_tunit_list.length + 1))"
+                                            onclick="vm.selected_tunit_list_container.list.push(vm.create_empty_taxonomic_unit(vm.selected_tunit_list_container.list.length + 1))"
                                             ><strong>Add new taxonomic unit</strong></a>
                                     </div>
 
                                 </div>
                             </form>
-                        </div>
                     </div>
 
                     <!-- Footer of the specifier editor modal dialog box -->

--- a/index.html
+++ b/index.html
@@ -441,8 +441,20 @@
                                 id="definition"
                                 v-model="selected_phyloref.cladeDefinition"
                                 class="form-control"
-                                rows="8"
+                                rows="6"
                                 placeholder="Phylogenetic clade definition"
+                                ></textarea>
+                        </div>
+
+                        <!-- Phyloreference curator comments -->
+                        <label for="curator-comments" class="control-label col-md-4">Curator comments</label>
+                        <div class="input-group col-md-8">
+                            <textarea
+                                id="curator-comments"
+                                v-model="selected_phyloref['curatorComments']"
+                                class="form-control"
+                                rows="2"
+                                placeholder="Curator notes relating to this phyloreference"
                                 ></textarea>
                         </div>
 

--- a/index.html
+++ b/index.html
@@ -441,14 +441,14 @@
                     <form id="phyloref" class="form-horizontal">
 
                         <!-- Phyloreference label -->
-                        <label for="label" class="control-label col-md-4">Label</label>
-                        <div class="input-group col-md-8">
+                        <label for="label" class="control-label col-md-3">Label</label>
+                        <div class="input-group col-md-9">
                             <input id="label" v-model="selected_phyloref.label" type="text" class="form-control"  placeholder="Phyloreference label">
                         </div>
 
                         <!-- Phyloreference clade definition -->
-                        <label for="definition" class="control-label col-md-4">Clade definition</label>
-                        <div class="input-group col-md-8">
+                        <label for="definition" class="control-label col-md-3">Clade definition</label>
+                        <div class="input-group col-md-9">
                             <textarea
                                 id="definition"
                                 v-model="selected_phyloref.cladeDefinition"
@@ -459,8 +459,8 @@
                         </div>
 
                         <!-- Phyloreference curator comments -->
-                        <label for="curator-comments" class="control-label col-md-4">Curator comments</label>
-                        <div class="input-group col-md-8">
+                        <label for="curator-comments" class="control-label col-md-3">Curator comments</label>
+                        <div class="input-group col-md-9">
                             <textarea
                                 id="curator-comments"
                                 v-model="selected_phyloref['curatorComments']"

--- a/js/curation-tool.js
+++ b/js/curation-tool.js
@@ -385,6 +385,92 @@ var vm = new Vue({
 
             return potential_label;
         },
+        get_phyloref_expected_node_labels: function(phylogeny, phyloref) {
+            // Given a specifier, determine which node labels we expect it to
+            // resolve to. To do this, we:
+            //  1. Find all node labels that are case-sensitively identical
+            //     to the phyloreference.
+            //  2. Find all node labels that have additionalNodeProperties with
+            //     expectedPhyloreferenceNamed case-sensitively identical to
+            //     the phyloreference.
+            let phyloref_label = this.get_phyloref_label(phyloref);
+            let node_labels = new Set();
+            for(node_label of this.get_node_labels_in_phylogeny(phylogeny)) {
+                // Is this node label identical to the phyloreference name?
+                if(node_label === phyloref_label) {
+                    node_labels.add(node_label);
+                    continue;
+                }
+
+                // Does this node label have an expectedPhyloreferenceNamed that
+                // includes this phyloreference name?
+                if(
+                    phylogeny.hasOwnProperty('additionalNodeProperties') &&
+                    phylogeny.additionalNodeProperties.hasOwnProperty(node_label) &&
+                    phylogeny.additionalNodeProperties[node_label].hasOwnProperty('expectedPhyloreferenceNamed')
+                ) {
+                    let expectedPhylorefs = phylogeny.additionalNodeProperties[node_label].expectedPhyloreferenceNamed;
+
+                    if(expectedPhylorefs.includes(phyloref_label)) {
+                        node_labels.add(node_label);
+                        continue;
+                    }
+                }
+            }
+
+            // Return node labels sorted alphabetically.
+            return Array.from(node_labels).sort();
+        },
+        toggle_phyloref_expected_node_label: function(phylogeny, phyloref, node_label_to_toggle) {
+            // Change the PHYX model so that the provided node label is either
+            // added to the list of nodes we expect this phyloreference to resolve
+            // to, or removed from that list.
+            //
+            // In the user interface, the expected node label is a property of
+            // the phyloreference, which is the most reasonable approach for
+            // curators. However, in the data model, this is a property of the
+            // phylogeny, which is where all phyloreference resolution expectations
+            // should be. Therefore, this method will actually modify the phylogeny in
+            // order to set where this phyloreference is expected to resolve.
+            // See https://github.com/phyloref/curation-tool/issues/32 for more
+            // information.
+            //
+            let phyloref_label = this.get_phyloref_label(phyloref);
+            let current_expected_node_labels = this.get_phyloref_expected_node_labels(phylogeny, phyloref);
+
+            if(current_expected_node_labels.includes(node_label_to_toggle)) {
+                // We need to delete this node label.
+                if(
+                    phylogeny.hasOwnProperty('additionalNodeProperties') &&
+                    phylogeny.additionalNodeProperties.hasOwnProperty(node_label_to_toggle) &&
+                    phylogeny.additionalNodeProperties[node_label_to_toggle].hasOwnProperty('expectedPhyloreferenceNamed')
+                ) {
+                    // Delete this phyloreference from the provided node label.
+                    phylogeny.additionalNodeProperties[node_label_to_toggle].expectedPhyloreferenceNamed =
+                        phylogeny.additionalNodeProperties[node_label_to_toggle].expectedPhyloreferenceNamed.filter(
+                            label => (phyloref_label !== label)
+                        );
+                }
+            } else {
+                // We need to add this node label.
+
+                // First, we need to make sure we have additional node properties
+                // and expected phyloreference named for this node. If not, make them!
+                if(!phylogeny.hasOwnProperty('additionalNodeProperties')) phylogeny.additionalNodeProperties = {};
+                if(!phylogeny.additionalNodeProperties.hasOwnProperty(node_label_to_toggle))
+                    phylogeny.additionalNodeProperties[node_label_to_toggle] = {};
+
+                if(!phylogeny.additionalNodeProperties[node_label_to_toggle].hasOwnProperty('expectedPhyloreferenceNamed'))
+                    phylogeny.additionalNodeProperties[node_label_to_toggle].expectedPhyloreferenceNamed = [];
+
+                // Finally, add it to the list unless it's already there!
+                if(!phylogeny.additionalNodeProperties[node_label_to_toggle].expectedPhyloreferenceNamed.includes(phyloref_label))
+                    phylogeny.additionalNodeProperties[node_label_to_toggle].expectedPhyloreferenceNamed.push(phyloref_label);
+            }
+
+            // Did that work?
+            console.log("Additional node properties for '" + node_label_to_toggle + "'", phylogeny.additionalNodeProperties[node_label_to_toggle]);
+        },
         get_phylogeny_as_newick: function(node_expr, phylogeny) {
             // Returns the phylogeny as a Newick string. Since this method is
             // called frequently in rendering the "Edit as Newick" textareas,
@@ -543,15 +629,14 @@ var vm = new Vue({
         },
 
         // Methods for manipulating nodes in phylogenies.
-        get_node_labels_in_phylogeny: function(phylogeny) {
-            // Return an iterator to all the node labels in a phylogeny. These
-            // node labels come from two sources:
-            //  1. We look for node names in the Newick string.
-            //  2. We look for node names in the additionalNodeProperties.
+        get_node_labels_in_phylogeny: function(phylogeny, node_type='both') {
+            // Return a list of all the node labels in a phylogeny by
+            // looking for node names in the Newick string.
             //
-            // This means that we can pick up both (1) nodes in the Newick
-            // string without any additional properties, and (2) nodes with
-            // additional node properties which are not present.
+            // node_type can be one of:
+            // - 'internal': Return node labels on internal nodes.
+            // - 'terminal': Return node labels on terminal nodes.
+            // - 'both': Return node labels on both internal and terminal nodes.
 
             var node_labels = new Set();
 
@@ -573,8 +658,19 @@ var vm = new Vue({
                 var add_node_and_children_to_node_labels = function(node) {
                     // console.log("Recursing into: " + JSON.stringify(node));
 
-                    if(node.hasOwnProperty('name') && node.name != '')
-                        node_labels.add(node.name);
+                    if(node.hasOwnProperty('name') && node.name != '') {
+                        let node_has_children = node.hasOwnProperty('children') && node.children.length > 0;
+
+                        // Only add the node label if it is on the type of node
+                        // we're interested in.
+                        if(
+                            (node_type === 'both') ||
+                            (node_type === 'internal' && node_has_children) ||
+                            (node_type === 'terminal' && !node_has_children)
+                        ) {
+                            node_labels.add(node.name);
+                        }
+                    }
 
                     if(node.hasOwnProperty('children')) {
                         for(child of node.children) {
@@ -585,13 +681,6 @@ var vm = new Vue({
 
                 // Recurse away!
                 add_node_and_children_to_node_labels(parsed.json);
-            }
-
-            // Names from additionalNodeProperties
-            if(phylogeny.hasOwnProperty('additionalNodeProperties')) {
-                for(key of Object.keys(phylogeny.additionalNodeProperties)) {
-                    node_labels.add(key);
-                }
             }
 
             return Array.from(node_labels);

--- a/js/curation-tool.js
+++ b/js/curation-tool.js
@@ -1094,7 +1094,7 @@ function render_tree(node_expr, phylogeny) {
                 if(
                     vm.selected_phyloref !== undefined &&
                     vm.selected_phyloref.hasOwnProperty('label') &&
-                    vm.selected_phyloref.label == data.name
+                    vm.get_phyloref_expected_node_labels(phylogeny, vm.selected_phyloref).includes(data.name)
                 ) {
                     text_label.classed("selected-internal-label", true);
                 }

--- a/js/curation-tool.js
+++ b/js/curation-tool.js
@@ -97,14 +97,14 @@ var vm = new Vue({
             }
         },
         doi_without_prefix: {
-            // Extract the DOI from the '@id' or 'url'.
+            // Extract the DOI from the 'url'.
             get: function() {
                 // Is there a DOI? If so, use that.
                 if(this.testcase.hasOwnProperty('doi') && this.testcase.doi != "") {
                     return this.testcase.doi;
                 }
 
-                // If not, look for a DOI among the '@id' and the 'url'.
+                // If not, look for a DOI in the 'url'.
                 return identify_doi(this.testcase);
             },
             set: function(newDOI) {
@@ -946,9 +946,8 @@ function extract_tunits_from_node_label(node_label) {
  * identify_doi(testcase)
  *
  * DOIs should be entered into their own 'doi' field. This method looks through
- * all possible places where a DOI might be entered -- including the study @id
- * and the 'url' field -- and attempts to extract a DOI using the regular
- * expression DOI_REGEX.
+ * all possible places where a DOI might be entered -- including the 'url'
+ * field -- and attempts to extract a DOI using the regular expression DOI_REGEX.
  *
  * @return The best guess DOI or undefined.
  */
@@ -959,10 +958,6 @@ function identify_doi(testcase) {
 
     if(testcase.hasOwnProperty('doi')) {
         possibilities.push(testcase['doi']);
-    }
-
-    if(testcase.hasOwnProperty('@id')) {
-        possibilities.push(testcase['@id']);
     }
 
     if(testcase.hasOwnProperty('url')) {

--- a/js/curation-tool.js
+++ b/js/curation-tool.js
@@ -140,7 +140,18 @@ var vm = new Vue({
             return dict;
         },
         confirm(message, func) {
+            // Confirm an action with the user, then execute it if confirmed.
             if(window.confirm(message)) func();
+        },
+        prompt_and_set_dict(message, dict, key) {
+            // Prompt the user for a string, then set it in a dict.
+            if(dict.hasOwnProperty(key)) {
+                result = window.prompt(message, dict[key]);
+            } else {
+                result = window.prompt(message);
+            }
+
+            if(result !== null) Vue.set(dict, key, result);
         },
 
         // Data model management methods.

--- a/js/curation-tool.js
+++ b/js/curation-tool.js
@@ -467,9 +467,9 @@ var vm = new Vue({
 
                 // First, we need to make sure we have additional node properties
                 // and expected phyloreference named for this node. If not, make them!
-                if(!phylogeny.hasOwnProperty('additionalNodeProperties')) phylogeny.additionalNodeProperties = {};
+                if(!phylogeny.hasOwnProperty('additionalNodeProperties')) Vue.set(phylogeny, 'additionalNodeProperties', {});
                 if(!phylogeny.additionalNodeProperties.hasOwnProperty(node_label_to_toggle))
-                    phylogeny.additionalNodeProperties[node_label_to_toggle] = {};
+                    Vue.set(phylogeny.additionalNodeProperties, node_label_to_toggle, {});
 
                 if(!phylogeny.additionalNodeProperties[node_label_to_toggle].hasOwnProperty('expectedPhyloreferenceNamed'))
                     phylogeny.additionalNodeProperties[node_label_to_toggle].expectedPhyloreferenceNamed = [];

--- a/js/curation-tool.js
+++ b/js/curation-tool.js
@@ -49,15 +49,12 @@ var vm = new Vue({
 
         // UI elements.
         selected_phyloref: undefined,
-        selected_tunit_list: undefined,
+        selected_tunit_list_container: undefined,
         selected_tunit: undefined,
 
         // Phylogeny view modes
         phylogeny_newick_mode_for: undefined,
         phylogeny_annotations_mode_for: undefined,
-
-        // Taxonomic unit editor modal elements
-        tunit_editor_target_label: "(unlabeled)",
 
         // Display the delete buttons on the specifiers.
         specifier_delete_mode: false,
@@ -197,22 +194,30 @@ var vm = new Vue({
             if(type == 'specifier') {
                 // Specifiers store their taxonomic units in their
                 // 'referencesTaxonomicUnits' property.
-                this.tunit_editor_target_label = 'specifier ' + label;
 
                 // Specifiers store their tunit list in referencesTaxonomicUnits.
                 if(!tunit_list_container.hasOwnProperty('referencesTaxonomicUnits'))
                     Vue.set(tunit_list_container, 'referencesTaxonomicUnits', []);
 
-                this.selected_tunit_list = tunit_list_container.referencesTaxonomicUnits;
+                this.selected_tunit_list_container = {
+                    'type': 'specifier',
+                    'label': label,
+                    'container': tunit_list_container,
+                    'list': tunit_list_container.referencesTaxonomicUnits
+                };
             } else if (type == 'node') {
                 // Nodes store their taxonomic units in their
                 // 'representsTaxonomicUnits' property.
-                this.tunit_editor_target_label = 'node: ' + label;
 
                 if(!tunit_list_container.hasOwnProperty('representsTaxonomicUnits'))
                     Vue.set(tunit_list_container, 'representsTaxonomicUnits', []);
 
-                this.selected_tunit_list = tunit_list_container.representsTaxonomicUnits;
+                this.selected_tunit_list_container = {
+                    'type': 'node',
+                    'label': label,
+                    'container': tunit_list_container,
+                    'list': tunit_list_container.representsTaxonomicUnits
+                };
 
             } else {
                 throw "Tunit editor modal started with invalid type: " + type + ".";
@@ -220,15 +225,15 @@ var vm = new Vue({
 
             // If we don't have a first tunit, create an empty, blank one
             // so we don't have to display an empty website.
-            if(this.selected_tunit_list.length > 0) {
+            if(this.selected_tunit_list_container.list.length > 0) {
                 // We have a first tunit, so select it!
-                this.selected_tunit = this.selected_tunit_list[0];
+                this.selected_tunit = this.selected_tunit_list_container.list[0];
             } else {
                 // Specifier doesn't represent any taxonomic unit, but it's
                 // bad UX to just display a blank screen. So let's create a
                 // blank taxonomic unit to work with.
                 var new_tunit = this.create_empty_taxonomic_unit();
-                this.selected_tunit_list.push(new_tunit);
+                this.selected_tunit_list_container.list.push(new_tunit);
                 this.selected_tunit = new_tunit;
             }
 

--- a/js/curation-tool.js
+++ b/js/curation-tool.js
@@ -336,14 +336,20 @@ var vm = new Vue({
             // Any scientific names?
             if('scientificNames' in tu) {
                 for(scname of tu.scientificNames) {
-                    if('scientificName' in scname) labels.push(scname.scientificName);
+                    if('label' in scname) labels.push(scname.label);
+                    else if('scientificName' in scname) labels.push(scname.scientificName);
+                    else if('binomialName' in scname) labels.push(scname.binomialName);
+                    else labels.push("Unformatted scientific name");
                 }
             }
 
             // Any specimens?
             if('includesSpecimens' in tu) {
                 for(specimen of tu.includesSpecimens) {
-                    if('occurrenceID' in specimen) labels.push("Specimen " + specimen.occurrenceID);
+                    if('label' in specimen) labels.push("Specimen " + specimen.label);
+                    else if('occurrenceID' in specimen) labels.push("Specimen " + specimen.occurrenceID);
+                    else if('catalogNumber' in specimen) labels.push("Specimen " + specimen.catalogNumber);
+                    else labels.push("Unlabeled specimen");
                 }
             }
 

--- a/js/curation-tool.js
+++ b/js/curation-tool.js
@@ -28,7 +28,6 @@ var vm = new Vue({
 
         // The main data model.
         testcase: {
-            '@id': "",
             'doi': "",
             'url': "",
             'citation': "",
@@ -39,7 +38,6 @@ var vm = new Vue({
         // A copy of the data model, used to test when the data model has been
         // modified.
         testcase_as_loaded: {
-            '@id': "",
             'doi': "",
             'url': "",
             'citation': "",


### PR DESCRIPTION
This pull request changes some aspects of the PHYX model in order to facilitate curation and to keep the Curation Tool in sync with the Curation Workflow. These changes includes:
- Removed `@id` field (closes #2).
- Added a verbatim specifier field for all specifiers (closes #17).
- Added a curator comments field for all phyloreferences (closes #24).
- Allows the curator to document that they expect a single node to resolve to multiple phyloreferences by selecting a matching labeled node from the phyloreferencing panel (#32).
- Added a simple system for marking specifiers that could not be matched (#49).
- Improved display of scientific names and specimens as specifiers.

This pull request is ready to be merged.