### PR TITLE
Export PHYX as JSON-LD for reasoning

### DIFF
--- a/index.html
+++ b/index.html
@@ -68,6 +68,10 @@
                 <div class="btn-group" role="group">
                     <button id="display-as-json-btn" type="button" class="btn btn-success" onclick="$('#display-as-json').toggle(300)">Display as JSON</button>
                 </div>
+
+                <div class="btn-group" role="group">
+                    <button id="download-as-jsonld-btn" type="button" class="btn btn-info" @click="downloadAsJSONLD()">Download as JSON-LD</button>
+                </div>
             </div>
         </div>
 
@@ -709,6 +713,9 @@
 
     <!-- Moment: for datetime calculations -->
     <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.22.2/moment.min.js"></script>
+
+    <!-- FileSaver.js: for saving generated files to the local hard drive -->
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/FileSaver.js/1.3.8/FileSaver.min.js"></script>
 
     <!-- Our source code -->
     <script src="./js/phyx.js"></script>

--- a/js/curation-tool.js
+++ b/js/curation-tool.js
@@ -19,6 +19,7 @@
 /* global PhylogenyWrapper */
 /* global SpecimenWrapper */
 /* global PhylorefWrapper */
+/* global PHYXWrapper */
 /* global phyxCacheManager */
 
 // List of example files to provide in the "Examples" dropdown.
@@ -351,7 +352,8 @@ const vm = new Vue({
       // This is a temporary function to help develop the JSON-LD production
       // system -- eventually, we'll rename it to downloadAsJSON and make it
       // export the PHYX file for download.
-      const content = ["{ 'hello': 'world' }"];
+      const wrapped = new PHYXWrapper(this.testcase);
+      const content = [wrapped.asJSONLD()];
 
       // Save to local hard drive.
       const jsonldFile = new File(content, 'download.json', { type: 'application/json;charset=utf-8' });

--- a/js/curation-tool.js
+++ b/js/curation-tool.js
@@ -10,6 +10,7 @@
 /* global _ */ // From http://underscorejs.org/
 /* global d3 */ // From https://d3js.org/
 /* global moment */ // From https://momentjs.com/
+/* global saveAs */ // From https://github.com/eligrey/FileSaver.js
 
 // These globals are from phyx.js. Eventually, we will replace this with
 // import/export.
@@ -343,6 +344,18 @@ const vm = new Vue({
       } catch (err) {
         throw new Error(`Error occurred while displaying new testcase: ${err}`);
       }
+    },
+
+    // Export functions.
+    downloadAsJSONLD() {
+      // This is a temporary function to help develop the JSON-LD production
+      // system -- eventually, we'll rename it to downloadAsJSON and make it
+      // export the PHYX file for download.
+      const content = ["{ 'hello': 'world' }"];
+
+      // Save to local hard drive.
+      const jsonldFile = new File(content, 'download.json', { type: 'application/json;charset=utf-8' });
+      saveAs(jsonldFile);
     },
 
     // User interface helper methods.

--- a/js/phyx.js
+++ b/js/phyx.js
@@ -736,11 +736,13 @@ class PhylogenyWrapper {
           nodeAsJSONLD.representsTaxonomicUnits = this.getTaxonomicUnitsForNodeLabel(node.name);
 
           // Apply @id and @type to each taxonomic unit.
+          let countTaxonomicUnits = 0;
           nodeAsJSONLD.representsTaxonomicUnits.forEach((tunitToChange) => {
             const tunit = tunitToChange;
 
-            tunit['@id'] = `${nodeURI}_taxonomicunit${nodeCount}`;
+            tunit['@id'] = `${nodeURI}_taxonomicunit${countTaxonomicUnits}`;
             tunit['@type'] = { '@id': 'http://purl.obolibrary.org/obo/CDAO_0000138' };
+            countTaxonomicUnits += 1;
           });
         }
 
@@ -974,7 +976,6 @@ class PhylorefWrapper {
       internalSpecifier['@id'] = specifierId;
       internalSpecifier['@type'] = [
         'http://phyloinformatics.net/phyloref.owl#Specifier',
-        'owl:Class',
       ];
 
       // Add identifiers to all taxonomic units.
@@ -995,12 +996,11 @@ class PhylorefWrapper {
       externalSpecifierCount += 1;
 
       const externalSpecifier = externalSpecifierToChange;
-      const specifierId = `${phylorefURI}_specifier_external${internalSpecifierCount}`;
+      const specifierId = `${phylorefURI}_specifier_external${externalSpecifierCount}`;
 
       externalSpecifier['@id'] = specifierId;
       externalSpecifier['@type'] = [
         'http://phyloinformatics.net/phyloref.owl#Specifier',
-        'owl:Class',
       ];
 
       // Add identifiers to all taxonomic units.
@@ -1063,7 +1063,7 @@ class PhylorefWrapper {
       // This phyloreference is made up of one external specifier and some number
       // of internal specifiers.
 
-      const internalSpecifierRestrictions = phylorefAsJSONLD.externalSpecifiers
+      const internalSpecifierRestrictions = phylorefAsJSONLD.internalSpecifiers
         .map(specifier => PhylorefWrapper
           .wrapInternalOWLRestriction(PhylorefWrapper.getOWLRestrictionForSpecifier(specifier)));
 

--- a/js/phyx.js
+++ b/js/phyx.js
@@ -120,22 +120,6 @@ class ScientificNameWrapper {
     return scname;
   }
 
-/*
-  asJSON() {
-    // Return this scientific name as a JSON object.
-
-    const result = {
-      '@id': 'dwc:Taxon',
-      scientificName: this.scientificName,
-    };
-
-    if (this.genus !== undefined) result.genus = this.genus;
-    if (this.specificEpithet !== undefined) result.specificEpithet = this.specificEpithet;
-
-    return result;
-  }
-*/
-
   get scientificName() {
     // Get the "dwc:scientificName" -- the complete scientific name.
     return this.scname.scientificName;

--- a/js/phyx.js
+++ b/js/phyx.js
@@ -971,7 +971,7 @@ class PhylorefWrapper {
 
     if (internalSpecifierCount === 0 && externalSpecifierCount === 0) {
       phylorefAsJSONLD.malformedPhyloreference = 'No specifiers provided';
-    } else if (externalSpecifierCount > 0) {
+    } else if (externalSpecifierCount > 1) {
       phylorefAsJSONLD.malformedPhyloreference = 'Multiple external specifiers are not yet supported';
     } else if (internalSpecifierCount === 1 && externalSpecifierCount === 0) {
       phylorefAsJSONLD.malformedPhyloreference = 'Only a single internal specifier was provided';
@@ -1005,11 +1005,22 @@ class PhylorefWrapper {
       }
 
       phylorefAsJSONLD.equivalentClass = equivalentClassAccumulator;
-
     } else {
       // This phyloreference is made up of one external specifier and some number
       // of internal specifiers.
 
+      const internalSpecifierRestrictions = phylorefAsJSONLD.externalSpecifiers
+        .map(specifier => PhylorefWrapper
+          .wrapInternalOWLRestriction(PhylorefWrapper.getOWLRestrictionForSpecifier(specifier)));
+
+      const externalSpecifierRestrictions = phylorefAsJSONLD.externalSpecifiers
+        .map(specifier => PhylorefWrapper
+          .wrapExternalOWLRestriction(PhylorefWrapper.getOWLRestrictionForSpecifier(specifier)));
+
+      phylorefAsJSONLD.equivalentClass = {
+        '@type': 'owl:Class',
+        intersectionOf: internalSpecifierRestrictions.concat(externalSpecifierRestrictions),
+      };
     }
 
     return phylorefAsJSONLD;

--- a/js/phyx.js
+++ b/js/phyx.js
@@ -716,13 +716,14 @@ class PhylogenyWrapper {
     const nodeIdsByParentId = {};
 
     // Extract the newick string.
-    const { newick = '()' } = this.phylogeny;
+    const { newick = '()', additionalNodeProperties } = this.phylogeny;
 
     // Parse the Newick string; if parseable, recurse through the nodes,
     // added them to the list of JSON-LD nodes as we go.
     const parsed = d3.layout.newick_parser(newick);
     if (hasOwnProperty(parsed, 'json')) {
       PhylogenyWrapper.recurseNodes(parsed.json, (node, nodeCount, parentCount) => {
+        // Start with the additional node properties.
         const nodeAsJSONLD = {};
 
         // Set @id and @type.
@@ -730,9 +731,19 @@ class PhylogenyWrapper {
         nodeAsJSONLD['@id'] = nodeURI;
         nodeAsJSONLD['@type'] = { '@id': 'http://purl.obolibrary.org/obo/CDAO_0000140' };
 
-        // Add label and taxonomic units.
+        // Add labels, additional node properties and taxonomic units.
         if (hasOwnProperty(node, 'name') && node.name !== '') {
+          // Add labels.
           nodeAsJSONLD.labels = [node.name];
+
+          // Add additional node properties, if any.
+          if (additionalNodeProperties && hasOwnProperty(additionalNodeProperties, node.name)) {
+            Object.keys(additionalNodeProperties[node.name]).forEach((key) => {
+              nodeAsJSONLD[key] = additionalNodeProperties[node.name][key];
+            });
+          }
+
+          // Add taxonomic units.
           nodeAsJSONLD.representsTaxonomicUnits = this.getTaxonomicUnitsForNodeLabel(node.name);
 
           // Apply @id and @type to each taxonomic unit.

--- a/js/phyx.js
+++ b/js/phyx.js
@@ -798,6 +798,7 @@ const CDAO_HAS_DESCENDANT = 'obo:CDAO_0000174';
 const PHYLOREF_HAS_SIBLING = 'http://phyloinformatics.net/phyloref.owl#has_Sibling';
 const PHYLOREFERENCE_TEST_CASE = 'testcase:PhyloreferenceTestCase';
 const PHYLOREFERENCE_PHYLOGENY = 'testcase:PhyloreferenceTestPhylogeny';
+const TESTCASE_SPECIFIER = 'testcase:Specifier';
 
 // eslint-disable-next-line no-unused-vars
 class PhylorefWrapper {
@@ -975,7 +976,7 @@ class PhylorefWrapper {
 
       internalSpecifier['@id'] = specifierId;
       internalSpecifier['@type'] = [
-        'http://phyloinformatics.net/phyloref.owl#Specifier',
+        TESTCASE_SPECIFIER,
       ];
 
       // Add identifiers to all taxonomic units.
@@ -1000,7 +1001,7 @@ class PhylorefWrapper {
 
       externalSpecifier['@id'] = specifierId;
       externalSpecifier['@type'] = [
-        'http://phyloinformatics.net/phyloref.owl#Specifier',
+        TESTCASE_SPECIFIER,
       ];
 
       // Add identifiers to all taxonomic units.

--- a/js/phyx.js
+++ b/js/phyx.js
@@ -807,7 +807,7 @@ class PhylogenyWrapper {
 // We need some OWL constants for this.
 const CDAO_HAS_CHILD = 'obo:CDAO_0000149';
 const CDAO_HAS_DESCENDANT = 'obo:CDAO_0000174';
-const PHYLOREF_HAS_SIBLING = 'http://phyloinformatics.net/phyloref.owl#has_Sibling';
+const PHYLOREF_HAS_SIBLING = 'http://ontology.phyloref.org/phyloref.owl#has_Sibling';
 const PHYLOREFERENCE_TEST_CASE = 'testcase:PhyloreferenceTestCase';
 const PHYLOREFERENCE_PHYLOGENY = 'testcase:PhyloreferenceTestPhylogeny';
 const TESTCASE_SPECIFIER = 'testcase:Specifier';
@@ -1350,16 +1350,15 @@ class PHYXWrapper {
     jsonld['owl:imports'] = [
       'https://raw.githubusercontent.com/phyloref/curation-workflow/develop/ontologies/phyloref_testcase.owl',
       // - Will become 'http://vocab.phyloref.org/phyloref/testcase.owl'
-      'https://raw.githubusercontent.com/phyloref/phyloref-ontology/master/phyloref.owl',
-      // - Will become 'http://phyloinformatics.net/phyloref.owl'
+      'https://ontology.phyloref.org/phyloref.owl',
+      // - Phyloreferencing Ontology
       'http://purl.obolibrary.org/obo/bco.owl',
       // - Contains OWL definitions for Darwin Core terms
     ];
 
     // If the '@context' is missing, add it here.
     if (!hasOwnProperty(jsonld, '@context')) {
-      // TODO: replace with 'http://phyloref.org/' once we have a copy there.
-      jsonld['@context'] = 'http://www.ggvaidya.com/curation-tool/json/phyx.json';
+      jsonld['@context'] = 'https://www.phyloref.org/curation-tool/json/phyx.json';
     }
 
     return JSON.stringify([jsonld], undefined, 4);

--- a/js/phyx.js
+++ b/js/phyx.js
@@ -786,6 +786,7 @@ const CDAO_HAS_CHILD = 'obo:CDAO_0000149';
 const CDAO_HAS_DESCENDANT = 'obo:CDAO_0000174';
 const PHYLOREF_HAS_SIBLING = 'http://phyloinformatics.net/phyloref.owl#has_Sibling';
 const PHYLOREFERENCE_TEST_CASE = 'testcase:PhyloreferenceTestCase';
+const PHYLOREFERENCE_PHYLOGENY = 'testcase:PhyloreferenceTestPhylogeny';
 
 // eslint-disable-next-line no-unused-vars
 class PhylorefWrapper {
@@ -977,6 +978,13 @@ class PhylorefWrapper {
         'owl:Class',
       ];
     });
+
+    // For historical reasons, the Clade Ontology uses 'hasInternalSpecifier' to
+    // store the specifiers as OWL classes and 'internalSpecifiers' to store them
+    // as RDF annotations. We simplify that here by duplicating them here, but
+    // this should really be fixed in the Clade Ontology and in phyx.json.
+    phylorefAsJSONLD.hasInternalSpecifier = phylorefAsJSONLD.internalSpecifiers;
+    phylorefAsJSONLD.hasExternalSpecifier = phylorefAsJSONLD.externalSpecifiers;
 
     if (internalSpecifierCount === 0 && externalSpecifierCount === 0) {
       phylorefAsJSONLD.malformedPhyloreference = 'No specifiers provided';
@@ -1200,6 +1208,12 @@ class PHYXWrapper {
       let countPhylogeny = 0;
       jsonld.phylogenies.forEach((phylogenyToChange) => {
         const phylogeny = phylogenyToChange;
+
+        // Set name and class for phylogeny.
+        phylogeny['@id'] = `_:phylogeny${countPhylogeny}`;
+        phylogeny['@type'] = PHYLOREFERENCE_PHYLOGENY;
+
+        // Extract nodes from phylogeny.
         const wrapper = new PhylogenyWrapper(phylogeny);
         countPhylogeny += 1;
 

--- a/js/phyx.js
+++ b/js/phyx.js
@@ -465,8 +465,8 @@ class TaxonomicUnitMatcher {
       '@type': 'testcase:TUMatch',
       reason: this.matchReason,
       matchesTaxonomicUnits: [
-        this.tunit1,
-        this.tunit2,
+        { '@id': this.tunit1['@id'] },
+        { '@id': this.tunit2['@id'] },
       ],
     };
   }

--- a/json/phyx.json
+++ b/json/phyx.json
@@ -52,7 +52,7 @@
 
         "== CDAO and Phyloref properties ==": {},
         "obo": "http://purl.obolibrary.org/obo/",
-        "phyloref": "http://phyloinformatics.net/phyloref.owl#",
+        "phyloref": "http://ontology.phyloref.org/phyloref.owl#",
 
         "children": {
             "@id": "obo:CDAO_0000149",

--- a/lib/filesaver/FileSaver.js
+++ b/lib/filesaver/FileSaver.js
@@ -1,0 +1,182 @@
+/* FileSaver.js
+ * A saveAs() FileSaver implementation.
+ * 1.3.8
+ * 2018-03-22 14:03:47
+ *
+ * By Eli Grey, https://eligrey.com
+ * License: MIT
+ *   See https://github.com/eligrey/FileSaver.js/blob/master/LICENSE.md
+ */
+
+/*global self */
+/*jslint bitwise: true, indent: 4, laxbreak: true, laxcomma: true, smarttabs: true, plusplus: true */
+
+/*! @source http://purl.eligrey.com/github/FileSaver.js/blob/master/src/FileSaver.js */
+
+export var saveAs = saveAs || (function(view) {
+	"use strict";
+	// IE <10 is explicitly unsupported
+	if (typeof view === "undefined" || typeof navigator !== "undefined" && /MSIE [1-9]\./.test(navigator.userAgent)) {
+		return;
+	}
+	var
+		  doc = view.document
+		  // only get URL when necessary in case Blob.js hasn't overridden it yet
+		, get_URL = function() {
+			return view.URL || view.webkitURL || view;
+		}
+		, save_link = doc.createElementNS("http://www.w3.org/1999/xhtml", "a")
+		, can_use_save_link = "download" in save_link
+		, click = function(node) {
+			var event = new MouseEvent("click");
+			node.dispatchEvent(event);
+		}
+		, is_safari = /constructor/i.test(view.HTMLElement) || view.safari
+		, is_chrome_ios =/CriOS\/[\d]+/.test(navigator.userAgent)
+		, setImmediate = view.setImmediate || view.setTimeout
+		, throw_outside = function(ex) {
+			setImmediate(function() {
+				throw ex;
+			}, 0);
+		}
+		, force_saveable_type = "application/octet-stream"
+		// the Blob API is fundamentally broken as there is no "downloadfinished" event to subscribe to
+		, arbitrary_revoke_timeout = 1000 * 40 // in ms
+		, revoke = function(file) {
+			var revoker = function() {
+				if (typeof file === "string") { // file is an object URL
+					get_URL().revokeObjectURL(file);
+				} else { // file is a File
+					file.remove();
+				}
+			};
+			setTimeout(revoker, arbitrary_revoke_timeout);
+		}
+		, dispatch = function(filesaver, event_types, event) {
+			event_types = [].concat(event_types);
+			var i = event_types.length;
+			while (i--) {
+				var listener = filesaver["on" + event_types[i]];
+				if (typeof listener === "function") {
+					try {
+						listener.call(filesaver, event || filesaver);
+					} catch (ex) {
+						throw_outside(ex);
+					}
+				}
+			}
+		}
+		, auto_bom = function(blob) {
+			// prepend BOM for UTF-8 XML and text/* types (including HTML)
+			// note: your browser will automatically convert UTF-16 U+FEFF to EF BB BF
+			if (/^\s*(?:text\/\S*|application\/xml|\S*\/\S*\+xml)\s*;.*charset\s*=\s*utf-8/i.test(blob.type)) {
+				return new Blob([String.fromCharCode(0xFEFF), blob], {type: blob.type});
+			}
+			return blob;
+		}
+		, FileSaver = function(blob, name, no_auto_bom) {
+			if (!no_auto_bom) {
+				blob = auto_bom(blob);
+			}
+			// First try a.download, then web filesystem, then object URLs
+			var
+				  filesaver = this
+				, type = blob.type
+				, force = type === force_saveable_type
+				, object_url
+				, dispatch_all = function() {
+					dispatch(filesaver, "writestart progress write writeend".split(" "));
+				}
+				// on any filesys errors revert to saving with object URLs
+				, fs_error = function() {
+					if ((is_chrome_ios || (force && is_safari)) && view.FileReader) {
+						// Safari doesn't allow downloading of blob urls
+						var reader = new FileReader();
+						reader.onloadend = function() {
+							var url = is_chrome_ios ? reader.result : reader.result.replace(/^data:[^;]*;/, 'data:attachment/file;');
+							var popup = view.open(url, '_blank');
+							if(!popup) view.location.href = url;
+							url=undefined; // release reference before dispatching
+							filesaver.readyState = filesaver.DONE;
+							dispatch_all();
+						};
+						reader.readAsDataURL(blob);
+						filesaver.readyState = filesaver.INIT;
+						return;
+					}
+					// don't create more object URLs than needed
+					if (!object_url) {
+						object_url = get_URL().createObjectURL(blob);
+					}
+					if (force) {
+						view.location.href = object_url;
+					} else {
+						var opened = view.open(object_url, "_blank");
+						if (!opened) {
+							// Apple does not allow window.open, see https://developer.apple.com/library/safari/documentation/Tools/Conceptual/SafariExtensionGuide/WorkingwithWindowsandTabs/WorkingwithWindowsandTabs.html
+							view.location.href = object_url;
+						}
+					}
+					filesaver.readyState = filesaver.DONE;
+					dispatch_all();
+					revoke(object_url);
+				}
+			;
+			filesaver.readyState = filesaver.INIT;
+
+			if (can_use_save_link) {
+				object_url = get_URL().createObjectURL(blob);
+				setImmediate(function() {
+					save_link.href = object_url;
+					save_link.download = name;
+					click(save_link);
+					dispatch_all();
+					revoke(object_url);
+					filesaver.readyState = filesaver.DONE;
+				}, 0);
+				return;
+			}
+
+			fs_error();
+		}
+		, FS_proto = FileSaver.prototype
+		, saveAs = function(blob, name, no_auto_bom) {
+			return new FileSaver(blob, name || blob.name || "download", no_auto_bom);
+		}
+	;
+
+	// IE 10+ (native saveAs)
+	if (typeof navigator !== "undefined" && navigator.msSaveOrOpenBlob) {
+		return function(blob, name, no_auto_bom) {
+			name = name || blob.name || "download";
+
+			if (!no_auto_bom) {
+				blob = auto_bom(blob);
+			}
+			return navigator.msSaveOrOpenBlob(blob, name);
+		};
+	}
+
+	// todo: detect chrome extensions & packaged apps
+	//save_link.target = "_blank";
+
+	FS_proto.abort = function(){};
+	FS_proto.readyState = FS_proto.INIT = 0;
+	FS_proto.WRITING = 1;
+	FS_proto.DONE = 2;
+
+	FS_proto.error =
+	FS_proto.onwritestart =
+	FS_proto.onprogress =
+	FS_proto.onwrite =
+	FS_proto.onabort =
+	FS_proto.onerror =
+	FS_proto.onwriteend =
+		null;
+
+	return saveAs;
+}(
+	   typeof self !== "undefined" && self
+	|| typeof window !== "undefined" && window
+	|| this
+));


### PR DESCRIPTION
The first step in allowing the Curation Tool to carry out reasoning is to modify it to be able to produce JSON-LD that can be automatically converted into an OWL ontology that can be tested using JPhyloRef. This pull request adds a button to the Curation Tool user interface that allows the study to be downloaded as a JSON-LD file.

I'm holding off on testing the JSON-LD file produced as we can perform ad-hoc testing by converting it into RDF/XML using rdfpipe and then seeing if phyloreferences are resolved as expected using JPhyloRef, but implementing such testing will be tracked by #83.