### PR TITLE
Added simple phyloreference state system

### DIFF
--- a/examples/brochu_2003.json
+++ b/examples/brochu_2003.json
@@ -41,6 +41,11 @@
                     "expectedPhyloreferenceNamed": [
                         "Crocodyloidea"
                     ]
+                },
+                "Osteolaemus tetraspis": {
+                    "expectedPhyloreferenceNamed": [
+                        "Osteolaeminae"
+                    ]
                 }
             }
         }
@@ -96,7 +101,18 @@
                     "specifierWillNotMatch": "Not present in figure 1"
                 }
             ],
-            "externalSpecifiers": []
+            "externalSpecifiers": [],
+            "pso:holdsStatusInTime": [
+                {
+                    "@type": "http://purl.org/spar/pso/StatusInTime",
+                    "pso:withStatus": {
+                        "@id": "pso:final-draft"
+                    },
+                    "tvc:atTime": {
+                        "timeinterval:hasIntervalStartDate": "2018-06-11T22:46:23.547Z"
+                    }
+                }
+            ]
         },
         {
             "label": "Crocodylia",
@@ -136,7 +152,18 @@
                     ]
                 }
             ],
-            "externalSpecifiers": []
+            "externalSpecifiers": [],
+            "pso:holdsStatusInTime": [
+                {
+                    "@type": "http://purl.org/spar/pso/StatusInTime",
+                    "pso:withStatus": {
+                        "@id": "pso:submitted"
+                    },
+                    "tvc:atTime": {
+                        "timeinterval:hasIntervalStartDate": "2018-06-11T22:46:33.179Z"
+                    }
+                }
+            ]
         },
         {
             "label": "Gavialoidea",
@@ -176,6 +203,17 @@
                             ]
                         }
                     ]
+                }
+            ],
+            "pso:holdsStatusInTime": [
+                {
+                    "@type": "http://purl.org/spar/pso/StatusInTime",
+                    "pso:withStatus": {
+                        "@id": "pso:under-review"
+                    },
+                    "tvc:atTime": {
+                        "timeinterval:hasIntervalStartDate": "2018-06-11T22:48:48.903Z"
+                    }
                 }
             ]
         },
@@ -231,7 +269,18 @@
                     ]
                 }
             ],
-            "curatorComments": "Not included in figure 1."
+            "curatorComments": "Not included in figure 1.",
+            "pso:holdsStatusInTime": [
+                {
+                    "@type": "http://purl.org/spar/pso/StatusInTime",
+                    "pso:withStatus": {
+                        "@id": "pso:final-draft"
+                    },
+                    "tvc:atTime": {
+                        "timeinterval:hasIntervalStartDate": "2018-06-11T22:48:53.135Z"
+                    }
+                }
+            ]
         },
         {
             "label": "Brevirostres",
@@ -260,7 +309,18 @@
                     ]
                 }
             ],
-            "externalSpecifiers": []
+            "externalSpecifiers": [],
+            "pso:holdsStatusInTime": [
+                {
+                    "@type": "http://purl.org/spar/pso/StatusInTime",
+                    "pso:withStatus": {
+                        "@id": "pso:submitted"
+                    },
+                    "tvc:atTime": {
+                        "timeinterval:hasIntervalStartDate": "2018-06-11T22:49:04.648Z"
+                    }
+                }
+            ]
         },
         {
             "label": "Alligatoroidea",
@@ -301,6 +361,19 @@
                         }
                     ]
                 }
+            ],
+            "pso:holdsStatusInTime": [
+                {
+                    "@type": "http://purl.org/spar/pso/StatusInTime",
+                    "pso:withStatus": {
+                        "@id": "pso:final-draft"
+                    },
+                    "tvc:atTime": {
+                        "timeinterval:hasIntervalStartDate": "2018-06-11T20:00:47.151Z"
+                    },
+                    "statusCURIE": "pso:final-draft",
+                    "intervalStart": "2018-06-11T20:00:47.151Z"
+                }
             ]
         },
         {
@@ -330,6 +403,17 @@
                             ]
                         }
                     ]
+                }
+            ],
+            "pso:holdsStatusInTime": [
+                {
+                    "@type": "http://purl.org/spar/pso/StatusInTime",
+                    "pso:withStatus": {
+                        "@id": "pso:submitted"
+                    },
+                    "tvc:atTime": {
+                        "timeinterval:hasIntervalStartDate": "2018-06-11T22:49:22.452Z"
+                    }
                 }
             ]
         },
@@ -361,6 +445,17 @@
                         }
                     ]
                 }
+            ],
+            "pso:holdsStatusInTime": [
+                {
+                    "@type": "http://purl.org/spar/pso/StatusInTime",
+                    "pso:withStatus": {
+                        "@id": "pso:submitted"
+                    },
+                    "tvc:atTime": {
+                        "timeinterval:hasIntervalStartDate": "2018-06-11T22:49:26.424Z"
+                    }
+                }
             ]
         },
         {
@@ -390,7 +485,18 @@
                     ]
                 }
             ],
-            "externalSpecifiers": []
+            "externalSpecifiers": [],
+            "pso:holdsStatusInTime": [
+                {
+                    "@type": "http://purl.org/spar/pso/StatusInTime",
+                    "pso:withStatus": {
+                        "@id": "pso:submitted"
+                    },
+                    "tvc:atTime": {
+                        "timeinterval:hasIntervalStartDate": "2018-06-11T22:49:31.471Z"
+                    }
+                }
+            ]
         },
         {
             "label": "Alligatorinae",
@@ -419,6 +525,17 @@
                             ]
                         }
                     ]
+                }
+            ],
+            "pso:holdsStatusInTime": [
+                {
+                    "@type": "http://purl.org/spar/pso/StatusInTime",
+                    "pso:withStatus": {
+                        "@id": "pso:submitted"
+                    },
+                    "tvc:atTime": {
+                        "timeinterval:hasIntervalStartDate": "2018-06-11T22:49:36.063Z"
+                    }
                 }
             ]
         },
@@ -449,6 +566,17 @@
                             ]
                         }
                     ]
+                }
+            ],
+            "pso:holdsStatusInTime": [
+                {
+                    "@type": "http://purl.org/spar/pso/StatusInTime",
+                    "pso:withStatus": {
+                        "@id": "pso:submitted"
+                    },
+                    "tvc:atTime": {
+                        "timeinterval:hasIntervalStartDate": "2018-06-11T22:49:42.007Z"
+                    }
                 }
             ]
         },
@@ -491,6 +619,17 @@
                         }
                     ]
                 }
+            ],
+            "pso:holdsStatusInTime": [
+                {
+                    "@type": "http://purl.org/spar/pso/StatusInTime",
+                    "pso:withStatus": {
+                        "@id": "pso:under-review"
+                    },
+                    "tvc:atTime": {
+                        "timeinterval:hasIntervalStartDate": "2018-06-11T22:49:48.240Z"
+                    }
+                }
             ]
         },
         {
@@ -531,7 +670,18 @@
                     ]
                 }
             ],
-            "externalSpecifiers": []
+            "externalSpecifiers": [],
+            "pso:holdsStatusInTime": [
+                {
+                    "@type": "http://purl.org/spar/pso/StatusInTime",
+                    "pso:withStatus": {
+                        "@id": "pso:submitted"
+                    },
+                    "tvc:atTime": {
+                        "timeinterval:hasIntervalStartDate": "2018-06-11T22:49:51.960Z"
+                    }
+                }
+            ]
         },
         {
             "label": "Mekosuchinae",
@@ -623,7 +773,18 @@
                 }
             ],
             "externalSpecifiers": [],
-            "curatorComments": "Not illustrated in fig 1"
+            "curatorComments": "Not illustrated in fig 1",
+            "pso:holdsStatusInTime": [
+                {
+                    "@type": "http://purl.org/spar/pso/StatusInTime",
+                    "pso:withStatus": {
+                        "@id": "pso:final-draft"
+                    },
+                    "tvc:atTime": {
+                        "timeinterval:hasIntervalStartDate": "2018-06-11T22:49:57.400Z"
+                    }
+                }
+            ]
         },
         {
             "label": "Tomistominae",
@@ -652,6 +813,17 @@
                             ]
                         }
                     ]
+                }
+            ],
+            "pso:holdsStatusInTime": [
+                {
+                    "@type": "http://purl.org/spar/pso/StatusInTime",
+                    "pso:withStatus": {
+                        "@id": "pso:submitted"
+                    },
+                    "tvc:atTime": {
+                        "timeinterval:hasIntervalStartDate": "2018-06-11T22:50:16.649Z"
+                    }
                 }
             ]
         },
@@ -682,6 +854,17 @@
                             ]
                         }
                     ]
+                }
+            ],
+            "pso:holdsStatusInTime": [
+                {
+                    "@type": "http://purl.org/spar/pso/StatusInTime",
+                    "pso:withStatus": {
+                        "@id": "pso:submitted"
+                    },
+                    "tvc:atTime": {
+                        "timeinterval:hasIntervalStartDate": "2018-06-11T22:50:26.448Z"
+                    }
                 }
             ]
         },
@@ -714,7 +897,18 @@
                     ]
                 }
             ],
-            "curatorComments": "Not illustrated in fig 1"
+            "curatorComments": "Not illustrated in fig 1, but it's resolution is pretty unambiguous, so I'm going to assert that it should resolve to \"Osteolaemus tetraspis\"",
+            "pso:holdsStatusInTime": [
+                {
+                    "@type": "http://purl.org/spar/pso/StatusInTime",
+                    "pso:withStatus": {
+                        "@id": "pso:submitted"
+                    },
+                    "tvc:atTime": {
+                        "timeinterval:hasIntervalStartDate": "2018-06-11T21:47:47.495Z"
+                    }
+                }
+            ]
         },
         {
             "label": "Crocodylidae (alt)",
@@ -744,7 +938,18 @@
                 }
             ],
             "externalSpecifiers": [],
-            "curatorComments": "Not illustrated on fig 1."
+            "curatorComments": "Not illustrated on fig 1.",
+            "pso:holdsStatusInTime": [
+                {
+                    "@type": "http://purl.org/spar/pso/StatusInTime",
+                    "pso:withStatus": {
+                        "@id": "pso:final-draft"
+                    },
+                    "tvc:atTime": {
+                        "timeinterval:hasIntervalStartDate": "2018-06-11T22:50:46.938Z"
+                    }
+                }
+            ]
         },
         {
             "label": "Crocodylinae (alt)",
@@ -775,7 +980,18 @@
                     ]
                 }
             ],
-            "curatorComments": "Not illustrated in fig 1."
+            "curatorComments": "Not illustrated in fig 1.",
+            "pso:holdsStatusInTime": [
+                {
+                    "@type": "http://purl.org/spar/pso/StatusInTime",
+                    "pso:withStatus": {
+                        "@id": "pso:final-draft"
+                    },
+                    "tvc:atTime": {
+                        "timeinterval:hasIntervalStartDate": "2018-06-11T22:50:53.131Z"
+                    }
+                }
+            ]
         },
         {
             "label": "Gavialidae (alt)",
@@ -805,7 +1021,18 @@
                 }
             ],
             "externalSpecifiers": [],
-            "curatorComments": "Not illustrated in fig 1."
+            "curatorComments": "Not illustrated in fig 1.",
+            "pso:holdsStatusInTime": [
+                {
+                    "@type": "http://purl.org/spar/pso/StatusInTime",
+                    "pso:withStatus": {
+                        "@id": "pso:final-draft"
+                    },
+                    "tvc:atTime": {
+                        "timeinterval:hasIntervalStartDate": "2018-06-11T22:50:58.482Z"
+                    }
+                }
+            ]
         },
         {
             "label": "Tomistominae (alt)",
@@ -836,7 +1063,18 @@
                     ]
                 }
             ],
-            "curatorComments": "Not illustrated in fig 1."
+            "curatorComments": "Not illustrated in fig 1.",
+            "pso:holdsStatusInTime": [
+                {
+                    "@type": "http://purl.org/spar/pso/StatusInTime",
+                    "pso:withStatus": {
+                        "@id": "pso:final-draft"
+                    },
+                    "tvc:atTime": {
+                        "timeinterval:hasIntervalStartDate": "2018-06-11T22:51:01.914Z"
+                    }
+                }
+            ]
         },
         {
             "label": "Gavialinae (alt)",
@@ -867,8 +1105,20 @@
                     ]
                 }
             ],
-            "curatorComments": "Not illustrated in fig 1"
+            "curatorComments": "Not illustrated in fig 1",
+            "pso:holdsStatusInTime": [
+                {
+                    "@type": "http://purl.org/spar/pso/StatusInTime",
+                    "pso:withStatus": {
+                        "@id": "pso:final-draft"
+                    },
+                    "tvc:atTime": {
+                        "timeinterval:hasIntervalStartDate": "2018-06-11T22:51:05.073Z"
+                    }
+                }
+            ]
         }
     ],
-    "title": "Phylogenetic Approaches Toward Crocodylian History"
+    "title": "Phylogenetic Approaches Toward Crocodylian History",
+    "@context": "https://www.ggvaidya.com/curation-tool/json/phyx.json"
 }

--- a/index.html
+++ b/index.html
@@ -649,13 +649,10 @@
                                 {{ getPhylorefStatusChanges(selectedPhyloref).length }} changes <span class="caret"></span>
                             </button>
                             <ul class="dropdown-menu">
-                              <a href="#selected-phyloref" v-for="statusChange of getPhylorefStatusChanges(selectedPhyloref)">
+                              <li><a href="#selected-phyloref" v-for="statusChange of getPhylorefStatusChanges(selectedPhyloref)">
                                 {{ statusChange.statusInEnglish }}
-                                <small v-if="hasProperty(statusChange, 'intervalStart') || hasProperty(statusChange, 'intervalEnd')">
-                                  <template v-if="hasProperty(statusChange, 'intervalStart')">from {{statusChange.intervalStart}}</template>
-                                  <template v-if="hasProperty(statusChange, 'intervalEnd')">to {{statusChange.intervalEnd}}</template>
-                                </small>
-                              </a>
+                                <div style="font-size: 70%" v-if="hasProperty(statusChange, 'intervalStartAsCalendar')">{{ statusChange.intervalStartAsCalendar }}</div>
+                              </a></li>
                             </ul>
                         </div>
                         <a
@@ -709,6 +706,9 @@
     <script src="https://d3js.org/d3.v3.min.js"></script>
     <script src="./lib/phylotree.js/phylotree.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/underscore.js/1.8.3/underscore-min.js" charset="utf-8"></script>
+
+    <!-- Moment: for datetime calculations -->
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.22.2/moment.min.js"></script>
 
     <!-- Our source code -->
     <script src="./js/curation-tool.js"></script>

--- a/index.html
+++ b/index.html
@@ -627,7 +627,7 @@
                                 data-toggle="dropdown"
                                 aria-haspopup="true"
                                 aria-expanded="false">
-                                Status: {{ getPhylorefStatus(selectedPhyloref) }} <span class="caret"></span>
+                                Status: {{ getPhylorefStatus(selectedPhyloref).statusInEnglish }} <span class="caret"></span>
                             </button>
                             <ul class="dropdown-menu">
                               <li><a href="#selected-phyloref" @click="setPhylorefStatus(selectedPhyloref, 'pso:draft')">Draft</a></li>
@@ -650,7 +650,7 @@
                             </button>
                             <ul class="dropdown-menu">
                               <a href="#selected-phyloref" v-for="statusChange of getPhylorefStatusChanges(selectedPhyloref)">
-                                {{ statusChange.statusCURIE }}
+                                {{ statusChange.statusInEnglish }}
                                 <small v-if="hasProperty(statusChange, 'intervalStart') || hasProperty(statusChange, 'intervalEnd')">
                                   <template v-if="hasProperty(statusChange, 'intervalStart')">from {{statusChange.intervalStart}}</template>
                                   <template v-if="hasProperty(statusChange, 'intervalEnd')">to {{statusChange.intervalEnd}}</template>

--- a/index.html
+++ b/index.html
@@ -618,17 +618,56 @@
                             href="#selected-phyloref"
                             class="btn btn-default"
                             @click="changeSelectedPhyloref(-1)"
-                            >Previous phyloreference</a>
+                            >Previous</a>
+                        <div class="btn-group" role="group">
+                            <button
+                                id="phyloref-status"
+                                type="button"
+                                class="btn btn-primary dropdown-toggle"
+                                data-toggle="dropdown"
+                                aria-haspopup="true"
+                                aria-expanded="false">
+                                Status: {{ getPhylorefStatus(selectedPhyloref) }} <span class="caret"></span>
+                            </button>
+                            <ul class="dropdown-menu">
+                              <li><a href="#selected-phyloref" @click="setPhylorefStatus(selectedPhyloref, 'pso:draft')">Draft</a></li>
+                              <li><a href="#selected-phyloref" @click="setPhylorefStatus(selectedPhyloref, 'pso:final-draft')">Final draft</a></li>
+                              <li><a href="#selected-phyloref" @click="setPhylorefStatus(selectedPhyloref, 'pso:under-review')">Under review</a></li>
+                              <li><a href="#selected-phyloref" @click="setPhylorefStatus(selectedPhyloref, 'pso:submitted')">Tested</a></li>
+                              <li><a href="#selected-phyloref" @click="setPhylorefStatus(selectedPhyloref, 'pso:published')">Published</a></li>
+                              <li><a href="#selected-phyloref" @click="setPhylorefStatus(selectedPhyloref, 'pso:retracted-from-publication')">Retracted</a></li>
+                            </ul>
+                        </div>
+                        <div class="btn-group" role="group">
+                            <button
+                                id="phyloref-status-changes"
+                                type="button"
+                                class="btn btn-default dropdown-toggle"
+                                data-toggle="dropdown"
+                                aria-haspopup="true"
+                                aria-expanded="false">
+                                {{ getPhylorefStatusChanges(selectedPhyloref).length }} changes <span class="caret"></span>
+                            </button>
+                            <ul class="dropdown-menu">
+                              <a href="#selected-phyloref" v-for="statusChange of getPhylorefStatusChanges(selectedPhyloref)">
+                                {{ statusChange.statusCURIE }}
+                                <small v-if="hasProperty(statusChange, 'intervalStart') || hasProperty(statusChange, 'intervalEnd')">
+                                  <template v-if="hasProperty(statusChange, 'intervalStart')">from {{statusChange.intervalStart}}</template>
+                                  <template v-if="hasProperty(statusChange, 'intervalEnd')">to {{statusChange.intervalEnd}}</template>
+                                </small>
+                              </a>
+                            </ul>
+                        </div>
                         <a
                             href="#selected-phyloref"
                             class="btn btn-danger"
                             onclick="if(window.confirm('Are you sure you want to delete this phyloreference?')) { vm.testcase.phylorefs.splice(vm.testcase.phylorefs.indexOf(vm.selectedPhyloref), 1); vm.selectedPhyloref = undefined; }"
-                            >Delete phyloreference</a>
+                            >Delete</a>
                         <a
                             href="#selected-phyloref"
                             class="btn btn-default"
                             @click="changeSelectedPhyloref(+1)"
-                            >Next phyloreference</a>
+                            >Next</a>
                     </div>
                 </div>
 

--- a/index.html
+++ b/index.html
@@ -297,7 +297,7 @@
                                                         <span class="input-group-btn">
                                                             <button type="button" class="btn btn-danger" @click="selectedTUnit.scientificNames.splice(scnameIndex, 1)"><span class="glyphicon glyphicon-remove"></span></button>
                                                         </span>
-                                                        <input type="text" class="form-control" v-model:lazy="scname.scientificName">
+                                                        <input type="text" class="form-control" v-model.lazy="scname.scientificName">
                                                         <div class="input-group-btn">
                                                             <button type="button"
                                                                 class="btn btn-primary dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false"
@@ -336,7 +336,7 @@
                                                             <button type="button" class="btn btn-danger" @click="selectedTUnit.externalReferences.splice(externalRefIndex, 1)"
                                                                 ><span class="glyphicon glyphicon-remove"></span></button>
                                                         </div>
-                                                        <input type="url" class="form-control" v-model:lazy="selectedTUnit.externalReferences[externalRefIndex]">
+                                                        <input type="url" class="form-control" v-model.lazy="selectedTUnit.externalReferences[externalRefIndex]">
                                                         <div class="input-group-btn">
                                                             <button type="button" class="btn btn-primary" @click="openURL(externalRef)">Go to URL</button>
                                                         </div>
@@ -369,7 +369,7 @@
                                                         <span class="input-group-btn">
                                                             <button type="button" class="btn btn-danger" @click="selectedTUnit.includesSpecimens.splice(scnameIndex, 1)"><span class="glyphicon glyphicon-remove"></span></button>
                                                         </span>
-                                                        <input type="text" class="form-control" v-model:lazy="specimen.occurrenceID">
+                                                        <input type="text" class="form-control" v-model.lazy="specimen.occurrenceID">
                                                         <div class="input-group-btn">
                                                             <button type="button"
                                                                 class="btn btn-primary dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false"
@@ -437,7 +437,7 @@
                         <div class="input-group col-md-9">
                             <textarea
                                 id="definition"
-                                v-model="selectedPhyloref.cladeDefinition"
+                                v-model.lazy="selectedPhyloref.cladeDefinition"
                                 class="form-control"
                                 rows="6"
                                 placeholder="Phylogenetic clade definition"
@@ -449,7 +449,7 @@
                         <div class="input-group col-md-9">
                             <textarea
                                 id="curator-comments"
-                                v-model="selectedPhyloref['curatorComments']"
+                                v-model.lazy="selectedPhyloref.curatorComments"
                                 class="form-control"
                                 rows="2"
                                 placeholder="Curator notes relating to this phyloreference"

--- a/js/curation-tool.js
+++ b/js/curation-tool.js
@@ -747,12 +747,15 @@ const vm = new Vue({
         Array.isArray(phyloref['pso:holdsStatusInTime']) &&
         phyloref['pso:holdsStatusInTime'].length > 0
       ) {
+        // If we have any pso:holdsStatusInTime entries, pick the first one and
+        // extract the CURIE and time interval information from it.
         const lastStatusInTime = phyloref['pso:holdsStatusInTime'][phyloref['pso:holdsStatusInTime'].length - 1];
         const statusCURIE = lastStatusInTime['pso:withStatus']['@id'];
+
+        // Look for time interval information
         let intervalStart;
         let intervalEnd;
 
-        // Look for time interval information
         if (this.hasProperty(lastStatusInTime, 'tvc:atTime')) {
           const atTime = lastStatusInTime['tvc:atTime'];
           if (this.hasProperty(atTime, 'timeinterval:hasIntervalStartDate')) intervalStart = atTime['timeinterval:hasIntervalStartDate'];

--- a/js/curation-tool.js
+++ b/js/curation-tool.js
@@ -218,7 +218,7 @@ function getTaxonomicUnitsFromNodeLabel(nodeLabel) {
   if (nodeLabel === undefined || nodeLabel === null) return [];
 
   // Check if the label starts with a binomial name.
-  const results = /^([A-Z][a-z]+)[\s_]([a-z-]+)[\b_]/.exec(nodeLabel);
+  const results = /^([A-Z][a-z]+)[\s_]([a-z-]+)(?:\b|_)/.exec(nodeLabel);
   if (results !== null) {
     return [{
       scientificNames: [{

--- a/js/curation-tool.js
+++ b/js/curation-tool.js
@@ -218,7 +218,7 @@ function getTaxonomicUnitsFromNodeLabel(nodeLabel) {
   if (nodeLabel === undefined || nodeLabel === null) return [];
 
   // Check if the label starts with a binomial name.
-  const results = /^([A-Z][a-z]+) ([a-z-]+)\b/.exec(nodeLabel);
+  const results = /^([A-Z][a-z]+)[\s_]([a-z-]+)[\b_]/.exec(nodeLabel);
   if (results !== null) {
     return [{
       scientificNames: [{

--- a/js/curation-tool.js
+++ b/js/curation-tool.js
@@ -9,6 +9,7 @@
 /* global Vue */ // From https://vuejs.org/
 /* global _ */ // From http://underscorejs.org/
 /* global d3 */ // From https://d3js.org/
+/* global moment */ // From https://momentjs.com/
 
 // List of example files to provide in the "Examples" dropdown.
 const examplePHYXURLs = [
@@ -803,8 +804,15 @@ const vm = new Vue({
           // Create intervalStart/intervalEnd convenient fields
           if (this.hasProperty(entry, 'tvc:atTime')) {
             const atTime = entry['tvc:atTime'];
-            if (this.hasProperty(atTime, 'timeinterval:hasIntervalStartDate')) entry.intervalStart = atTime['timeinterval:hasIntervalStartDate'];
-            if (this.hasProperty(atTime, 'timeinterval:hasIntervalEndDate')) entry.intervalEnd = atTime['timeinterval:hasIntervalEndDate'];
+            if (this.hasProperty(atTime, 'timeinterval:hasIntervalStartDate')) {
+              entry.intervalStart = atTime['timeinterval:hasIntervalStartDate'];
+              entry.intervalStartAsCalendar = moment(entry.intervalStart).calendar();
+            }
+
+            if (this.hasProperty(atTime, 'timeinterval:hasIntervalEndDate')) {
+              entry.intervalEnd = atTime['timeinterval:hasIntervalEndDate'];
+              entry.intervalEndAsCalendar = moment(entry.intervalEnd).calendar();
+            }
           }
 
           return entry;

--- a/js/curation-tool.js
+++ b/js/curation-tool.js
@@ -218,11 +218,16 @@ function getTaxonomicUnitsFromNodeLabel(nodeLabel) {
   if (nodeLabel === undefined || nodeLabel === null) return [];
 
   // Check if the label starts with a binomial name.
-  const results = /^([A-Z][a-z]+)[\s_]([a-z-]+)(?:\b|_)/.exec(nodeLabel);
+  const results = /^([A-Z][a-z]+)[\s_]([a-z-]+)(\b.*|\s.*|_.*)$/.exec(nodeLabel);
   if (results !== null) {
+    // Add an extra space before the rest of the name if it exists
+    let rest = results[3];
+    if (rest !== undefined) rest = ` ${rest}`;
+
+    // Return all the components of each name including binomial, genus and specificEpithet.
     return [{
       scientificNames: [{
-        scientificName: nodeLabel,
+        scientificName: `${results[1]} ${results[2]}${rest}`,
         binomialName: `${results[1]} ${results[2]}`,
         genus: results[1],
         specificEpithet: results[2],

--- a/js/curation-tool.js
+++ b/js/curation-tool.js
@@ -298,6 +298,7 @@ const vm = new Vue({
 
     // The main data model.
     testcase: {
+      '@context': 'http://phyloref.org/curation-tool/json/phyx.json',
       doi: '',
       url: '',
       citation: '',
@@ -308,6 +309,7 @@ const vm = new Vue({
     // A copy of the data model, used to test when the data model has been
     // modified.
     testcaseAsLoaded: {
+      '@context': 'http://phyloref.org/curation-tool/json/phyx.json',
       doi: '',
       url: '',
       citation: '',

--- a/js/curation-tool.js
+++ b/js/curation-tool.js
@@ -794,30 +794,30 @@ const vm = new Vue({
     getPhylorefStatusChanges(phyloref) {
       // Return a list of status changes for a particular phyloreference
       if (this.hasProperty(phyloref, 'pso:holdsStatusInTime')) {
-        return phyloref['pso:holdsStatusInTime'].map((entryToChange) => {
-          const entry = entryToChange;
+        return phyloref['pso:holdsStatusInTime'].map((entry) => {
+          const result = {};
 
           // Create a statusCURIE convenience field.
           if (this.hasProperty(entry, 'pso:withStatus')) {
-            entry.statusCURIE = entry['pso:withStatus']['@id'];
-            entry.statusInEnglish = this.getPhylorefStatusCURIEsInEnglish()[entry.statusCURIE];
+            result.statusCURIE = entry['pso:withStatus']['@id'];
+            result.statusInEnglish = this.getPhylorefStatusCURIEsInEnglish()[result.statusCURIE];
           }
 
           // Create intervalStart/intervalEnd convenient fields
           if (this.hasProperty(entry, 'tvc:atTime')) {
             const atTime = entry['tvc:atTime'];
             if (this.hasProperty(atTime, 'timeinterval:hasIntervalStartDate')) {
-              entry.intervalStart = atTime['timeinterval:hasIntervalStartDate'];
-              entry.intervalStartAsCalendar = moment(entry.intervalStart).calendar();
+              result.intervalStart = atTime['timeinterval:hasIntervalStartDate'];
+              result.intervalStartAsCalendar = moment(result.intervalStart).calendar();
             }
 
             if (this.hasProperty(atTime, 'timeinterval:hasIntervalEndDate')) {
-              entry.intervalEnd = atTime['timeinterval:hasIntervalEndDate'];
-              entry.intervalEndAsCalendar = moment(entry.intervalEnd).calendar();
+              result.intervalEnd = atTime['timeinterval:hasIntervalEndDate'];
+              result.intervalEndAsCalendar = moment(result.intervalEnd).calendar();
             }
           }
 
-          return entry;
+          return result;
         });
       }
 

--- a/json/phyx.json
+++ b/json/phyx.json
@@ -235,12 +235,12 @@
             "range": "TU",
             "@type": "@set"
         },
-        
+
         "specifierWillNotMatch": {
             "@id": "testcase:specifier_will_not_match",
             "@type": "@set"
         },
-        
+
 
         "== TERMS FROM THE ANNOTATION ONTOLOGY ==": {},
 
@@ -264,7 +264,12 @@
         "annotationBody": {
             "@id": "oa:hasBody",
             "@type": "xsd:string"
-        }
+        },
 
+        "== TERMS FROM THE PUBLISHING STATUS ONTOLOGY AND RELATED ==": {},
+
+        "pso": "http://purl.org/spar/pso/",
+        "tvc": "http://www.essepuntato.it/2012/04/tvc/",
+        "timeinterval": "http://www.ontologydesignpatterns.org/cp/owl/timeinterval.owl#"
     }
 }

--- a/json/phyx.json
+++ b/json/phyx.json
@@ -1,0 +1,270 @@
+{
+    "@context": {
+        "xsd": "http://www.w3.org/2001/XMLSchema#",
+
+        "== TOP-LEVEL DOCUMENT PROPERTIES ==": {},
+        "ot": "http://purl.org/opentree/nexson#",
+
+        "curator": {
+            "@id": "ot:curatorName",
+            "@type": "xsd:string"
+        },
+
+        "comments": {
+            "@id": "ot:comment",
+            "@type": "xsd:string"
+        },
+
+        "citation": "ot:studyPublicationReference",
+
+        "url": {
+            "@id": "ot:studyPublication",
+            "@type": "@id"
+        },
+
+        "year": {
+            "@id": "ot:studyYear",
+            "@type": "xsd:integer"
+        },
+
+        "== Management of nodes and internode relationships ==": {},
+        "testcase": "http://vocab.phyloref.org/phyloref/testcase.owl#",
+
+        "nodes": {
+            "@id": "testcase:has_node",
+            "@container": "@set"
+        },
+
+        "inPhylogeny": {
+            "@id": "testcase:in_phylogeny",
+            "@type": "@id"
+        },
+
+        "hasRootNode": {
+            "@id": "testcase:has_root_node",
+            "@type": "@id"
+        },
+
+        "phylogenies": {
+            "@id": "testcase:has_phylogeny",
+            "@container": "@set"
+        },
+
+        "== CDAO and Phyloref properties ==": {},
+        "obo": "http://purl.obolibrary.org/obo/",
+        "phyloref": "http://phyloinformatics.net/phyloref.owl#",
+
+        "children": {
+            "@id": "obo:CDAO_0000149",
+            "@type": "@id"
+        },
+
+        "siblings": {
+            "@id": "phyloref:has_Sibling",
+            "@type": "@id"
+        },
+
+        "phylorefs": {
+            "@id": "testcase:has_phyloreference",
+            "@container": "@set"
+        },
+
+        "malformedPhyloreference": {
+            "@id": "testcase:malformed_phyloreference",
+            "@type": "xsd:string"
+        },
+
+        "hasSpecifier": {
+            "@id": "testcase:has_specifier",
+            "@type": "@set"
+        },
+
+        "hasInternalSpecifier": {
+            "@id": "testcase:has_internal_specifier",
+            "@type": "@set"
+        },
+
+        "hasExternalSpecifier": {
+            "@id": "testcase:has_external_specifier",
+            "@type": "@set"
+        },
+
+        "hasUnmatchedSpecifiers": {
+            "@id": "testcase:has_unmatched_specifier",
+            "@type": "@set"
+        },
+
+        "hasAdditionalClass": {
+            "@id": "testcase:has_additional_class",
+            "@type": "@set"
+        },
+
+        "newick": {
+            "@id": "testcase:as_newick_string",
+            "@type": "xsd:string"
+        },
+
+        "cladeDefinition": {
+            "@id": "testcase:clade_definition",
+            "@type": "xsd:string"
+        },
+
+        "== LOW-LEVEL RDF/RDFS/OWL TERMS ==": {},
+        "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+
+        "label": {
+            "@id": "rdfs:label",
+            "@type": "xsd:string"
+        },
+
+        "comment": {
+            "@id": "rdfs:comment",
+            "@type": "xsd:string"
+        },
+
+        "== GLUE TO RENDER ONTOLOGY IN RDF ==": {},
+        "owl": "http://www.w3.org/2002/07/owl#",
+
+        "owl:imports": {
+            "@id": "owl:imports",
+            "@type": "@id"
+        },
+
+        "equivalentClass": "owl:equivalentClass",
+        "intersectionOf": {
+            "@id": "owl:intersectionOf",
+            "@container": "@list"
+        },
+        "onProperty": {
+            "@id": "owl:onProperty",
+            "@type": "@id"
+        },
+        "someValuesFrom": {
+            "@id": "owl:someValuesFrom",
+            "@container": "@set"
+        },
+        "unionOf": {
+            "@id": "owl:unionOf",
+            "@container": "@list"
+        },
+        "hasValue": {
+            "@id": "owl:hasValue",
+            "@type": "xsd:string"
+        },
+
+        "filename": "testcase:filename",
+
+        "externalReferences": {
+            "@id": "obo:CDAO_0000164",
+            "@type": "@set"
+        },
+
+        "scientificNames": {
+            "@id": "testcase:has_scientific_name",
+            "@type": "@set"
+        },
+
+        "includesSpecimens": {
+            "@id": "testcase:includes_specimen",
+            "@type": "@set"
+        },
+
+        "== Properties of individual TUs ==": {},
+        "dwc": "http://rs.tdwg.org/dwc/terms/",
+
+        "=== Scientific names ===": {},
+
+        "scientificName": {
+            "@id": "dwc:scientificName",
+            "@type": "xsd:string"
+        },
+        "binomialName": {
+            "@id": "testcase:has_binomial_name",
+            "@type": "xsd:string"
+        },
+        "genus": {
+            "@id": "dwc:genus",
+            "@type": "xsd:string"
+        },
+        "specificEpithet": {
+            "@id": "dwc:specificEpithet",
+            "@type": "xsd:string"
+        },
+
+        "=== Specimen identifiers ===": {},
+
+        "occurrenceID": "dwc:occurrenceID",
+        "catalogNumber": "dwc:catalogNumber",
+        "collectionCode": "dwc:collectionCode",
+        "institutionCode": "dwc:institutionCode",
+
+        "subClassOf": {
+            "@id": "rdfs:subClassOf",
+            "@type": "@id"
+        },
+
+        "expectedPhyloreferenceNamed": "testcase:expected_phyloreference_named",
+
+        "reason": {
+            "@id": "testcase:reason_for_match",
+            "@type": "xsd:string"
+        },
+
+        "hasTaxonomicUnitMatches": {
+            "@id": "testcase:has_taxonomic_unit_match",
+            "@type": "@set"
+        },
+
+        "referencesTaxonomicUnits": {
+            "@id": "testcase:references_taxonomic_unit",
+            "domain": "Specifier",
+            "range": "TU",
+            "@type": "@set"
+        },
+
+        "matchesTaxonomicUnits": {
+            "@id": "testcase:matches_taxonomic_unit",
+            "domain": "TUMatch",
+            "range": "TU",
+            "@type": "@set"
+        },
+
+        "representsTaxonomicUnits": {
+            "@id": "obo:CDAO_0000187",
+            "domain": "Node",
+            "range": "TU",
+            "@type": "@set"
+        },
+        
+        "specifierWillNotMatch": {
+            "@id": "testcase:specifier_will_not_match",
+            "@type": "@set"
+        },
+        
+
+        "== TERMS FROM THE ANNOTATION ONTOLOGY ==": {},
+
+        "oa": "http://www.w3.org/ns/oa#",
+
+        "annotations": {
+            "@id": "testcase:has_annotation",
+            "@container": "@set"
+        },
+
+        "annotationTarget": {
+            "@id": "oa:hasTarget",
+            "@type": "@id"
+        },
+
+        "annotationName": {
+            "@id": "rdfs:label",
+            "@type": "xsd:string"
+        },
+
+        "annotationBody": {
+            "@id": "oa:hasBody",
+            "@type": "xsd:string"
+        }
+
+    }
+}

--- a/json/phyx.json
+++ b/json/phyx.json
@@ -117,6 +117,12 @@
             "@type": "xsd:string"
         },
 
+        "labels": {
+            "@id": "rdfs:label",
+            "@type": "xsd:string",
+            "@container": "@set"
+        },
+
         "comment": {
             "@id": "rdfs:comment",
             "@type": "xsd:string"


### PR DESCRIPTION
This allows each phyloreference to be in one of the states laid out in #25. Changes in state for each phyloreference are recorded along with a timestamp, allowing the previous history of the phyloreference to be documented. In the future, this could be extended to archive previous versions of the phyloreference or to identify who changed its state (#59).

Since this pull request requires new prefixes in the PHYX file, I've also included a fix for #46 so that we include a copy of the context we need in this repository. I've incorporated [Brochu 2003](http://dx.doi.org/10.1146/annurev.earth.31.100901.141308) as an example for demonstrating phyloreference statuses.

This has been tested in phyloref/clade-ontology#29 and is ready to be merged.