### PR TITLE
Added a new example: Brochu 2003

### DIFF
--- a/examples/brochu_2003.json
+++ b/examples/brochu_2003.json
@@ -1,0 +1,736 @@
+{
+    "doi": "10.1146/annurev.earth.31.100901.141308",
+    "url": "https://www.annualreviews.org/doi/10.1146/annurev.earth.31.100901.141308",
+    "citation": "Brochu (2003) Annual Review of Earth and Planetary Sciences 31:357-397",
+    "phylogenies": [
+        {
+            "description": "Fig 1 from the paper",
+            "newick": "(Parasuchia,(rauisuchians,Aetosauria,(sphenosuchians,(protosuchians,(mesosuchians,(Hylaeochampsa,Aegyptosuchus,Stomatosuchus,(Allodaposuchus,('Gavialis gangeticus',(('Diplocynodon ratelii',('Alligator mississippiensis','Caiman crocodilus')Alligatoridae)Alligatoroidea,('Tomistoma schlegelii',('Osteolaemus tetraspis','Crocodylus niloticus')Crocodylinae)Crocodylidae)Brevirostres)Crocodylia))Eusuchia)Mesoeucrocodylia)Crocodyliformes)Crocodylomorpha))root;",
+            "additionalNodeProperties": {
+                "Gavialis gangeticus": {
+                    "expectedPhyloreferenceNamed": [
+                        "Gavialoidea"
+                    ]
+                },
+                "Diplocynodon ratelii": {
+                    "expectedPhyloreferenceNamed": [
+                        "Diplocynodontinae"
+                    ]
+                },
+                "Tomistoma schlegelii": {
+                    "expectedPhyloreferenceNamed": [
+                        "Tomistominae"
+                    ]
+                }
+            }
+        }
+    ],
+    "phylorefs": [
+        {
+            "label": "Eusuchia",
+            "cladeDefinition": "Eusuchia (Huxley 1875). Amended definition.\n\nLast common ancestor of Hylaeochampsa vectiana, Crocodylus niloticus, Gavialis gangeticus, and Alligator mississippiensis\t and all of its descendents.",
+            "internalSpecifiers": [
+                {
+                    "referencesTaxonomicUnits": [
+                        {
+                            "scientificNames": [
+                                {
+                                    "scientificName": "Alligator mississippiensis"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "referencesTaxonomicUnits": [
+                        {
+                            "scientificNames": [
+                                {
+                                    "scientificName": "Gavialis gangeticus"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "referencesTaxonomicUnits": [
+                        {
+                            "scientificNames": [
+                                {
+                                    "scientificName": "Crocodylus niloticus"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "referencesTaxonomicUnits": [
+                        {
+                            "scientificNames": [
+                                {
+                                    "scientificName": "Hylaeochampsa vectiana"
+                                }
+                            ]
+                        }
+                    ],
+                    "specifierWillNotMatch": "Not present in figure 1"
+                }
+            ],
+            "externalSpecifiers": []
+        },
+        {
+            "label": "Crocodylia",
+            "cladeDefinition": "Crocodylia (Gmelin 1789). Amended definition.\n\nLast common ancestor of Gavialis gangeticus, Alligator mississippiensis, and Crocodylus niloticus and all of its\t descendents.",
+            "internalSpecifiers": [
+                {
+                    "referencesTaxonomicUnits": [
+                        {
+                            "scientificNames": [
+                                {
+                                    "scientificName": "Crocodylus niloticus"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "referencesTaxonomicUnits": [
+                        {
+                            "scientificNames": [
+                                {
+                                    "scientificName": "Alligator mississippiensis"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "referencesTaxonomicUnits": [
+                        {
+                            "scientificNames": [
+                                {
+                                    "scientificName": "Gavialis gangeticus"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ],
+            "externalSpecifiers": []
+        },
+        {
+            "label": "Gavialoidea",
+            "cladeDefinition": "Gavialoidea (Case 1930).\n\nGavialis gangeticus and all crocodylians closer to it than to Alligator mississippiensis or Crocodylus niloticus.",
+            "internalSpecifiers": [
+                {
+                    "referencesTaxonomicUnits": [
+                        {
+                            "scientificNames": [
+                                {
+                                    "scientificName": "Gavialis gangeticus"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ],
+            "externalSpecifiers": [
+                {
+                    "referencesTaxonomicUnits": [
+                        {
+                            "scientificNames": [
+                                {
+                                    "scientificName": "Alligator mississippiensis"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "referencesTaxonomicUnits": [
+                        {
+                            "scientificNames": [
+                                {
+                                    "scientificName": "Crocodylus niloticus"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "label": "Pristichampsinae",
+            "cladeDefinition": "Pristichampsinae (Kuhn 1968)\t. New definition.\n\nPristichampsus rollinati and all crocodylians closer to it than to Gavialis gangeticus, Alligator mississippiensis, or Crocodylus niloticus.",
+            "internalSpecifiers": [
+                {
+                    "referencesTaxonomicUnits": [
+                        {
+                            "scientificNames": [
+                                {
+                                    "scientificName": "Pristichampsus rollinati"
+                                }
+                            ]
+                        }
+                    ],
+                    "specifierWillNotMatch": "Not included in figure 1"
+                }
+            ],
+            "externalSpecifiers": [
+                {
+                    "referencesTaxonomicUnits": [
+                        {
+                            "scientificNames": [
+                                {
+                                    "scientificName": "Gavialis gangeticus"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "referencesTaxonomicUnits": [
+                        {
+                            "scientificNames": [
+                                {
+                                    "scientificName": "Alligator mississippiensis"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "referencesTaxonomicUnits": [
+                        {
+                            "scientificNames": [
+                                {
+                                    "scientificName": "Crocodylus niloticus"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ],
+            "curatorComments": "Not included in figure 1."
+        },
+        {
+            "label": "Brevirostres",
+            "cladeDefinition": "Brevirostres (von Zittel 1890). If Gavialis and Tomistoma are sister taxa, Brevirostres is a junior synonym of Crocodylia.\n\nLast common ancestor of Alligator mississippiensis and Crocodylus niloticus and all of its descendents.\n \t \t ",
+            "internalSpecifiers": [
+                {
+                    "referencesTaxonomicUnits": [
+                        {
+                            "scientificNames": [
+                                {
+                                    "scientificName": "Crocodylus niloticus"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "referencesTaxonomicUnits": [
+                        {
+                            "scientificNames": [
+                                {
+                                    "scientificName": "Alligator mississippiensis"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ],
+            "externalSpecifiers": []
+        },
+        {
+            "label": "Alligatoroidea",
+            "cladeDefinition": "Alligatoroidea (Gray 1844). \n\nAlligator mississippiensis and all crocodylians closer to it than to Crocodylus niloticus or Gavialis gangeticus.",
+            "internalSpecifiers": [
+                {
+                    "referencesTaxonomicUnits": [
+                        {
+                            "scientificNames": [
+                                {
+                                    "scientificName": "Alligator mississippiensis"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ],
+            "externalSpecifiers": [
+                {
+                    "referencesTaxonomicUnits": [
+                        {
+                            "scientificNames": [
+                                {
+                                    "scientificName": "Crocodylus niloticus"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "referencesTaxonomicUnits": [
+                        {
+                            "scientificNames": [
+                                {
+                                    "scientificName": "Gavialis gangeticus"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "label": "Diplocynodontinae",
+            "cladeDefinition": "Diplocynodontinae (Brochu 1999).\n\nDiplocynodon ratelii and all crocodylians closer to it than to Alligator mississippiensis.",
+            "internalSpecifiers": [
+                {
+                    "referencesTaxonomicUnits": [
+                        {
+                            "scientificNames": [
+                                {
+                                    "scientificName": "Diplocynodon ratelii"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ],
+            "externalSpecifiers": [
+                {
+                    "referencesTaxonomicUnits": [
+                        {
+                            "scientificNames": [
+                                {
+                                    "scientificName": "Alligator mississippiensis"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "label": "Globidonta",
+            "cladeDefinition": "Globidonta (Brochu 1999).\n\nAlligator mississippiensis and all crocodylians closer to it than to Diplocynodon ratelii.",
+            "internalSpecifiers": [
+                {
+                    "referencesTaxonomicUnits": [
+                        {
+                            "scientificNames": [
+                                {
+                                    "scientificName": "Alligator mississippiensis"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ],
+            "externalSpecifiers": [
+                {
+                    "referencesTaxonomicUnits": [
+                        {
+                            "scientificNames": [
+                                {
+                                    "scientificName": "Diplocynodon ratelii"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "label": "Alligatoridae",
+            "cladeDefinition": "Alligatoridae (Cuvier 1807).\n\nLast common ancestor of Alligator mississippiensis and Caiman crocodilus and all of its descendents.",
+            "internalSpecifiers": [
+                {
+                    "referencesTaxonomicUnits": [
+                        {
+                            "scientificNames": [
+                                {
+                                    "scientificName": "Caiman crocodilus"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "referencesTaxonomicUnits": [
+                        {
+                            "scientificNames": [
+                                {
+                                    "scientificName": "Alligator mississippiensis"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ],
+            "externalSpecifiers": []
+        },
+        {
+            "label": "Alligatorinae",
+            "cladeDefinition": "Alligatorinae (Kälin 1940).\n\nAlligator mississippiensis and all crocodylians closer to it than to Caiman crocodilus.",
+            "internalSpecifiers": [
+                {
+                    "referencesTaxonomicUnits": [
+                        {
+                            "scientificNames": [
+                                {
+                                    "scientificName": "Alligator mississippiensis"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ],
+            "externalSpecifiers": [
+                {
+                    "referencesTaxonomicUnits": [
+                        {
+                            "scientificNames": [
+                                {
+                                    "scientificName": "Caiman crocodilus"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "label": "Caimaninae",
+            "cladeDefinition": "Caimaninae (Norell 1988).\n\nCaiman crocodilus and all crocodylians closer to it than to Alligator mississippiensis.",
+            "internalSpecifiers": [
+                {
+                    "referencesTaxonomicUnits": [
+                        {
+                            "scientificNames": [
+                                {
+                                    "scientificName": "Caiman crocodilus"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ],
+            "externalSpecifiers": [
+                {
+                    "referencesTaxonomicUnits": [
+                        {
+                            "scientificNames": [
+                                {
+                                    "scientificName": "Alligator mississippiensis"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "label": "Crocodyloidea",
+            "cladeDefinition": "Crocodyloidea (Fitzinger 1826).\n\nCrocodylus niloticus and all crocodylians closer to it than to Alligator mississippiensis or Gavialis gangeticus.",
+            "internalSpecifiers": [
+                {
+                    "referencesTaxonomicUnits": [
+                        {
+                            "scientificNames": [
+                                {
+                                    "scientificName": "Crocodylus niloticus"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ],
+            "externalSpecifiers": [
+                {
+                    "referencesTaxonomicUnits": [
+                        {
+                            "scientificNames": [
+                                {
+                                    "scientificName": "Alligator mississippiensis"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "referencesTaxonomicUnits": [
+                        {
+                            "scientificNames": [
+                                {
+                                    "scientificName": "Gavialis gangeticus"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "label": "Crocodylidae",
+            "cladeDefinition": "Crocodylidae (Cuvier 1807). Definition dependent on phylogenetic context.\n\nLast common ancestor of Crocodylus niloticus, Osteolaemus tetraspis, and Tomistoma schlegelii and all of its descendents.",
+            "internalSpecifiers": [
+                {
+                    "referencesTaxonomicUnits": [
+                        {
+                            "scientificNames": [
+                                {
+                                    "scientificName": "Tomistoma schlegelii"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "referencesTaxonomicUnits": [
+                        {
+                            "scientificNames": [
+                                {
+                                    "scientificName": "Osteolaemus tetraspis"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "referencesTaxonomicUnits": [
+                        {
+                            "scientificNames": [
+                                {
+                                    "scientificName": "Crocodylus niloticus"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ],
+            "externalSpecifiers": []
+        },
+        {
+            "label": "Mekosuchinae",
+            "cladeDefinition": "Mekosuchinae (Balouet & Buffetaut 1987). Definition adapted from Salisbury & Willis 1996.\n\nLast common ancestor of Kambara murgonensis, Australosuchus clarkae, Pallimnarchus pollens, Baru darrowi, Trilophosuchus rackhami, Quinkana\t fortirostrum, and Mekosuchus inexpectatus and all of its descendents.",
+            "internalSpecifiers": [
+                {
+                    "referencesTaxonomicUnits": [
+                        {
+                            "scientificNames": [
+                                {
+                                    "scientificName": "Mekosuchus inexpectatus"
+                                }
+                            ]
+                        }
+                    ],
+                    "specifierWillNotMatch": "Not illustrated in fig 1"
+                },
+                {
+                    "referencesTaxonomicUnits": [
+                        {
+                            "scientificNames": [
+                                {
+                                    "scientificName": "Quinkana fortirostrum"
+                                }
+                            ]
+                        }
+                    ],
+                    "specifierWillNotMatch": "Not illustrated in fig 1"
+                },
+                {
+                    "referencesTaxonomicUnits": [
+                        {
+                            "scientificNames": [
+                                {
+                                    "scientificName": "Trilophosuchus rackhami"
+                                }
+                            ]
+                        }
+                    ],
+                    "specifierWillNotMatch": "Not illustrated in fig 1"
+                },
+                {
+                    "referencesTaxonomicUnits": [
+                        {
+                            "scientificNames": [
+                                {
+                                    "scientificName": "Baru darrowi"
+                                }
+                            ]
+                        }
+                    ],
+                    "specifierWillNotMatch": "Not illustrated in fig 1"
+                },
+                {
+                    "referencesTaxonomicUnits": [
+                        {
+                            "scientificNames": [
+                                {
+                                    "scientificName": "Pallimnarchus pollens"
+                                }
+                            ]
+                        }
+                    ],
+                    "specifierWillNotMatch": "Not illustrated in fig 1"
+                },
+                {
+                    "referencesTaxonomicUnits": [
+                        {
+                            "scientificNames": [
+                                {
+                                    "scientificName": "Australosuchus clarkae"
+                                }
+                            ]
+                        }
+                    ],
+                    "specifierWillNotMatch": "Not illustrated in fig 1"
+                },
+                {
+                    "referencesTaxonomicUnits": [
+                        {
+                            "scientificNames": [
+                                {
+                                    "scientificName": "Kambara murgonensis"
+                                }
+                            ]
+                        }
+                    ],
+                    "specifierWillNotMatch": "Not illustrated in fig 1"
+                }
+            ],
+            "externalSpecifiers": [],
+            "curatorComments": "Not illustrated in fig 1"
+        },
+        {
+            "label": "Tomistominae",
+            "cladeDefinition": "Tomistominae (Kälin 1955). Definition dependent on phylogenetic context.\n\nTomistoma schlegelii and all crocodylians closer to it than to Crocodylus niloticus.",
+            "internalSpecifiers": [
+                {
+                    "referencesTaxonomicUnits": [
+                        {
+                            "scientificNames": [
+                                {
+                                    "scientificName": "Tomistoma schlegelii"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ],
+            "externalSpecifiers": [
+                {
+                    "referencesTaxonomicUnits": [
+                        {
+                            "scientificNames": [
+                                {
+                                    "scientificName": "Crocodylus niloticus"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "label": "Crocodylinae",
+            "cladeDefinition": "Crocodylinae (Cuvier 1807). Definition dependent on phylogenetic context.\n\nCrocodylus niloticus and all crocodylians closer to it than to Tomistoma schlegelii.\n \t \t ",
+            "internalSpecifiers": [
+                {
+                    "referencesTaxonomicUnits": [
+                        {
+                            "scientificNames": [
+                                {
+                                    "scientificName": "Crocodylus niloticus"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ],
+            "externalSpecifiers": [
+                {
+                    "referencesTaxonomicUnits": [
+                        {
+                            "scientificNames": [
+                                {
+                                    "scientificName": "Tomistoma schlegelii"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "label": "Osteolaeminae",
+            "cladeDefinition": "Osteolaeminae tax. nov. New definition.\n\nOsteolaemus tetraspis and all crocodylians closer to it than to Crocodylus niloticus.",
+            "internalSpecifiers": [
+                {
+                    "referencesTaxonomicUnits": [
+                        {
+                            "scientificNames": [
+                                {
+                                    "scientificName": "Osteolaemus tetraspis"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ],
+            "externalSpecifiers": [
+                {
+                    "referencesTaxonomicUnits": [
+                        {
+                            "scientificNames": [
+                                {
+                                    "scientificName": "Crocodylus niloticus"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ],
+            "curatorComments": "Not illustrated in fig 1"
+        },
+        {
+            "label": "Crocodylidae (alt)",
+            "cladeDefinition": "Crocodylidae (Cuvier 1807).\n\nLast common ancestor of Crocodylus niloticus and Osteolaemus tetraspis and all of its descendents.",
+            "internalSpecifiers": [],
+            "externalSpecifiers": [],
+            "curatorComments": "Not illustrated on fig 1."
+        },
+        {
+            "label": "Crocodylinae (alt)",
+            "cladeDefinition": "Crocodylinae (Cuvier 1807). At present, this would be redundant with Crocodylus.\n\nCrocodylus niloticus and all crocodylians closer to it than to Osteolaemus tetraspis.",
+            "internalSpecifiers": [],
+            "externalSpecifiers": [],
+            "curatorComments": "Not illustrated in fig 1."
+        },
+        {
+            "label": "Gavialidae (alt)",
+            "cladeDefinition": "Gavialidae (Adams 1854). In a morphological context, Gavialidae would be redundant with Gavialis gangeticus.\n\nLast common ancestor of Gavialis gangeticus and Tomistoma schlegelii and all of its descendents.",
+            "internalSpecifiers": [],
+            "externalSpecifiers": [],
+            "curatorComments": "Not illustrated in fig 1."
+        },
+        {
+            "label": "Tomistominae (alt)",
+            "cladeDefinition": "Tomistominae (Kälin 1955).\n\nTomistoma schlegelii and all crocodylians closer to it than to Gavialis gangeticus.",
+            "internalSpecifiers": [],
+            "externalSpecifiers": [],
+            "curatorComments": "Not illustrated in fig 1."
+        },
+        {
+            "label": "Gavialinae (alt)",
+            "cladeDefinition": "Gavialinae (Nopcsa 1923).\n\nGavialis gangeticus and all crocodylians closer to it than to Tomistoma schlegelii.",
+            "internalSpecifiers": [],
+            "externalSpecifiers": [],
+            "curatorComments": "Not illustrated in fig 1"
+        }
+    ],
+    "title": "Phylogenetic Approaches Toward Crocodylian History"
+}

--- a/examples/brochu_2003.json
+++ b/examples/brochu_2003.json
@@ -21,6 +21,26 @@
                     "expectedPhyloreferenceNamed": [
                         "Tomistominae"
                     ]
+                },
+                "Alligatoridae": {
+                    "expectedPhyloreferenceNamed": [
+                        "Globidonta"
+                    ]
+                },
+                "Alligator mississippiensis": {
+                    "expectedPhyloreferenceNamed": [
+                        "Alligatorinae"
+                    ]
+                },
+                "Caiman crocodilus": {
+                    "expectedPhyloreferenceNamed": [
+                        "Caimaninae"
+                    ]
+                },
+                "Crocodylidae": {
+                    "expectedPhyloreferenceNamed": [
+                        "Crocodyloidea"
+                    ]
                 }
             }
         }

--- a/examples/brochu_2003.json
+++ b/examples/brochu_2003.json
@@ -719,36 +719,154 @@
         {
             "label": "Crocodylidae (alt)",
             "cladeDefinition": "Crocodylidae (Cuvier 1807).\n\nLast common ancestor of Crocodylus niloticus and Osteolaemus tetraspis and all of its descendents.",
-            "internalSpecifiers": [],
+            "internalSpecifiers": [
+                {
+                    "referencesTaxonomicUnits": [
+                        {
+                            "scientificNames": [
+                                {
+                                    "scientificName": "Osteolaemus tetraspis"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "referencesTaxonomicUnits": [
+                        {
+                            "scientificNames": [
+                                {
+                                    "scientificName": "Crocodylus niloticus"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ],
             "externalSpecifiers": [],
             "curatorComments": "Not illustrated on fig 1."
         },
         {
             "label": "Crocodylinae (alt)",
             "cladeDefinition": "Crocodylinae (Cuvier 1807). At present, this would be redundant with Crocodylus.\n\nCrocodylus niloticus and all crocodylians closer to it than to Osteolaemus tetraspis.",
-            "internalSpecifiers": [],
-            "externalSpecifiers": [],
+            "internalSpecifiers": [
+                {
+                    "referencesTaxonomicUnits": [
+                        {
+                            "scientificNames": [
+                                {
+                                    "scientificName": "Crocodylus niloticus"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ],
+            "externalSpecifiers": [
+                {
+                    "referencesTaxonomicUnits": [
+                        {
+                            "scientificNames": [
+                                {
+                                    "scientificName": "Osteolaemus tetraspis"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ],
             "curatorComments": "Not illustrated in fig 1."
         },
         {
             "label": "Gavialidae (alt)",
             "cladeDefinition": "Gavialidae (Adams 1854). In a morphological context, Gavialidae would be redundant with Gavialis gangeticus.\n\nLast common ancestor of Gavialis gangeticus and Tomistoma schlegelii and all of its descendents.",
-            "internalSpecifiers": [],
+            "internalSpecifiers": [
+                {
+                    "referencesTaxonomicUnits": [
+                        {
+                            "scientificNames": [
+                                {
+                                    "scientificName": "Tomistoma schlegelii"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "referencesTaxonomicUnits": [
+                        {
+                            "scientificNames": [
+                                {
+                                    "scientificName": "Gavialis gangeticus"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ],
             "externalSpecifiers": [],
             "curatorComments": "Not illustrated in fig 1."
         },
         {
             "label": "Tomistominae (alt)",
             "cladeDefinition": "Tomistominae (Kälin 1955).\n\nTomistoma schlegelii and all crocodylians closer to it than to Gavialis gangeticus.",
-            "internalSpecifiers": [],
-            "externalSpecifiers": [],
+            "internalSpecifiers": [
+                {
+                    "referencesTaxonomicUnits": [
+                        {
+                            "scientificNames": [
+                                {
+                                    "scientificName": "Tomistoma schlegelii"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ],
+            "externalSpecifiers": [
+                {
+                    "referencesTaxonomicUnits": [
+                        {
+                            "scientificNames": [
+                                {
+                                    "scientificName": "Gavialis gangeticus"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ],
             "curatorComments": "Not illustrated in fig 1."
         },
         {
             "label": "Gavialinae (alt)",
             "cladeDefinition": "Gavialinae (Nopcsa 1923).\n\nGavialis gangeticus and all crocodylians closer to it than to Tomistoma schlegelii.",
-            "internalSpecifiers": [],
-            "externalSpecifiers": [],
+            "internalSpecifiers": [
+                {
+                    "referencesTaxonomicUnits": [
+                        {
+                            "scientificNames": [
+                                {
+                                    "scientificName": "Gavialis gangeticus"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ],
+            "externalSpecifiers": [
+                {
+                    "referencesTaxonomicUnits": [
+                        {
+                            "scientificNames": [
+                                {
+                                    "scientificName": "Tomistoma schlegelii"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ],
             "curatorComments": "Not illustrated in fig 1"
         }
     ],

--- a/js/curation-tool.js
+++ b/js/curation-tool.js
@@ -13,6 +13,10 @@ var example_phyx_urls = [
     {
         url: "examples/hillis_and_wilcox_2005.json",
         title: "Hillis and Wilcox, 2005"
+    },
+    {
+        url: "examples/brochu_2003.json",
+        title: "Brochu 2003"
     }
 ];
 


### PR DESCRIPTION
[Brochu 2003](http://doi.org/10.1146/annurev.earth.31.100901.141308) is an example PHYX file curated entirely using the Curation Tool and then added to the Curation Workflow (under phyloref/curation-workflow#29).