### PR TITLE
Addition field for documenting that a single node resolves to multiple phyloreferences

### DIFF
--- a/examples/hillis_and_wilcox_2005.json
+++ b/examples/hillis_and_wilcox_2005.json
@@ -5,7 +5,7 @@
     "@type": "testcase:TestSuiteFromPublication",
 
     "curator": "Gaurav Vaidya <gaurav@ggvaidya.com>",
-    "comments": " - The Laurasiarana expected node is not found in the TreeBase tree, so I've placed it where I think it should go.",
+    "comments": "None.",
 
     "citation": "Hillis DM and Wilcox TP (2005) Molecular Phylogenetics and Evolution 34(2):299-314",
     "url": "https://doi.org/10.1016/j.ympev.2004.10.007",
@@ -810,7 +810,9 @@
         {
             "label": "Laurasiarana",
             "cladeDefinition": "Laurasiarana, new clade name. Definition: The clade stemming from the most recent common ancestor of Rana temporaria Linne 1758 and Rana aurora Baird and Girard 1852.",
+            "curatorComments": "The Laurasiarana expected node is not found in the TreeBase tree, so I've placed it where I think it should go.",
             "internalSpecifiers": [{
+                "verbatimSpecifier": "Rana temporaria Linne 1758",
                 "referencesTaxonomicUnits": [{
                     "scientificNames": [{
                         "scientificName": "Rana temporaria Linne 1758",
@@ -818,6 +820,7 @@
                     }]
                 }]
             }, {
+                "verbatimSpecifier": "Rana aurora Baird and Girard 1852",
                 "referencesTaxonomicUnits": [{
                     "scientificNames": [{
                         "scientificName": "Rana aurora Baird and Girard 1852",

--- a/index.html
+++ b/index.html
@@ -66,17 +66,19 @@
                 </label>
 
                 <div class="btn-group" role="group">
-                    <button id="export-as-json" type="button" class="btn btn-success" onclick="$('#view-as-json').toggle(300)">Export as JSON</button>
+                    <button id="display-as-json-btn" type="button" class="btn btn-success" onclick="$('#display-as-json').toggle(300)">Display as JSON</button>
                 </div>
             </div>
         </div>
 
         <!-- Displays the test case as a JSON document -->
-        <div id="view-as-json" class="col-md-12" hidden>
+        <div id="display-as-json" class="col-md-12" hidden>
             <div class="panel panel-success">
                 <div class="panel-heading">Test case as JSON</div>
                 <div class="panel-body">
-                    <textarea id="test-content" cols="80" rows="10" v-model="testcase_as_json"></textarea>
+                    <p>The following is a representation of this PHYX in JSON. You
+                    can edit the JSON directly, or copy it elsewhere to save it.</p>
+                    <textarea id="test-content" class="form-control" cols="80" rows="10" v-model="testcase_as_json"></textarea>
                 </div>
             </div>
         </div>
@@ -92,7 +94,7 @@
                             If one is present in the PHYX file, the Curation Tool will
                             allow curators to edit it, but does not allow curators to
                             add it to a PHYX file that is missing it unless it is
-                            manually added to the PHYX file using the "Export as JSON"
+                            manually added to the PHYX file using the "Display as JSON"
                             option.
                         -->
                         <label for="testcase-id" class="col-md-1 control-label">Testcase IRI</label>

--- a/index.html
+++ b/index.html
@@ -86,10 +86,20 @@
             <div class="panel panel-info">
                 <div class="panel-heading">Study metadata</div>
                 <div class="form-group panel-body">
-                    <label for="testcase-id" class="col-md-1 control-label">Testcase URI</label>
-                    <div class="col-md-10 input-group">
-                        <input id="testcase-id" type="url" class="form-control" v-model.trim="testcase['@id']" placeholder="Enter URI that identifies this testcase">
-                    </div>
+                    <template v-if="testcase.hasOwnProperty('@id')">
+                        <!--
+                            The Testcase IRI is an optional, not-recommended property.
+                            If one is present in the PHYX file, the Curation Tool will
+                            allow curators to edit it, but does not allow curators to
+                            add it to a PHYX file that is missing it unless it is
+                            manually added to the PHYX file using the "Export as JSON"
+                            option.
+                        -->
+                        <label for="testcase-id" class="col-md-1 control-label">Testcase IRI</label>
+                        <div class="col-md-10 input-group">
+                            <input id="testcase-id" type="url" class="form-control" v-model.trim="testcase['@id']" placeholder="Enter IRI that identifies this testcase">
+                        </div>
+                    </template>
 
                     <label for="title" class="col-md-1 control-label">Title</label>
                     <div class="col-md-10 input-group">

--- a/index.html
+++ b/index.html
@@ -132,7 +132,14 @@
                     </button>
                     <ul class="dropdown-menu">
                         <template v-for="(phylogeny, phylogeny_index) of testcase.phylogenies">
-                            <li><a :href="'#phylogeny-' + phylogeny_index">Phylogeny {{phylogeny_index + 1}}</a></li>
+                            <li><a :href="'#phylogeny-' + phylogeny_index">
+                                <template v-if="phylogeny.hasOwnProperty('description')">
+                                    {{phylogeny['description']}}
+                                </template>
+                                <template v-else>
+                                    Phylogeny {{phylogeny_index + 1}}
+                                </template>
+                            </a></li>
                         </template>
                         <li><a href="#phylogeny-footer" @click="testcase.phylogenies.push({})"><strong>Add phylogeny</strong></a></li>
                     </ul>

--- a/index.html
+++ b/index.html
@@ -166,7 +166,7 @@
         <div class="col-md-7">
             <div :id="'phylogeny-' + phylogeny_index" class="panel panel-info" v-for="(phylogeny, phylogeny_index) of testcase.phylogenies">
                 <div class="panel-heading">
-                    <a href="#" class="close glyphicon glyphicon-remove" onclick="if(window.confirm('Are you sure you want to delete this phylogeny?')) vm.testcase.phylogenies.splice(vm.phylogeny_index, 1)"></a>
+                    <a href="#" class="close glyphicon glyphicon-remove" @click="confirm('Are you sure you want to delete this phylogeny?', () => testcase.phylogenies.splice(phylogeny_index, 1))"></a>
                     <template v-if="phylogeny_description_being_edited !== phylogeny">
                         <span role="button" @click="phylogeny_description_being_edited = phylogeny" title="Click to edit">
                             <template v-if="phylogeny.hasOwnProperty('description')">

--- a/index.html
+++ b/index.html
@@ -470,95 +470,153 @@
                                 ></textarea>
                         </div>
 
-                        <!-- List of specifiers associated with this phyloreference -->
-                        <div class="panel panel-info" style="margin-top: 1em">
-                            <div class="panel-heading">Specifiers</div>
-                            <div class="panel-body">
-                                <div class="input-group"
-                                    v-if="selected_phyloref"
-                                    v-for="(specifier, specifier_index) of get_specifiers(selected_phyloref)"
-                                    :id="'specifier_' + specifier_index"
-                                >
-                                    <!-- Buttons before specifier label -->
-                                    <div class="input-group-btn">
-                                        <!-- Delete button: initially hidden, made visible by clicking the "Delete some specifiers" button -->
-                                        <button v-if="specifier_delete_mode" type="button"
-                                            class="btn btn-danger"
-                                            @click="delete_specifier(selected_phyloref, specifier)"
-                                            ><span class="glyphicon glyphicon-remove"></span>
-                                        </button>
+                        <!-- Node(s) this phyloreference is expected to resolve to -->
+                        <label for="curator-comments" class="control-label col-md-3">Expected node resolution</label>
+                        <div class="input-group col-md-9">
+                            <!-- What if no phylogenies were loaded? -->
+                            <div
+                                v-if="testcase['phylogenies'].length == 0"
+                            >No phylogenies loaded.</div>
 
-                                        <!-- Match results with dropdown menu -->
+                            <!-- If phylogenies were loaded, we need to display a selector for each phylogeny -->
+                            <div class="input-group" v-for="(phylogeny, phylogeny_index) of testcase['phylogenies']">
+                                <!-- Display the phylogeny where this node is expected to match -->
+                                <span class="input-group-addon" :title="phylogeny['description']">Phylogeny {{phylogeny_index + 1}}</span>
 
-                                        <button
-                                            @click="specifier_dropdown_target = 'match_result'"
-                                            type="button" class="btn dropdown-toggle"
-                                                :class="{ 'btn-warning': get_all_node_labels_matched_by_specifier(specifier).length == 0, 'btn-success': get_all_node_labels_matched_by_specifier(specifier).length > 0}" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                                            <span class="glyphicon"
-                                                :class="{ 'glyphicon-asterisk': get_all_node_labels_matched_by_specifier(specifier).length == 0, 'glyphicon-ok': (get_all_node_labels_matched_by_specifier(specifier).length > 0) || specifier.hasOwnProperty('specifierWillNotMatch') }"></span>
-                                        </button>
-                                        <ul v-if="specifier_dropdown_target == 'match_result'" class="dropdown-menu dropdown-menu-left">
-                                            <li class="dropdown-header">Match result</li>
-                                            <li v-if="get_all_node_labels_matched_by_specifier(specifier).length == 0">
-                                                <a href="#" onclick="return false;"><em>No matches</em></a>
-                                            </li>
-                                            <li v-for="(node_label, node_label_index) of get_all_node_labels_matched_by_specifier(specifier)">
-                                                <a href="#" onclick="return false;">{{node_label}}</a>
-                                            </li>
-                                            <template v-if="get_all_node_labels_matched_by_specifier(specifier).length == 0">
-                                                <li class="dropdown-header">Specifier will not match</li>
-                                                <li><a href="#"
-                                                    @click="prompt_for_dict_by_key('Why couldn\'t this specifier be matched?', specifier, 'specifierWillNotMatch'); return false;"
-                                                    >
-                                                        <template v-if="specifier.hasOwnProperty('specifierWillNotMatch')">Reason <small>(click to edit)</small>: {{specifier.specifierWillNotMatch}}</template>
-                                                        <template v-else><em>No reason given: click here to set one</em></template>
-                                                </a></li>
-                                            </template>
-                                        </ul>
-                                        <ul v-if="specifier_dropdown_target == 'specifier_type'" class="dropdown-menu dropdown-menu-left">
-                                            <li class="dropdown-header">Specifier type</li>
-                                            <li :class="{active: get_specifier_type(selected_phyloref, specifier) == 'Internal'}">
-                                                <a href="#" onclick="return false;"
-                                                    @click="set_specifier_type(selected_phyloref, specifier, 'Internal')"
-                                                >Internal specifier</a></li>
-                                            <li :class="{active: get_specifier_type(selected_phyloref, specifier) == 'External'}">
-                                                <a href="#" onclick="return false;"
-                                                    @click="set_specifier_type(selected_phyloref, specifier, 'External')"
-                                                >External specifier</a></li>
-                                        </ul>
+                                <!-- Display the matching node(s) -->
+                                <template v-if="get_phyloref_expected_node_labels(phylogeny, selected_phyloref).length === 0">
+                                    <!-- We matched no nodes -->
+                                    <input readonly type="text" class="form-control" value="No nodes could be matched">
+                                </template>
+                                <template v-if="get_phyloref_expected_node_labels(phylogeny, selected_phyloref).length === 1">
+                                    <!-- We matched exactly one node -->
+                                    <input readonly type="text" class="form-control" :value="get_phyloref_expected_node_labels(phylogeny, selected_phyloref)[0]">
+                                </template>
+                                <template v-if="get_phyloref_expected_node_labels(phylogeny, selected_phyloref).length > 1">
+                                    <!-- We matched more than one node -->
+                                    <input readonly type="text" class="form-control" :value="get_phyloref_expected_node_labels(phylogeny, selected_phyloref).length + ' nodes matched: ' + get_phyloref_expected_node_labels(phylogeny, selected_phyloref).join(', ')">
+                                </template>
 
-                                        <!-- Specifier type with dropdown menu: internal or external specifier -->
-                                        <button
-                                            @click="specifier_dropdown_target = 'specifier_type'"
-                                            type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false"
-                                            > {{get_specifier_type(selected_phyloref, specifier)}} <span class="caret"></span></button>
-
-                                    </div>
-
-                                    <!-- Specifier label -->
-                                    <input type="text" disabled class="form-control" :value="get_specifier_label(specifier)" :title="get_specifier_label(specifier)">
-
-                                    <!-- Buttons after specifier label: edit button -->
-                                    <div class="input-group-btn">
-                                        <button type="button" class="btn btn-primary"
-                                            @click="start_tunit_editor_modal('specifier', get_specifier_label(specifier), specifier)"
-                                            ><span class="glyphicon glyphicon-edit"></span></button>
-                                    </div>
+                                <!-- Display a dropdown menu that allows the modified label to be changed. -->
+                                <div class="input-group-btn">
+                                    <button
+                                        type="button"
+                                        class="btn btn-primary dropdown-toggle"
+                                        data-toggle="dropdown"
+                                        aria-haspopup="true"
+                                        aria-expanded="false"
+                                        >Change <span class="caret"></span></button>
+                                    </button>
+                                    <ul class="dropdown-menu dropdown-menu-right">
+                                        <!-- List every labeled node in this phylogeny. -->
+                                        <li class="dropdown-header">Labeled internal nodes in this phylogeny</li>
+                                        <li
+                                            v-for="node_label of get_node_labels_in_phylogeny(phylogeny, 'internal').sort()"
+                                            :class="{active: get_phyloref_expected_node_labels(phylogeny, selected_phyloref).includes(node_label)}"
+                                        >
+                                            <a href="#selected-phyloref" @click="set_phyloref_expected_node_label(phylogeny, selected_phyloref, node_label)">{{node_label}}</a>
+                                        </li>
+                                        <li class="dropdown-header">Labeled terminal nodes in this phylogeny</li>
+                                        <li
+                                            v-for="node_label of get_node_labels_in_phylogeny(phylogeny, 'terminal').sort()"
+                                            :class="{active: get_phyloref_expected_node_labels(phylogeny, selected_phyloref).includes(node_label)}"
+                                        >
+                                            <a href="#selected-phyloref" @click="set_phyloref_expected_node_label(phylogeny, selected_phyloref, node_label)">{{node_label}}</a>
+                                        </li>
+                                    </ul>
                                 </div>
                             </div>
+                        </div>
 
-                            <!-- Add or delete specifiers -->
-                            <div class="panel-footer">
-                                <button
-                                    type="button"
-                                    class="btn btn-default"
-                                    onclick="if(!vm.selected_phyloref.hasOwnProperty('externalSpecifiers')) vm.selected_phyloref.externalSpecifiers = []; vm.selected_phyloref.externalSpecifiers.push({});"
-                                >Add new specifier</button>
-                                <button
-                                    type="button"
-                                    class="btn btn-default"
-                                    @click="specifier_delete_mode = !specifier_delete_mode"
-                                >Delete some specifiers</button>
+                        <!-- List of specifiers associated with this phyloreference -->
+                        <div class="col-md-12">
+                            <div class="panel panel-info" style="margin-top: 1em">
+                                <div class="panel-heading">Specifiers</div>
+                                <div class="panel-body">
+                                    <div class="input-group"
+                                        v-if="selected_phyloref"
+                                        v-for="(specifier, specifier_index) of get_specifiers(selected_phyloref)"
+                                        :id="'specifier_' + specifier_index"
+                                    >
+                                        <!-- Buttons before specifier label -->
+                                        <div class="input-group-btn">
+                                            <!-- Delete button: initially hidden, made visible by clicking the "Delete some specifiers" button -->
+                                            <button v-if="specifier_delete_mode" type="button"
+                                                class="btn btn-danger"
+                                                @click="delete_specifier(selected_phyloref, specifier)"
+                                                ><span class="glyphicon glyphicon-remove"></span>
+                                            </button>
+
+                                            <!-- Match results with dropdown menu -->
+
+                                            <button
+                                                @click="specifier_dropdown_target = 'match_result'"
+                                                type="button" class="btn dropdown-toggle" :class="{ 'btn-warning': get_all_node_labels_matched_by_specifier(specifier).length == 0, 'btn-success': get_all_node_labels_matched_by_specifier(specifier).length > 0}" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                                                <span class="glyphicon" :class="{ 'glyphicon-asterisk': get_all_node_labels_matched_by_specifier(specifier).length == 0, 'glyphicon-ok': get_all_node_labels_matched_by_specifier(specifier).length > 0}"></span>
+                                            </button>
+                                            <ul v-if="specifier_dropdown_target == 'match_result'" class="dropdown-menu dropdown-menu-left">
+                                                <li class="dropdown-header">Match result</li>
+                                                <li v-if="get_all_node_labels_matched_by_specifier(specifier).length == 0">
+                                                    <a href="#" onclick="return false;"><em>No matches</em></a>
+                                                </li>
+                                                <li v-for="(node_label, node_label_index) of get_all_node_labels_matched_by_specifier(specifier)">
+                                                    <a href="#" onclick="return false;">{{node_label}}</a>
+                                                </li>
+                                                <template v-if="get_all_node_labels_matched_by_specifier(specifier).length == 0">
+                                                    <li class="dropdown-header">Specifier will not match</li>
+                                                    <li><a href="#"
+                                                        @click="prompt_for_dict_by_key('Why couldn\'t this specifier be matched?', specifier, 'specifierWillNotMatch'); return false;"
+                                                        >
+                                                            <template v-if="specifier.hasOwnProperty('specifierWillNotMatch')">Reason <small>(click to edit)</small>: {{specifier.specifierWillNotMatch}}</template>
+                                                            <template v-else><em>No reason given: click here to set one</em></template>
+                                                    </a></li>
+                                                </template>
+                                            </ul>
+                                            <ul v-if="specifier_dropdown_target == 'specifier_type'" class="dropdown-menu dropdown-menu-left">
+                                                <li class="dropdown-header">Specifier type</li>
+                                                <li :class="{active: get_specifier_type(selected_phyloref, specifier) == 'Internal'}">
+                                                    <a href="#" onclick="return false;"
+                                                        @click="set_specifier_type(selected_phyloref, specifier, 'Internal')"
+                                                    >Internal specifier</a></li>
+                                                <li :class="{active: get_specifier_type(selected_phyloref, specifier) == 'External'}">
+                                                    <a href="#" onclick="return false;"
+                                                        @click="set_specifier_type(selected_phyloref, specifier, 'External')"
+                                                    >External specifier</a></li>
+                                            </ul>
+
+                                            <!-- Specifier type with dropdown menu: internal or external specifier -->
+                                            <button
+                                                @click="specifier_dropdown_target = 'specifier_type'"
+                                                type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false"
+                                                > {{get_specifier_type(selected_phyloref, specifier)}} <span class="caret"></span></button>
+
+                                        </div>
+
+                                        <!-- Specifier label -->
+                                        <input type="text" disabled class="form-control" :value="get_specifier_label(specifier)" :title="get_specifier_label(specifier)">
+
+                                        <!-- Buttons after specifier label: edit button -->
+                                        <div class="input-group-btn">
+                                            <button type="button" class="btn btn-primary"
+                                                @click="start_tunit_editor_modal('specifier', get_specifier_label(specifier), specifier)"
+                                                ><span class="glyphicon glyphicon-edit"></span></button>
+                                        </div>
+                                    </div>
+                                </div>
+
+                                <!-- Add or delete specifiers -->
+                                <div class="panel-footer">
+                                    <button
+                                        type="button"
+                                        class="btn btn-default"
+                                        onclick="if(!vm.selected_phyloref.hasOwnProperty('externalSpecifiers')) vm.selected_phyloref.externalSpecifiers = []; vm.selected_phyloref.externalSpecifiers.push({});"
+                                    >Add new specifier</button>
+                                    <button
+                                        type="button"
+                                        class="btn btn-default"
+                                        @click="specifier_delete_mode = !specifier_delete_mode"
+                                    >Delete some specifiers</button>
+                                </div>
                             </div>
                         </div>
                     </form>

--- a/index.html
+++ b/index.html
@@ -492,8 +492,10 @@
 
                                         <button
                                             @click="specifier_dropdown_target = 'match_result'"
-                                            type="button" class="btn dropdown-toggle" :class="{ 'btn-warning': get_all_node_labels_matched_by_specifier(specifier).length == 0, 'btn-success': get_all_node_labels_matched_by_specifier(specifier).length > 0}" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                                            <span class="glyphicon" :class="{ 'glyphicon-asterisk': get_all_node_labels_matched_by_specifier(specifier).length == 0, 'glyphicon-ok': get_all_node_labels_matched_by_specifier(specifier).length > 0}"></span>
+                                            type="button" class="btn dropdown-toggle"
+                                                :class="{ 'btn-warning': get_all_node_labels_matched_by_specifier(specifier).length == 0, 'btn-success': get_all_node_labels_matched_by_specifier(specifier).length > 0}" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                                            <span class="glyphicon"
+                                                :class="{ 'glyphicon-asterisk': get_all_node_labels_matched_by_specifier(specifier).length == 0, 'glyphicon-ok': (get_all_node_labels_matched_by_specifier(specifier).length > 0) || specifier.hasOwnProperty('specifierWillNotMatch') }"></span>
                                         </button>
                                         <ul v-if="specifier_dropdown_target == 'match_result'" class="dropdown-menu dropdown-menu-left">
                                             <li class="dropdown-header">Match result</li>

--- a/index.html
+++ b/index.html
@@ -514,14 +514,14 @@
                                             v-for="node_label of get_node_labels_in_phylogeny(phylogeny, 'internal').sort()"
                                             :class="{active: get_phyloref_expected_node_labels(phylogeny, selected_phyloref).includes(node_label)}"
                                         >
-                                            <a href="#selected-phyloref" @click="set_phyloref_expected_node_label(phylogeny, selected_phyloref, node_label)">{{node_label}}</a>
+                                            <a href="#selected-phyloref" @click="toggle_phyloref_expected_node_label(phylogeny, selected_phyloref, node_label)">{{node_label}}</a>
                                         </li>
                                         <li class="dropdown-header">Labeled terminal nodes in this phylogeny</li>
                                         <li
                                             v-for="node_label of get_node_labels_in_phylogeny(phylogeny, 'terminal').sort()"
                                             :class="{active: get_phyloref_expected_node_labels(phylogeny, selected_phyloref).includes(node_label)}"
                                         >
-                                            <a href="#selected-phyloref" @click="set_phyloref_expected_node_label(phylogeny, selected_phyloref, node_label)">{{node_label}}</a>
+                                            <a href="#selected-phyloref" @click="toggle_phyloref_expected_node_label(phylogeny, selected_phyloref, node_label)">{{node_label}}</a>
                                         </li>
                                     </ul>
                                 </div>

--- a/index.html
+++ b/index.html
@@ -417,8 +417,20 @@
                                 id="definition"
                                 v-model="selected_phyloref.cladeDefinition"
                                 class="form-control"
-                                rows="8"
+                                rows="6"
                                 placeholder="Phylogenetic clade definition"
+                                ></textarea>
+                        </div>
+
+                        <!-- Phyloreference curator comments -->
+                        <label for="curator-comments" class="control-label col-md-4">Curator comments</label>
+                        <div class="input-group col-md-8">
+                            <textarea
+                                id="curator-comments"
+                                v-model="selected_phyloref['curatorComments']"
+                                class="form-control"
+                                rows="2"
+                                placeholder="Curator notes relating to this phyloreference"
                                 ></textarea>
                         </div>
 

--- a/index.html
+++ b/index.html
@@ -160,7 +160,24 @@
             <div :id="'phylogeny-' + phylogeny_index" class="panel panel-info" v-for="(phylogeny, phylogeny_index) of testcase.phylogenies">
                 <div class="panel-heading">
                     <a href="#" class="close glyphicon glyphicon-remove" onclick="if(window.confirm('Are you sure you want to delete this phylogeny?')) vm.testcase.phylogenies.splice(vm.phylogeny_index, 1)"></a>
-                    Phylogeny {{phylogeny_index + 1}}
+                    <template v-if="phylogeny_description_being_edited !== phylogeny">
+                        <span role="button" @click="phylogeny_description_being_edited = phylogeny" title="Click to edit">
+                            <template v-if="phylogeny.hasOwnProperty('description')">
+                                {{phylogeny['description']}}
+                            </template>
+                            <template v-else>
+                                Phylogeny {{phylogeny_index + 1}}
+                            </template>
+                        </span>
+                    </template>
+                    <template v-else>
+                        <div class="input-group">
+                            <input v-model.lazy="phylogeny['description']" type="text" class="form-control" placeholder="Enter a description for this phylogeny, including links">
+                            <span class="input-group-btn">
+                                <button class="btn btn-default" type="button"  @click="phylogeny_description_being_edited = undefined">Done editing</button>
+                            </span>
+                        </div>
+                    </template>
                 </div>
                 <div class="panel-body">
                     <svg v-if="phylogeny_annotations_mode_for !== phylogeny" :id="'phylogeny-svg-' + phylogeny_index" :alt="get_phylogeny_as_newick('#phylogeny-svg-' + phylogeny_index, phylogeny)"></svg>

--- a/index.html
+++ b/index.html
@@ -441,14 +441,14 @@
                     <form id="phyloref" class="form-horizontal">
 
                         <!-- Phyloreference label -->
-                        <label for="label" class="control-label col-md-4">Label</label>
-                        <div class="input-group col-md-8">
+                        <label for="label" class="control-label col-md-3">Label</label>
+                        <div class="input-group col-md-9">
                             <input id="label" v-model="selected_phyloref.label" type="text" class="form-control"  placeholder="Phyloreference label">
                         </div>
 
                         <!-- Phyloreference clade definition -->
-                        <label for="definition" class="control-label col-md-4">Clade definition</label>
-                        <div class="input-group col-md-8">
+                        <label for="definition" class="control-label col-md-3">Clade definition</label>
+                        <div class="input-group col-md-9">
                             <textarea
                                 id="definition"
                                 v-model="selected_phyloref.cladeDefinition"
@@ -459,8 +459,8 @@
                         </div>
 
                         <!-- Phyloreference curator comments -->
-                        <label for="curator-comments" class="control-label col-md-4">Curator comments</label>
-                        <div class="input-group col-md-8">
+                        <label for="curator-comments" class="control-label col-md-3">Curator comments</label>
+                        <div class="input-group col-md-9">
                             <textarea
                                 id="curator-comments"
                                 v-model="selected_phyloref['curatorComments']"

--- a/index.html
+++ b/index.html
@@ -233,24 +233,21 @@
         <!-- Taxonomic unit editing modal: dialog box to allow editing lists of taxonomic units -->
         <div id="tunit-editor-modal" class="modal fade">
             <div class="modal-dialog modal-lg form-horizontal">
-                <div class="modal-content" v-if="selected_tunit_list !== undefined">
+                <div class="modal-content" v-if="selected_tunit_list_container !== undefined">
 
                     <!-- Header of tunit editor modal dialog box -->
                     <div class="modal-header">
                         <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-                        <h4 class="modal-title">Editing {{tunit_editor_target_label}}</h4>
+                        <h4 class="modal-title">Editing {{selected_tunit_list_container.type}} {{selected_tunit_list_container.label}}</h4>
                     </div>
 
                     <!-- Body of specifier editor modal dialog box -->
-                    <div class="modal-body form-group">
-                        <div class="col-md-12">
-                            <p>
-                                Each taxonomic unit can have any number of scientific names, external
-                                references and specimens. We recommend using a single taxonomic unit
-                                for each type of identifier.
-                            </p>
-
+                    <div class="modal-body col-md-12">
                             <form id="tunit-editor-form">
+                                <div v-if="selected_tunit_list_container.type == 'specifier'">
+                                    <label for="verbatim-specifier" class="control-label">Verbatim specifier</label>
+                                    <input id="verbatim-specifier" type="text" class="form-control" v-model.trim="selected_tunit_list_container.container['verbatimSpecifier']" placeholder="Enter the verbatim description of this specifier">
+                                </div>
 
                                 <!-- List of taxonomic units -->
                                 <div id="tunits-panel" class="panel panel-info" style="margin-top: 1em">
@@ -259,6 +256,11 @@
                                         <p><em>Select a taxonomic unit or create a new one.</em></p>
                                     </div>
                                     <div class="panel-body" v-if="selected_tunit">
+                                        <p>
+                                            Each taxonomic unit can have any number of scientific names, external
+                                            references and specimens. We recommend using a single taxonomic unit
+                                            for each type of identifier.
+                                        </p>
 
                                         <!-- Panel listing scientific names in this taxonomic unit -->
                                         <div class="col-md-12">
@@ -372,20 +374,19 @@
                                     <!-- List of taxonomic units, including the option to add new taxonomic units -->
                                     <div class="list-group">
                                         <a class="list-group-item"
-                                            v-for="(tunit, tunit_index) of selected_tunit_list"
+                                            v-for="(tunit, tunit_index) of selected_tunit_list_container.list"
                                             :class="{active: selected_tunit === tunit}"
                                             @click="selected_tunit = tunit"
                                             :title="get_taxonomic_unit_label(tunit)"
                                         >{{get_taxonomic_unit_label(tunit)}}</a>
                                         <a class="list-group-item"
                                             href="javascript: void(0)"
-                                            onclick="vm.selected_tunit_list.push(vm.create_empty_taxonomic_unit(vm.selected_tunit_list.length + 1))"
+                                            onclick="vm.selected_tunit_list_container.list.push(vm.create_empty_taxonomic_unit(vm.selected_tunit_list_container.list.length + 1))"
                                             ><strong>Add new taxonomic unit</strong></a>
                                     </div>
 
                                 </div>
                             </form>
-                        </div>
                     </div>
 
                     <!-- Footer of the specifier editor modal dialog box -->

--- a/index.html
+++ b/index.html
@@ -501,8 +501,17 @@
                                                 <a href="#" onclick="return false;"><em>No matches</em></a>
                                             </li>
                                             <li v-for="(node_label, node_label_index) of get_all_node_labels_matched_by_specifier(specifier)">
-                                                <a href="#" onclick="return false;">{{node_label}}<a>
+                                                <a href="#" onclick="return false;">{{node_label}}</a>
                                             </li>
+                                            <template v-if="get_all_node_labels_matched_by_specifier(specifier).length == 0">
+                                                <li class="dropdown-header">Specifier will not match</li>
+                                                <li><a href="#"
+                                                    @click="prompt_for_dict_by_key('Why couldn\'t this specifier be matched?', specifier, 'specifierWillNotMatch'); return false;"
+                                                    >
+                                                        <template v-if="specifier.hasOwnProperty('specifierWillNotMatch')">Reason <small>(click to edit)</small>: {{specifier.specifierWillNotMatch}}</template>
+                                                        <template v-else><em>No reason given: click here to set one</em></template>
+                                                </a></li>
+                                            </template>
                                         </ul>
                                         <ul v-if="specifier_dropdown_target == 'specifier_type'" class="dropdown-menu dropdown-menu-left">
                                             <li class="dropdown-header">Specifier type</li>

--- a/js/curation-tool.js
+++ b/js/curation-tool.js
@@ -59,6 +59,9 @@ var vm = new Vue({
         // Display the delete buttons on the specifiers.
         specifier_delete_mode: false,
 
+        // Which phylogeny label is currently being edited?
+        phylogeny_description_being_edited: undefined,
+
         // Display one of the two dropdown menus for the specifiers.
         specifier_dropdown_target: 'none',
 

--- a/js/curation-tool.js
+++ b/js/curation-tool.js
@@ -141,6 +141,9 @@ var vm = new Vue({
             dict[key].push(value);
             return dict;
         },
+        confirm(message, func) {
+            if(window.confirm(message)) func();
+        },
 
         // Data model management methods.
         load_phyx_from_url: function(url) {

--- a/js/curation-tool.js
+++ b/js/curation-tool.js
@@ -49,15 +49,12 @@ var vm = new Vue({
 
         // UI elements.
         selected_phyloref: undefined,
-        selected_tunit_list: undefined,
+        selected_tunit_list_container: undefined,
         selected_tunit: undefined,
 
         // Phylogeny view modes
         phylogeny_newick_mode_for: undefined,
         phylogeny_annotations_mode_for: undefined,
-
-        // Taxonomic unit editor modal elements
-        tunit_editor_target_label: "(unlabeled)",
 
         // Display the delete buttons on the specifiers.
         specifier_delete_mode: false,
@@ -191,22 +188,30 @@ var vm = new Vue({
             if(type == 'specifier') {
                 // Specifiers store their taxonomic units in their
                 // 'referencesTaxonomicUnits' property.
-                this.tunit_editor_target_label = 'specifier ' + label;
 
                 // Specifiers store their tunit list in referencesTaxonomicUnits.
                 if(!tunit_list_container.hasOwnProperty('referencesTaxonomicUnits'))
                     Vue.set(tunit_list_container, 'referencesTaxonomicUnits', []);
 
-                this.selected_tunit_list = tunit_list_container.referencesTaxonomicUnits;
+                this.selected_tunit_list_container = {
+                    'type': 'specifier',
+                    'label': label,
+                    'container': tunit_list_container,
+                    'list': tunit_list_container.referencesTaxonomicUnits
+                };
             } else if (type == 'node') {
                 // Nodes store their taxonomic units in their
                 // 'representsTaxonomicUnits' property.
-                this.tunit_editor_target_label = 'node: ' + label;
 
                 if(!tunit_list_container.hasOwnProperty('representsTaxonomicUnits'))
                     Vue.set(tunit_list_container, 'representsTaxonomicUnits', []);
 
-                this.selected_tunit_list = tunit_list_container.representsTaxonomicUnits;
+                this.selected_tunit_list_container = {
+                    'type': 'node',
+                    'label': label,
+                    'container': tunit_list_container,
+                    'list': tunit_list_container.representsTaxonomicUnits
+                };
 
             } else {
                 throw "Tunit editor modal started with invalid type: " + type + ".";
@@ -214,15 +219,15 @@ var vm = new Vue({
 
             // If we don't have a first tunit, create an empty, blank one
             // so we don't have to display an empty website.
-            if(this.selected_tunit_list.length > 0) {
+            if(this.selected_tunit_list_container.list.length > 0) {
                 // We have a first tunit, so select it!
-                this.selected_tunit = this.selected_tunit_list[0];
+                this.selected_tunit = this.selected_tunit_list_container.list[0];
             } else {
                 // Specifier doesn't represent any taxonomic unit, but it's
                 // bad UX to just display a blank screen. So let's create a
                 // blank taxonomic unit to work with.
                 var new_tunit = this.create_empty_taxonomic_unit();
-                this.selected_tunit_list.push(new_tunit);
+                this.selected_tunit_list_container.list.push(new_tunit);
                 this.selected_tunit = new_tunit;
             }
 

--- a/js/curation-tool.js
+++ b/js/curation-tool.js
@@ -390,6 +390,94 @@ var vm = new Vue({
 
             return potential_label;
         },
+        get_phyloref_expected_node_labels: function(phylogeny, phyloref) {
+            // Given a specifier, determine which node labels we expect it to
+            // resolve to. To do this, we:
+            //  1. Find all node labels that are case-sensitively identical
+            //     to the phyloreference.
+            //  2. Find all node labels that have additionalNodeProperties with
+            //     expectedPhyloreferenceNamed case-sensitively identical to
+            //     the phyloreference.
+            let phyloref_label = this.get_phyloref_label(phyloref);
+            let node_labels = new Set();
+            for(node_label of this.get_node_labels_in_phylogeny(phylogeny)) {
+                // Is this node label identical to the phyloreference name?
+                if(node_label === phyloref_label) {
+                    node_labels.add(node_label);
+                    continue;
+                }
+
+                // Does this node label have an expectedPhyloreferenceNamed that
+                // includes this phyloreference name?
+                if(
+                    phylogeny.hasOwnProperty('additionalNodeProperties') &&
+                    phylogeny.additionalNodeProperties.hasOwnProperty(node_label) &&
+                    phylogeny.additionalNodeProperties[node_label].hasOwnProperty('expectedPhyloreferenceNamed')
+                ) {
+                    let expectedPhylorefs = phylogeny.additionalNodeProperties[node_label].expectedPhyloreferenceNamed;
+
+                    if(expectedPhylorefs.includes(phyloref_label)) {
+                        node_labels.add(node_label);
+                        continue;
+                    }
+                }
+            }
+
+            // Return node labels sorted alphabetically.
+            return Array.from(node_labels).sort();
+        },
+        set_phyloref_expected_node_label: function(phylogeny, phyloref, updated_node_label) {
+            // Change the PHYX model so that a particular phyloreference is expected to
+            // resolve to a particular node label.
+            //
+            // In the user interface, this is a property of the phyloreference,
+            // which is the most reasonable approach for curators. However, in
+            // the data model, this is a property of the phylogeny, which is
+            // where all phyloreference resolution expectations should be.
+            // Therefore, this method will actually modify the phylogeny in
+            // order to set where this phyloreference is expected to resolve.
+            // See https://github.com/phyloref/curation-tool/issues/32 for more
+            // information.
+            //
+            // We need to do two things here:
+            //  1. Look through the expectedPhyloreferenceNamed data and remove this
+            //     phyloreference from any other nodes upon which it is expected to
+            //     resolve.
+            //  2. Update the selected node label to mark it as the one this
+            //     phyloreference is expected to resolve to.
+            let phyloref_label = this.get_phyloref_label(phyloref);
+
+            // Step 1. Remove this phyloreference as the expected phyloreference
+            // for all nodes in this phylogeny.
+            for(node_label of this.get_node_labels_in_phylogeny(phylogeny)) {
+                if(
+                    phylogeny.hasOwnProperty('additionalNodeProperties') &&
+                    phylogeny.additionalNodeProperties.hasOwnProperty(node_label) &&
+                    phylogeny.additionalNodeProperties[node_label].hasOwnProperty('expectedPhyloreferenceNamed')
+                ) {
+                    phylogeny.additionalNodeProperties[node_label].expectedPhyloreferenceNamed =
+                        phylogeny.additionalNodeProperties[node_label].expectedPhyloreferenceNamed.filter(
+                            label => (phyloref_label !== label)
+                        );
+                }
+            }
+
+            // Step 2. Update the selected node to mark it as the one this
+            // phyloreference is expected to resolve to.
+            if(!phylogeny.hasOwnProperty('additionalNodeProperties')) phylogeny.additionalNodeProperties = {};
+            if(!phylogeny.additionalNodeProperties.hasOwnProperty(updated_node_label))
+                phylogeny.additionalNodeProperties[updated_node_label] = {};
+
+            if(!phylogeny.additionalNodeProperties[updated_node_label].hasOwnProperty('expectedPhyloreferenceNamed'))
+                phylogeny.additionalNodeProperties[updated_node_label].expectedPhyloreferenceNamed = [];
+
+            // We don't need to delete it from the existing list, because
+            // the previous loop should already have done that!
+            phylogeny.additionalNodeProperties[updated_node_label].expectedPhyloreferenceNamed.push(phyloref_label);
+
+            // Did that work?
+            console.log("Additional node properties for '" + updated_node_label + "'", phylogeny.additionalNodeProperties[updated_node_label]);
+        },
         get_phylogeny_as_newick: function(node_expr, phylogeny) {
             // Returns the phylogeny as a Newick string. Since this method is
             // called frequently in rendering the "Edit as Newick" textareas,
@@ -513,15 +601,14 @@ var vm = new Vue({
         },
 
         // Methods for manipulating nodes in phylogenies.
-        get_node_labels_in_phylogeny: function(phylogeny) {
-            // Return an iterator to all the node labels in a phylogeny. These
-            // node labels come from two sources:
-            //  1. We look for node names in the Newick string.
-            //  2. We look for node names in the additionalNodeProperties.
+        get_node_labels_in_phylogeny: function(phylogeny, node_type = 'both') {
+            // Return an iterator to all the node labels in a phylogeny by
+            // looking for node names in the Newick string.
             //
-            // This means that we can pick up both (1) nodes in the Newick
-            // string without any additional properties, and (2) nodes with
-            // additional node properties which are not present.
+            // The node_type determines what type of nodes we return:
+            // - 'both': Return both internal and terminal node labels
+            // - 'internal': Return only internal node labels
+            // - 'terminal': Return only terminal node labels
 
             var node_labels = new Set();
 
@@ -529,7 +616,7 @@ var vm = new Vue({
             var newick = phylogeny.newick;
             if(newick == null)
                 newick = '()';
-            console.log("get_node_labels_in_phylogeny(" + newick + ")");
+            // console.log("get_node_labels_in_phylogeny(" + newick + ")");
 
             // Use PhyloTree's Newick parser to convert the Newick string
             // into a tree-based representation, which we can recurse through
@@ -543,8 +630,19 @@ var vm = new Vue({
                 var add_node_and_children_to_node_labels = function(node) {
                     // console.log("Recursing into: " + JSON.stringify(node));
 
-                    if(node.hasOwnProperty('name') && node.name != '')
-                        node_labels.add(node.name);
+                    if(node.hasOwnProperty('name') && node.name != '') {
+                        let node_has_children = node.hasOwnProperty('children') && node.children.length > 0;
+
+                        // Only add the node label if it is the type of node
+                        // we're interested in.
+                        if(
+                            node_type === 'both' ||
+                            (node_type === 'internal' && node_has_children) ||
+                            (node_type === 'terminal' && !node_has_children)
+                        ) {
+                            node_labels.add(node.name);
+                        }
+                    }
 
                     if(node.hasOwnProperty('children')) {
                         for(child of node.children) {
@@ -555,13 +653,6 @@ var vm = new Vue({
 
                 // Recurse away!
                 add_node_and_children_to_node_labels(parsed.json);
-            }
-
-            // Names from additionalNodeProperties
-            if(phylogeny.hasOwnProperty('additionalNodeProperties')) {
-                for(key of Object.keys(phylogeny.additionalNodeProperties)) {
-                    node_labels.add(key);
-                }
             }
 
             return Array.from(node_labels);

--- a/js/curation-tool.js
+++ b/js/curation-tool.js
@@ -1061,7 +1061,7 @@ function render_tree(node_expr, phylogeny) {
                 if(
                     vm.selected_phyloref !== undefined &&
                     vm.selected_phyloref.hasOwnProperty('label') &&
-                    vm.selected_phyloref.label == data.name
+                    vm.get_phyloref_expected_node_labels(phylogeny, vm.selected_phyloref).includes(data.name)
                 ) {
                     text_label.classed("selected-internal-label", true);
                 }

--- a/js/curation-tool.js
+++ b/js/curation-tool.js
@@ -28,7 +28,6 @@ var vm = new Vue({
 
         // The main data model.
         testcase: {
-            '@id': "",
             'doi': "",
             'url': "",
             'citation': "",
@@ -39,7 +38,6 @@ var vm = new Vue({
         // A copy of the data model, used to test when the data model has been
         // modified.
         testcase_as_loaded: {
-            '@id': "",
             'doi': "",
             'url': "",
             'citation': "",


### PR DESCRIPTION
Allows the curator to document that they expect a single node to resolve to multiple phyloreferences by selecting a matching labeled node from the phyloreferencing panel. I've think this feature might prove necessary to Curation Tool v0.1, since this expectation needs to be documented on many phylogenies.

Closes #32.

**Do not merge**: still in development, and has at least one outstanding bug: changing the expected node resolution works fine, but does not update the display.