### PR TITLE
Integration with JPhyloRef

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -18,5 +18,8 @@
         "vue",
         "json",
         "mocha"
-    ]
+    ],
+    "rules": {
+      "prefer-destructuring": "off"
+    }
 }

--- a/css/main.css
+++ b/css/main.css
@@ -50,6 +50,12 @@
     fill: blue;
 }
 
+/* An additional class for internal nodes that are the resolved node */
+.resolved-internal-label {
+    font-size: 16pt;
+    fill: green;
+}
+
 /*
  * Create a table class for a fixed size body.
  * Based on https://stackoverflow.com/a/23518856/27310

--- a/css/main.css
+++ b/css/main.css
@@ -8,23 +8,29 @@
  * Classes for phylogeny SVG elements
  */
 
-/* Phylotree nodes */
+/*
+ * Phylotree .node refers to the SVG groups that contain both the
+ * node itself as well as the text label next to it. This is confusing,
+ * but we will try to use that consistently below: *-node refers to the group
+ * that includes both the node as well as the label with it, while *-label
+ * refers only to the labels next to the nodes.
+ */
  .node {
      /* Phylotree's CSS sets this to 10px; we prefer larger node labels */
      font-size: 10pt;
  }
 
  /* Node label for an internal specifier */
-.internal-specifier-node {
+.internal-specifier-node text {
     font-weight: bolder;
-    fill: green;
+    fill: green !important;
     font-size: 12pt;
 }
 
 /* Node label for an external specifier */
-.external-specifier-node {
+.external-specifier-node-label {
     font-weight: bolder;
-    fill: magenta;
+    fill: green;
     font-size: 12pt;
 }
 
@@ -35,43 +41,47 @@
     font-weight: bolder;
 }
 
-/* Labels for internal nodes */
+/* Labels for internal nodes, whether phylorefs or not */
 .internal-label {
     font-family: serif;
     font-size: 12pt;
     font-style: italic;
 
-    text-anchor: start; /* Display text starting at the internal node */
-}
-
-/* An additional class for internal nodes that are currently selected */
-.selected-internal-label {
-    font-size: 16pt;
-    fill: blue;
-}
-
-/* An additional class for nodes that are the resolved node. */
-.resolved-node {
-  stroke: 1px solid black;
+    text-anchor: start; /* Display text starting at the node */
 }
 
 /*
- * The descendant-of-pinning-node class applies to the entire resolved node,
- * which includes the circle as well as the text label. This turns the circle red.
-*/
+ * An additional class for nodes that are the pinning node. When the phyloreference
+ * resolves to a single terminal node, it will be laid out in this way, rather
+ * than as an .internal-specifier-node.
+ */
+.pinning-node text {
+  font-size: 16pt;
+  fill: rgb(0, 24, 168) !important;
+}
+
+/*
+ * The descendant-of-pinning-node class instructions below apply to the entire resolved node,
+ * which includes the circle as well as the text label. We want to coordinate
+ * colours between:
+ *  - The circle that appears next to the node label,
+ *  - The node label, whether internal or terminal, and
+ *  - The branches descending from the pinning node.
+ *
+ * Note that .internal-specifier-node is set up to override this formatting, so
+ * internal node labels will be formatted differently from other terminals
+ * descending from the pinning node.
+ */
 .descendant-of-pinning-node-node circle {
-  fill: red;
+  fill: rgb(0, 24, 168);
+}
+
+.descendant-of-pinning-node-node text {
+  fill: rgb(0, 24, 168);
 }
 
 .descendant-of-pinning-node-branch {
-  stroke: red;
-}
-
-/* An additional class for internal node labels that are the resolved node */
-.resolved-internal-label {
-    fill: green;
-    font-style: normal;
-    font-weight: bolder;
+  stroke: rgb(0, 24, 168);
 }
 
 /*

--- a/css/main.css
+++ b/css/main.css
@@ -50,6 +50,11 @@
     text-anchor: start; /* Display text starting at the node */
 }
 
+/* The selected internal label on a phylogeny, whether determined to be the pinning node or not. */
+.selected-internal-label {
+  font-size: 16pt;
+}
+
 /*
  * An additional class for nodes that are the pinning node. When the phyloreference
  * resolves to a single terminal node, it will be laid out in this way, rather

--- a/css/main.css
+++ b/css/main.css
@@ -52,8 +52,9 @@
 
 /* An additional class for internal nodes that are the resolved node */
 .resolved-internal-label {
-    font-size: 16pt;
     fill: green;
+    font-style: normal;
+    font-weight: bolder;
 }
 
 /*

--- a/index.html
+++ b/index.html
@@ -461,7 +461,7 @@
                         </div>
 
                         <!-- Node(s) this phyloreference is expected to resolve to -->
-                        <label for="curator-comments" class="control-label col-md-3">Expected node resolution</label>
+                        <label for="curator-comments" class="control-label col-md-3">Expected nodes</label>
                         <div class="input-group col-md-9">
                             <!-- What if no phylogenies were loaded? -->
                             <div
@@ -514,6 +514,45 @@
                                             <a href="#selected-phyloref" @click="togglePhylorefExpectedNodeLabel(phylogeny, selectedPhyloref, nodeLabel)">{{nodeLabel}}</a>
                                         </li>
                                     </ul>
+                                </div>
+                            </div>
+                        </div>
+
+                        <!-- Node(s) this phyloreference actually resolved to -->
+                        <label for="curator-comments" class="control-label col-md-3">Actual nodes</label>
+                        <div class="input-group col-md-9">
+                            <!-- What if no phylogenies were loaded? -->
+                            <div
+                                v-if="testcase['phylogenies'].length == 0"
+                            >No phylogenies loaded.</div>
+
+                            <!-- If phylogenies were loaded, we need to display a selector for each phylogeny -->
+                            <div class="input-group" v-for="(phylogeny, phylogenyIndex) of testcase['phylogenies']">
+                                <!-- Display the phylogeny where this node is expected to match -->
+                                <span class="input-group-addon" :title="phylogeny['description']">Phylogeny {{phylogenyIndex + 1}}</span>
+
+                                <!-- Display the matching node(s) -->
+                                <template v-if="getPhylorefExpectedNodeLabels(phylogeny, selectedPhyloref).length === 0">
+                                    <!-- We matched no nodes -->
+                                    <input readonly type="text" class="form-control" value="No nodes could be matched">
+                                </template>
+                                <template v-if="getPhylorefExpectedNodeLabels(phylogeny, selectedPhyloref).length === 1">
+                                    <!-- We matched exactly one node -->
+                                    <input readonly type="text" class="form-control" :value="getPhylorefExpectedNodeLabels(phylogeny, selectedPhyloref)[0]">
+                                </template>
+                                <template v-if="getPhylorefExpectedNodeLabels(phylogeny, selectedPhyloref).length > 1">
+                                    <!-- We matched more than one node -->
+                                    <input readonly type="text" class="form-control" :value="getPhylorefExpectedNodeLabels(phylogeny, selectedPhyloref).length + ' nodes matched: ' + getPhylorefExpectedNodeLabels(phylogeny, selectedPhyloref).join(', ')">
+                                </template>
+
+                                <!-- Display a dropdown menu that allows the modified label to be changed. -->
+                                <div class="input-group-btn">
+                                    <button
+                                        type="button"
+                                        class="btn btn-primary"
+                                        @click="reasonOverPhyloreferences()"
+                                        >Reason</button>
+                                    </button>
                                 </div>
                             </div>
                         </div>

--- a/index.html
+++ b/index.html
@@ -611,8 +611,9 @@
                                 <!-- Display a button that activates reasoning. -->
                                 <div class="input-group-btn">
                                     <button
+                                        id="reason-over-phylorefs"
                                         type="button"
-                                        class="btn btn-primary reason-over-phylorefs"
+                                        class="btn btn-primary"
                                         @click="reasonOverPhyloreferences()"
                                         >Reason</button>
                                     </button>

--- a/index.html
+++ b/index.html
@@ -532,24 +532,24 @@
                                 <span class="input-group-addon" :title="phylogeny['description']">Phylogeny {{phylogenyIndex + 1}}</span>
 
                                 <!-- Display the matching node(s) -->
-                                <template v-if="getPhylorefExpectedNodeLabels(phylogeny, selectedPhyloref).length === 0">
+                                <template v-if="resolvedNodesForPhylogeny(selectedPhyloref, phylogeny).length === 0">
                                     <!-- We matched no nodes -->
                                     <input readonly type="text" class="form-control" value="No nodes could be matched">
                                 </template>
-                                <template v-if="getPhylorefExpectedNodeLabels(phylogeny, selectedPhyloref).length === 1">
+                                <template v-if="resolvedNodesForPhylogeny(selectedPhyloref, phylogeny).length === 1">
                                     <!-- We matched exactly one node -->
-                                    <input readonly type="text" class="form-control" :value="getPhylorefExpectedNodeLabels(phylogeny, selectedPhyloref)[0]">
+                                    <input readonly type="text" class="form-control" :value="resolvedNodesForPhylogeny(selectedPhyloref, phylogeny)[0]">
                                 </template>
-                                <template v-if="getPhylorefExpectedNodeLabels(phylogeny, selectedPhyloref).length > 1">
+                                <template v-if="resolvedNodesForPhylogeny(selectedPhyloref, phylogeny).length > 1">
                                     <!-- We matched more than one node -->
-                                    <input readonly type="text" class="form-control" :value="getPhylorefExpectedNodeLabels(phylogeny, selectedPhyloref).length + ' nodes matched: ' + getPhylorefExpectedNodeLabels(phylogeny, selectedPhyloref).join(', ')">
+                                    <input readonly type="text" class="form-control" :value="resolvedNodesForPhylogeny(selectedPhyloref, phylogeny).length + ' nodes matched: ' + resolvedNodesForPhylogeny(selectedPhyloref, phylogeny).join(', ')">
                                 </template>
 
-                                <!-- Display a dropdown menu that allows the modified label to be changed. -->
+                                <!-- Display a button that activates reasoning. -->
                                 <div class="input-group-btn">
                                     <button
                                         type="button"
-                                        class="btn btn-primary"
+                                        class="btn btn-primary reason-over-phylorefs"
                                         @click="reasonOverPhyloreferences()"
                                         >Reason</button>
                                     </button>

--- a/js/curation-tool.js
+++ b/js/curation-tool.js
@@ -735,6 +735,7 @@ const vm = new Vue({
 
       // Extract the Newick string to render.
       const phylogeny = phylogenyToRender;
+      const { newick = '()' } = phylogeny;
 
       // Once we identify one or more pinning nodes in this phylogeny,
       // we need to highlight all descendants of that node.

--- a/js/curation-tool.js
+++ b/js/curation-tool.js
@@ -1171,9 +1171,17 @@ const vm = new Vue({
         this.reasoningResults = data;
         // console.log('Data retrieved: ', data);
       }).fail((jqXHR, textStatus, errorThrown) => {
+        // We can try using the third argument, but it appears to be the
+        // HTTP status (e.g. 'Internal Server Error'). So we default to that,
+        // but look for a better one in the JSON response from the server, if
+        // available.
         let error = errorThrown;
+        if (this.hasProperty(jqXHR, 'responseJSON') && this.hasProperty(jqXHR.responseJSON, 'error')) {
+          ({ error } = jqXHR.responseJSON);
+        }
+
         if (error === undefined || error === '') error = 'unknown error';
-        this.alert(`Error occurred while reasoning (${textStatus}): ${error}`);
+        this.alert(`Error occurred on server while reasoning: ${error}`);
       }).always(() => {
         $('.reason-over-phylorefs').prop('disabled', false);
         $('.reason-over-phylorefs').html('Reason');

--- a/js/curation-tool.js
+++ b/js/curation-tool.js
@@ -1051,12 +1051,33 @@ const vm = new Vue({
       // Reason over all the phyloreferences and store the results on
       // the Vue model so we can.
 
+      $('.reason-over-phylorefs').html('(reasoning)');
+      $('.reason-over-phylorefs').prop('disabled', true);
       $.post('http://localhost:8080/reason', {
         jsonld: JSON.stringify([new PHYXWrapper(this.testcase).asJSONLD()], undefined, 4),
       }).done((data) => {
         this.reasoningResults = data;
         console.log('Data retrieved: ', data);
+      }).always(() => {
+        $('.reason-over-phylorefs').prop('disabled', false);
+        $('.reason-over-phylorefs').html('Reason');
       });
+    },
+
+    resolvedNodesForPhylogeny(phyloref, phylogeny) {
+      const phylorefCount = this.testcase.phylorefs.indexOf(phyloref) + 1;
+      const phylorefIRI = `http://example.org/produced_by_curation_tool#phyloref${phylorefCount}`;
+
+      // console.log('Looking up phylorefIRI ', phylorefIRI, ' in ', this.reasoningResults);
+      if (!hasProperty(this.reasoningResults, 'phylorefs') || !hasProperty(this.reasoningResults.phylorefs, phylorefIRI)) return [];
+      const nodesResolved = this.reasoningResults.phylorefs[phylorefIRI];
+
+      // To make a list of resolved nodes, let's remove the phylogenyIRI from each node.
+      const phylogenyCount = this.testcase.phylogenies.indexOf(phylogeny) + 1;
+      const phylogenyIRI = `http://example.org/produced_by_curation_tool#phylogeny${phylogenyCount}`;
+
+      // Only return nodes that are part of this phylogeny.
+      return nodesResolved.filter(iri => iri.includes(phylogenyIRI));
     },
   },
 });

--- a/js/curation-tool.js
+++ b/js/curation-tool.js
@@ -817,8 +817,8 @@ const vm = new Vue({
             pinningNodes.push(data);
             PhylogenyWrapper.recurseNodes(data, node => pinningNodeChildrenIRIs.add(node['@id']));
 
-            // Mark this node as a resolved node.
-            element.classed('resolved-node', true);
+            // Mark this node as the pinning node.
+            element.classed('pinning-node', true);
 
             // Make the pinning node circle larger (twice its usual size of 3).
             element.select('circle').attr('r', 6);
@@ -841,10 +841,7 @@ const vm = new Vue({
             if (tunits.length === 0) {
               element.classed('terminal-node-without-tunits', true);
             } else if (this.selectedPhyloref !== undefined) {
-              // If there's a selected phyloref, we should highlight
-              // specifiers:
-              //  - internal specifier in green
-              //  - external specifier in red
+              // We should highlight specifiers.
               if (hasProperty(this.selectedPhyloref, 'internalSpecifiers')) {
                 if (this.selectedPhyloref.internalSpecifiers
                   .some(specifier => wrappedPhylogeny.getNodeLabelsMatchedBySpecifier(specifier)

--- a/js/curation-tool.js
+++ b/js/curation-tool.js
@@ -1163,6 +1163,12 @@ const vm = new Vue({
       $('#reason-over-phylorefs').html('(reasoning)');
       $('#reason-over-phylorefs').prop('disabled', true);
       $.post(JPHYLOREF_REASON_URL, {
+        // This will convert the JSON-LD file into an application/x-www-form-urlencoded
+        // string (see https://api.jquery.com/jquery.ajax/#jQuery-ajax-settings under
+        // processData for details). The POST data sent to the server will look like:
+        //  jsonld=%7B%5B%7B%22title%22%3A...
+        // which translates to:
+        //  jsonld={[{"title":...
         jsonld: JSON.stringify([new PHYXWrapper(this.testcase).asJSONLD()], undefined, 4),
       }).done((data) => {
         this.reasoningResults = data;

--- a/js/curation-tool.js
+++ b/js/curation-tool.js
@@ -316,6 +316,9 @@ const vm = new Vue({
       // Before we load a new study, clear the PHYX caches.
       phyxCacheManager.clear();
 
+      // And reset the reasoning results.
+      this.reasoningResults = {};
+
       const testcase = testcaseToLoad;
 
       try {
@@ -726,9 +729,9 @@ const vm = new Vue({
             // we display it next to the node by creating a new 'text' element.
 
             // Make sure we don't already have an internal label node on this SVG node!
-            const label = element.selectAll('.internal-label');
-            if (label.empty()) {
-              const textLabel = element.append('text');
+            let textLabel = element.selectAll('.internal-label');
+            if (textLabel.empty()) {
+              textLabel = element.append('text');
 
               // Place internal label .3em to the right and below the node itself.
               textLabel.classed('internal-label', true)
@@ -746,6 +749,32 @@ const vm = new Vue({
               ) {
                 textLabel.classed('selected-internal-label', true);
               }
+            }
+
+            // If the internal label has the same IRI as the currently selected
+            // phyloreference's reasoned node, further mark it as the resolved node.
+            //
+            // Note that this node might NOT be labeled, in which case we need to
+            // label it now!
+            if (
+              this.selectedPhyloref !== undefined &&
+              hasProperty(data, '@id') &&
+              this.resolvedNodesForPhylogeny(this.selectedPhyloref, phylogeny).includes(data['@id'])
+            ) {
+              // TODO: maybe replace it with a star placed over the node or something.
+              if (textLabel.empty()) {
+                textLabel = element.append('text');
+
+                // Place internal label .3em to the right and below the node itself.
+                textLabel.classed('internal-label', true)
+                  .text('Actual resolution')
+                  .attr('dx', '.3em')
+                  .attr('dy', '.3em');
+
+                // TODO: perfect place to activate some kind of error!
+              }
+
+              textLabel.classed('resolved-internal-label', true);
             }
           }
 

--- a/js/curation-tool.js
+++ b/js/curation-tool.js
@@ -693,7 +693,6 @@ const vm = new Vue({
 
       // Extract the Newick string to render.
       const phylogeny = phylogenyToRender;
-      const { newick = '()' } = phylogeny;
 
       // Using Phylotree is a four step process:
       //  1. You use d3.layout.phyloref() to create a tree object, which you
@@ -777,7 +776,8 @@ const vm = new Vue({
             }
           }
         });
-      tree(d3.layout.newick_parser(newick));
+      const countPhylogeny = this.testcase.phylogenies.indexOf(phylogeny) + 1;
+      tree(new PhylogenyWrapper(phylogeny).getParsedNewickWithIRIs(`http://example.org/produced_by_curation_tool#phylogeny${countPhylogeny}`));
 
       // Phylotree supports reading the tree back out as Newick, but their Newick
       // representation doesn't annotate internal nodes. We add a method to allow
@@ -804,8 +804,15 @@ const vm = new Vue({
         // be changed, which should cause Vue.js to cause the tree to be
         // re-rendered.
         const node = nodeLCV;
+        const nodeID = hasProperty(node, '@id') ? node['@id'] : '(none)';
         const label = node.name;
         const isNodeLabeled = (label !== undefined && label.trim() !== '');
+
+        d3.layout.phylotree.add_custom_menu(
+          node,
+          () => `Node IRI: ${nodeID}`,
+          () => {},
+        );
 
         d3.layout.phylotree.add_custom_menu(
           node,

--- a/js/curation-tool.js
+++ b/js/curation-tool.js
@@ -152,6 +152,9 @@ const vm = new Vue({
 
     // Example PHYX URLs to display
     examplePHYXURLs,
+
+    // Reasoning results from JPhyloRef
+    reasoningResults: {},
   },
 
   // Computed values inside the data model.
@@ -353,7 +356,7 @@ const vm = new Vue({
       // system -- eventually, we'll rename it to downloadAsJSON and make it
       // export the PHYX file for download.
       const wrapped = new PHYXWrapper(this.testcase);
-      const content = [wrapped.asJSONLD()];
+      const content = [JSON.stringify([wrapped.asJSONLD()], undefined, 4)];
 
       // Save to local hard drive.
       const jsonldFile = new File(content, 'download.json', { type: 'application/json;charset=utf-8' });
@@ -1041,6 +1044,19 @@ const vm = new Vue({
       });
 
       return nodeLabelsWithPrefix;
+    },
+
+    // Reasoning over phyloreferences
+    reasonOverPhyloreferences() {
+      // Reason over all the phyloreferences and store the results on
+      // the Vue model so we can.
+
+      $.post('http://localhost:8080/reason', {
+        jsonld: JSON.stringify([new PHYXWrapper(this.testcase).asJSONLD()], undefined, 4),
+      }).done((data) => {
+        this.reasoningResults = data;
+        console.log('Data retrieved: ', data);
+      });
     },
   },
 });

--- a/js/curation-tool.js
+++ b/js/curation-tool.js
@@ -1160,8 +1160,8 @@ const vm = new Vue({
       // Reason over all the phyloreferences and store the results on
       // the Vue model at vm.reasoningResults so we can access them.
 
-      $('.reason-over-phylorefs').html('(reasoning)');
-      $('.reason-over-phylorefs').prop('disabled', true);
+      $('#reason-over-phylorefs').html('(reasoning)');
+      $('#reason-over-phylorefs').prop('disabled', true);
       $.post(JPHYLOREF_REASON_URL, {
         jsonld: JSON.stringify([new PHYXWrapper(this.testcase).asJSONLD()], undefined, 4),
       }).done((data) => {
@@ -1180,8 +1180,8 @@ const vm = new Vue({
         if (error === undefined || error === '') error = 'unknown error';
         this.alert(`Error occurred on server while reasoning: ${error}`);
       }).always(() => {
-        $('.reason-over-phylorefs').prop('disabled', false);
-        $('.reason-over-phylorefs').html('Reason');
+        $('#reason-over-phylorefs').prop('disabled', false);
+        $('#reason-over-phylorefs').html('Reason');
       });
     },
 

--- a/js/curation-tool.js
+++ b/js/curation-tool.js
@@ -706,7 +706,7 @@ const vm = new Vue({
     },
     getPhylogenyParsingErrors(phylogeny) {
       // Return a list of errors encountered when parsing this phylogeny.
-      const { newick = '()' } = phylogeny;
+      const newick = phylogeny.newick || '()';
       return PhylogenyWrapper.getErrorsInNewickString(newick);
     },
     getPhylogenyAsNewick(nodeExpr, phylogeny) {
@@ -715,7 +715,7 @@ const vm = new Vue({
       // we hijack it to redraw the phylogenies.
 
       // Redraw the phylogeny.
-      const { newick = '()' } = phylogeny;
+      const newick = phylogeny.newick || '()';
       const phylotree = this.renderTree(nodeExpr, phylogeny);
 
       // Return the Newick string that was rendered.
@@ -735,7 +735,7 @@ const vm = new Vue({
 
       // Extract the Newick string to render.
       const phylogeny = phylogenyToRender;
-      const { newick = '()' } = phylogeny;
+      const newick = phylogeny.newick || '()';
 
       // Once we identify one or more pinning nodes in this phylogeny,
       // we need to highlight all descendants of that node.
@@ -1181,7 +1181,7 @@ const vm = new Vue({
         // available.
         let error = errorThrown;
         if (this.hasProperty(jqXHR, 'responseJSON') && this.hasProperty(jqXHR.responseJSON, 'error')) {
-          ({ error } = jqXHR.responseJSON);
+          error = jqXHR.responseJSON.error;
         }
 
         if (error === undefined || error === '') error = 'unknown error';

--- a/js/curation-tool.js
+++ b/js/curation-tool.js
@@ -724,12 +724,12 @@ const vm = new Vue({
           // - data: The data associated with the node being styled
           const wrappedPhylogeny = new PhylogenyWrapper(phylogeny);
 
-          if (hasProperty(data, 'name') && data.children) {
+          // Make sure we don't already have an internal label node on this SVG node!
+          let textLabel = element.selectAll('.internal-label');
+
+          if (hasProperty(data, 'name') && data.name !== '' && data.children) {
             // If the node has a label and has children (i.e. is an internal node),
             // we display it next to the node by creating a new 'text' element.
-
-            // Make sure we don't already have an internal label node on this SVG node!
-            let textLabel = element.selectAll('.internal-label');
             if (textLabel.empty()) {
               textLabel = element.append('text');
 
@@ -750,32 +750,33 @@ const vm = new Vue({
                 textLabel.classed('selected-internal-label', true);
               }
             }
+          }
 
-            // If the internal label has the same IRI as the currently selected
-            // phyloreference's reasoned node, further mark it as the resolved node.
-            //
-            // Note that this node might NOT be labeled, in which case we need to
-            // label it now!
-            if (
-              this.selectedPhyloref !== undefined &&
-              hasProperty(data, '@id') &&
-              this.resolvedNodesForPhylogeny(this.selectedPhyloref, phylogeny).includes(data['@id'])
-            ) {
-              // TODO: maybe replace it with a star placed over the node or something.
-              if (textLabel.empty()) {
-                textLabel = element.append('text');
+          // If the internal label has the same IRI as the currently selected
+          // phyloreference's reasoned node, further mark it as the resolved node.
+          //
+          // Note that this node might NOT be labeled, in which case we need to
+          // label it now!
+          if (
+            this.selectedPhyloref !== undefined &&
+            hasProperty(data, '@id') &&
+            this.resolvedNodesForPhylogeny(this.selectedPhyloref, phylogeny).includes(data['@id'])
+          ) {
+            // TODO: maybe replace it with a star placed over the node or something.
+            // That would work for terminal nodes as well!
+            if (textLabel.empty()) {
+              textLabel = element.append('text');
 
-                // Place internal label .3em to the right and below the node itself.
-                textLabel.classed('internal-label', true)
-                  .text('Actual resolution')
-                  .attr('dx', '.3em')
-                  .attr('dy', '.3em');
+              // Place internal label .3em to the right and below the node itself.
+              textLabel.classed('internal-label', true)
+                .text('Phyloref resolution')
+                .attr('dx', '.3em')
+                .attr('dy', '.3em');
 
-                // TODO: perfect place to activate some kind of error!
-              }
-
-              textLabel.classed('resolved-internal-label', true);
+              // TODO: perfect place to activate some kind of error!
             }
+
+            textLabel.classed('resolved-internal-label', true);
           }
 
           if (data.name !== undefined && data.children === undefined) {

--- a/js/curation-tool.js
+++ b/js/curation-tool.js
@@ -875,7 +875,8 @@ const vm = new Vue({
           }
         });
       const countPhylogeny = this.testcase.phylogenies.indexOf(phylogeny) + 1;
-      tree(new PhylogenyWrapper(phylogeny).getParsedNewickWithIRIs(`http://example.org/produced_by_curation_tool#phylogeny${countPhylogeny}`));
+      tree(new PhylogenyWrapper(phylogeny)
+        .getParsedNewickWithIRIs(PHYXWrapper.getBaseURIForPhylogeny(countPhylogeny)));
 
       // Phylotree supports reading the tree back out as Newick, but their Newick
       // representation doesn't annotate internal nodes. We add a method to allow
@@ -1199,7 +1200,7 @@ const vm = new Vue({
 
       // Convert the phyloreference to an IRI so we can look it up.
       const phylorefCount = this.testcase.phylorefs.indexOf(phyloref) + 1;
-      const phylorefIRI = `http://example.org/produced_by_curation_tool#phyloref${phylorefCount}`;
+      const phylorefIRI = PHYXWrapper.getBaseURIForPhyloref(phylorefCount);
 
       // console.log('Looking up phylorefIRI ', phylorefIRI, ' in ', this.reasoningResults);
       if (!hasProperty(this.reasoningResults, 'phylorefs') || !hasProperty(this.reasoningResults.phylorefs, phylorefIRI)) return [];
@@ -1208,7 +1209,7 @@ const vm = new Vue({
       // We now have a list of all nodes matched by this phyloref, but we're
       // only interested in matches for a single phylogeny.
       const phylogenyCount = this.testcase.phylogenies.indexOf(phylogeny) + 1;
-      const phylogenyIRI = `http://example.org/produced_by_curation_tool#phylogeny${phylogenyCount}`;
+      const phylogenyIRI = PHYXWrapper.getBaseURIForPhylogeny(phylogenyCount);
 
       // Only return nodes that are part of this phylogeny. We can also remove
       // the phylogeny IRI, so we get node identifiers only.

--- a/js/curation-tool.js
+++ b/js/curation-tool.js
@@ -1083,7 +1083,7 @@ const vm = new Vue({
 
       $('.reason-over-phylorefs').html('(reasoning)');
       $('.reason-over-phylorefs').prop('disabled', true);
-      $.post('http://localhost:8080/reason', {
+      $.post('http://localhost:34214/reason', {
         jsonld: JSON.stringify([new PHYXWrapper(this.testcase).asJSONLD()], undefined, 4),
       }).done((data) => {
         this.reasoningResults = data;

--- a/js/phyx.js
+++ b/js/phyx.js
@@ -713,7 +713,7 @@ class PhylogenyWrapper {
         // Set @id and @type.
         const nodeURI = `${baseURI}_node${nodeCount}`;
         nodeAsJSONLD['@id'] = nodeURI;
-        nodeAsJSONLD['@type'] = { '@id': 'http://purl.obolibrary.org/obo/CDAO_0000140' };
+        nodeAsJSONLD['@type'] = 'http://purl.obolibrary.org/obo/CDAO_0000140';
 
         // Add labels, additional node properties and taxonomic units.
         if (hasOwnProperty(node, 'name') && node.name !== '') {
@@ -736,7 +736,7 @@ class PhylogenyWrapper {
             const tunit = tunitToChange;
 
             tunit['@id'] = `${nodeURI}_taxonomicunit${countTaxonomicUnits}`;
-            tunit['@type'] = { '@id': 'http://purl.obolibrary.org/obo/CDAO_0000138' };
+            tunit['@type'] = 'http://purl.obolibrary.org/obo/CDAO_0000138';
             countTaxonomicUnits += 1;
           });
         }
@@ -981,7 +981,7 @@ class PhylorefWrapper {
           const tunit = tunitToChange;
 
           tunit['@id'] = `${specifierId}_tunit${countTaxonomicUnits}`;
-          tunit['@type'] = { '@id': 'http://purl.obolibrary.org/obo/CDAO_0000138' };
+          tunit['@type'] = 'http://purl.obolibrary.org/obo/CDAO_0000138';
           countTaxonomicUnits += 1;
         });
       }
@@ -1006,7 +1006,7 @@ class PhylorefWrapper {
           const tunit = tunitToChange;
 
           tunit['@id'] = `${specifierId}_tunit${countTaxonomicUnits}`;
-          tunit['@type'] = { '@id': 'http://purl.obolibrary.org/obo/CDAO_0000138' };
+          tunit['@type'] = 'http://purl.obolibrary.org/obo/CDAO_0000138';
           countTaxonomicUnits += 1;
         });
       }

--- a/js/phyx.js
+++ b/js/phyx.js
@@ -736,11 +736,13 @@ class PhylogenyWrapper {
           nodeAsJSONLD.representsTaxonomicUnits = this.getTaxonomicUnitsForNodeLabel(node.name);
 
           // Apply @id and @type to each taxonomic unit.
+          let countTaxonomicUnits = 0;
           nodeAsJSONLD.representsTaxonomicUnits.forEach((tunitToChange) => {
             const tunit = tunitToChange;
 
-            tunit['@id'] = `${nodeURI}_taxonomicunit${nodeCount}`;
+            tunit['@id'] = `${nodeURI}_taxonomicunit${countTaxonomicUnits}`;
             tunit['@type'] = { '@id': 'http://purl.obolibrary.org/obo/CDAO_0000138' };
+            countTaxonomicUnits += 1;
           });
         }
 
@@ -974,7 +976,6 @@ class PhylorefWrapper {
       internalSpecifier['@id'] = specifierId;
       internalSpecifier['@type'] = [
         'http://phyloinformatics.net/phyloref.owl#Specifier',
-        'owl:Class',
       ];
 
       // Add identifiers to all taxonomic units.
@@ -995,12 +996,11 @@ class PhylorefWrapper {
       externalSpecifierCount += 1;
 
       const externalSpecifier = externalSpecifierToChange;
-      const specifierId = `${phylorefURI}_specifier_external${internalSpecifierCount}`;
+      const specifierId = `${phylorefURI}_specifier_external${externalSpecifierCount}`;
 
       externalSpecifier['@id'] = specifierId;
       externalSpecifier['@type'] = [
         'http://phyloinformatics.net/phyloref.owl#Specifier',
-        'owl:Class',
       ];
 
       // Add identifiers to all taxonomic units.
@@ -1063,7 +1063,7 @@ class PhylorefWrapper {
       // This phyloreference is made up of one external specifier and some number
       // of internal specifiers.
 
-      const internalSpecifierRestrictions = phylorefAsJSONLD.externalSpecifiers
+      const internalSpecifierRestrictions = phylorefAsJSONLD.internalSpecifiers
         .map(specifier => PhylorefWrapper
           .wrapInternalOWLRestriction(PhylorefWrapper.getOWLRestrictionForSpecifier(specifier)));
 

--- a/js/phyx.js
+++ b/js/phyx.js
@@ -120,22 +120,6 @@ class ScientificNameWrapper {
     return scname;
   }
 
-/*
-  asJSON() {
-    // Return this scientific name as a JSON object.
-
-    const result = {
-      '@id': 'dwc:Taxon',
-      scientificName: this.scientificName,
-    };
-
-    if (this.genus !== undefined) result.genus = this.genus;
-    if (this.specificEpithet !== undefined) result.specificEpithet = this.specificEpithet;
-
-    return result;
-  }
-*/
-
   get scientificName() {
     // Get the "dwc:scientificName" -- the complete scientific name.
     return this.scname.scientificName;

--- a/js/phyx.js
+++ b/js/phyx.js
@@ -716,13 +716,14 @@ class PhylogenyWrapper {
     const nodeIdsByParentId = {};
 
     // Extract the newick string.
-    const { newick = '()' } = this.phylogeny;
+    const { newick = '()', additionalNodeProperties } = this.phylogeny;
 
     // Parse the Newick string; if parseable, recurse through the nodes,
     // added them to the list of JSON-LD nodes as we go.
     const parsed = d3.layout.newick_parser(newick);
     if (hasOwnProperty(parsed, 'json')) {
       PhylogenyWrapper.recurseNodes(parsed.json, (node, nodeCount, parentCount) => {
+        // Start with the additional node properties.
         const nodeAsJSONLD = {};
 
         // Set @id and @type.
@@ -730,9 +731,19 @@ class PhylogenyWrapper {
         nodeAsJSONLD['@id'] = nodeURI;
         nodeAsJSONLD['@type'] = { '@id': 'http://purl.obolibrary.org/obo/CDAO_0000140' };
 
-        // Add label and taxonomic units.
+        // Add labels, additional node properties and taxonomic units.
         if (hasOwnProperty(node, 'name') && node.name !== '') {
+          // Add labels.
           nodeAsJSONLD.labels = [node.name];
+
+          // Add additional node properties, if any.
+          if (additionalNodeProperties && hasOwnProperty(additionalNodeProperties, node.name)) {
+            Object.keys(additionalNodeProperties[node.name]).forEach((key) => {
+              nodeAsJSONLD[key] = additionalNodeProperties[node.name][key];
+            });
+          }
+
+          // Add taxonomic units.
           nodeAsJSONLD.representsTaxonomicUnits = this.getTaxonomicUnitsForNodeLabel(node.name);
 
           // Apply @id and @type to each taxonomic unit.

--- a/js/phyx.js
+++ b/js/phyx.js
@@ -798,6 +798,7 @@ const CDAO_HAS_DESCENDANT = 'obo:CDAO_0000174';
 const PHYLOREF_HAS_SIBLING = 'http://phyloinformatics.net/phyloref.owl#has_Sibling';
 const PHYLOREFERENCE_TEST_CASE = 'testcase:PhyloreferenceTestCase';
 const PHYLOREFERENCE_PHYLOGENY = 'testcase:PhyloreferenceTestPhylogeny';
+const TESTCASE_SPECIFIER = 'testcase:Specifier';
 
 // eslint-disable-next-line no-unused-vars
 class PhylorefWrapper {
@@ -975,7 +976,7 @@ class PhylorefWrapper {
 
       internalSpecifier['@id'] = specifierId;
       internalSpecifier['@type'] = [
-        'http://phyloinformatics.net/phyloref.owl#Specifier',
+        TESTCASE_SPECIFIER,
       ];
 
       // Add identifiers to all taxonomic units.
@@ -1000,7 +1001,7 @@ class PhylorefWrapper {
 
       externalSpecifier['@id'] = specifierId;
       externalSpecifier['@type'] = [
-        'http://phyloinformatics.net/phyloref.owl#Specifier',
+        TESTCASE_SPECIFIER,
       ];
 
       // Add identifiers to all taxonomic units.

--- a/js/phyx.js
+++ b/js/phyx.js
@@ -1050,7 +1050,7 @@ class PhylorefWrapper {
       // These classes are phyloreferences, and so should be classified as such.
       'phyloref:Phyloreference',
 
-      // Since we're writting this in RDF, just adding a '@type' of
+      // Since we're writing this in RDF, just adding a '@type' of
       // phyloref:Phyloreference would imply that phylorefURI is a named
       // individual of class phyloref:Phyloreference. We need to explicitly
       // let OWL know that this phylorefURI is an owl:Class.

--- a/js/phyx.js
+++ b/js/phyx.js
@@ -685,7 +685,7 @@ class PhylogenyWrapper {
     const nodeLabels = new Set();
 
     // Names from the Newick string.
-    const { newick = '()' } = this.phylogeny;
+    const newick = this.phylogeny.newick || '()';
 
     // Parse the Newick string; if parseable, recurse through the node labels,
     // adding them all to 'nodeLabels'.
@@ -761,7 +761,7 @@ class PhylogenyWrapper {
     // Return the parsed Newick string, but with EVERY node given an IRI.
     // baseURI: The base URI to use for node elements (e.g. ':phylogeny1').
 
-    const { newick = '()' } = this.phylogeny;
+    const newick = this.phylogeny.newick || '()';
     const parsed = d3.layout.newick_parser(newick);
     if (hasOwnProperty(parsed, 'json')) {
       PhylogenyWrapper.recurseNodes(parsed.json, (node, nodeCount) => {

--- a/js/phyx.js
+++ b/js/phyx.js
@@ -1047,7 +1047,17 @@ class PhylorefWrapper {
     // Set the @id and @type.
     phylorefAsJSONLD['@id'] = phylorefURI;
     phylorefAsJSONLD['@type'] = [
+      // These classes are phyloreferences, and so should be classified as such.
       'phyloref:Phyloreference',
+
+      // Since we're writting this in RDF, just adding a '@type' of
+      // phyloref:Phyloreference would imply that phylorefURI is a named
+      // individual of class phyloref:Phyloreference. We need to explicitly
+      // let OWL know that this phylorefURI is an owl:Class.
+      //
+      // (This is implied by some of the properties that we apply to phylorefURI,
+      // such as by the domain of owl:equivalentClass. But it's nice to make that
+      // explicit as well!)
       'owl:Class',
     ];
 

--- a/js/phyx.js
+++ b/js/phyx.js
@@ -465,8 +465,8 @@ class TaxonomicUnitMatcher {
       '@type': 'testcase:TUMatch',
       reason: this.matchReason,
       matchesTaxonomicUnits: [
-        this.tunit1,
-        this.tunit2,
+        { '@id': this.tunit1['@id'] },
+        { '@id': this.tunit2['@id'] },
       ],
     };
   }

--- a/js/phyx.js
+++ b/js/phyx.js
@@ -1364,7 +1364,7 @@ class PHYXWrapper {
       jsonld['@context'] = 'http://www.ggvaidya.com/curation-tool/json/phyx.json';
     }
 
-    return JSON.stringify([jsonld], undefined, 4);
+    return jsonld;
   }
 }
 

--- a/json/phyx.json
+++ b/json/phyx.json
@@ -3,6 +3,7 @@
         "xsd": "http://www.w3.org/2001/XMLSchema#"
     }, {
         "_comments": {
+          "@id": "rdfs:comment",
           "_comments": "TOP-LEVEL DOCUMENT PROPERTIES"
         },
 
@@ -31,6 +32,7 @@
         }
     }, {
         "_comments": {
+          "@id": "rdfs:comment",
           "_comments": "Management of nodes and internode relationships"
         },
 
@@ -57,6 +59,7 @@
         }
     }, {
         "_comments": {
+          "@id": "rdfs:comment",
           "_comments": "CDAO and Phyloref properties"
         },
 
@@ -119,6 +122,7 @@
         }
     }, {
         "_comments": {
+          "@id": "rdfs:comment",
           "_comments": "LOW-LEVEL RDF/RDFS/OWL TERMS"
         },
 
@@ -141,6 +145,7 @@
         }
     }, {
         "_comments": {
+          "@id": "rdfs:comment",
           "_comments": "GLUE TO RENDER ONTOLOGY IN RDF"
         },
 
@@ -191,6 +196,7 @@
         }
     }, {
         "_comments": {
+          "@id": "rdfs:comment",
           "_comments": "Properties of individual TUs: scientific name and specimens"
         },
 
@@ -262,6 +268,7 @@
         }
     }, {
         "_comments": {
+          "@id": "rdfs:comment",
           "_comments": "TERMS FROM THE ANNOTATION ONTOLOGY"
         },
 
@@ -288,6 +295,7 @@
         }
     }, {
         "_comments": {
+          "@id": "rdfs:comment",
           "_comments": "TERMS FROM THE PUBLISHING STATUS ONTOLOGY AND RELATED"
         },
 

--- a/json/phyx.json
+++ b/json/phyx.json
@@ -85,27 +85,27 @@
 
         "hasSpecifier": {
             "@id": "testcase:has_specifier",
-            "@type": "@set"
+            "@container": "@set"
         },
 
         "hasInternalSpecifier": {
             "@id": "testcase:has_internal_specifier",
-            "@type": "@set"
+            "@container": "@set"
         },
 
         "hasExternalSpecifier": {
             "@id": "testcase:has_external_specifier",
-            "@type": "@set"
+            "@container": "@set"
         },
 
         "hasUnmatchedSpecifiers": {
             "@id": "testcase:has_unmatched_specifier",
-            "@type": "@set"
+            "@container": "@set"
         },
 
         "hasAdditionalClass": {
             "@id": "testcase:has_additional_class",
-            "@type": "@set"
+            "@container": "@set"
         },
 
         "newick": {
@@ -177,17 +177,17 @@
 
         "externalReferences": {
             "@id": "obo:CDAO_0000164",
-            "@type": "@set"
+            "@container": "@set"
         },
 
         "scientificNames": {
             "@id": "testcase:has_scientific_name",
-            "@type": "@set"
+            "@container": "@set"
         },
 
         "includesSpecimens": {
             "@id": "testcase:includes_specimen",
-            "@type": "@set"
+            "@container": "@set"
         }
     }, {
         "_comments": {
@@ -232,33 +232,33 @@
 
         "hasTaxonomicUnitMatches": {
             "@id": "testcase:has_taxonomic_unit_match",
-            "@type": "@set"
+            "@container": "@set"
         },
 
         "referencesTaxonomicUnits": {
             "@id": "testcase:references_taxonomic_unit",
             "domain": "Specifier",
             "range": "TU",
-            "@type": "@set"
+            "@container": "@set"
         },
 
         "matchesTaxonomicUnits": {
             "@id": "testcase:matches_taxonomic_unit",
             "domain": "TUMatch",
             "range": "TU",
-            "@type": "@set"
+            "@container": "@set"
         },
 
         "representsTaxonomicUnits": {
             "@id": "obo:CDAO_0000187",
             "domain": "Node",
             "range": "TU",
-            "@type": "@set"
+            "@container": "@set"
         },
 
         "specifierWillNotMatch": {
             "@id": "testcase:specifier_will_not_match",
-            "@type": "@set"
+            "@container": "@set"
         }
     }, {
         "_comments": {

--- a/json/phyx.json
+++ b/json/phyx.json
@@ -1,8 +1,11 @@
 {
-    "@context": {
-        "xsd": "http://www.w3.org/2001/XMLSchema#",
+    "@context": [{
+        "xsd": "http://www.w3.org/2001/XMLSchema#"
+    }, {
+        "_comments": {
+          "_comments": "TOP-LEVEL DOCUMENT PROPERTIES"
+        },
 
-        "== TOP-LEVEL DOCUMENT PROPERTIES ==": {},
         "ot": "http://purl.org/opentree/nexson#",
 
         "curator": {
@@ -25,9 +28,12 @@
         "year": {
             "@id": "ot:studyYear",
             "@type": "xsd:integer"
+        }
+    }, {
+        "_comments": {
+          "_comments": "Management of nodes and internode relationships"
         },
 
-        "== Management of nodes and internode relationships ==": {},
         "testcase": "http://vocab.phyloref.org/phyloref/testcase.owl#",
 
         "nodes": {
@@ -48,9 +54,12 @@
         "phylogenies": {
             "@id": "testcase:has_phylogeny",
             "@container": "@set"
+        }
+    }, {
+        "_comments": {
+          "_comments": "CDAO and Phyloref properties"
         },
 
-        "== CDAO and Phyloref properties ==": {},
         "obo": "http://purl.obolibrary.org/obo/",
         "phyloref": "http://phyloinformatics.net/phyloref.owl#",
 
@@ -107,9 +116,12 @@
         "cladeDefinition": {
             "@id": "testcase:clade_definition",
             "@type": "xsd:string"
+        }
+    }, {
+        "_comments": {
+          "_comments": "LOW-LEVEL RDF/RDFS/OWL TERMS"
         },
 
-        "== LOW-LEVEL RDF/RDFS/OWL TERMS ==": {},
         "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
 
         "label": {
@@ -126,9 +138,12 @@
         "comment": {
             "@id": "rdfs:comment",
             "@type": "xsd:string"
+        }
+    }, {
+        "_comments": {
+          "_comments": "GLUE TO RENDER ONTOLOGY IN RDF"
         },
 
-        "== GLUE TO RENDER ONTOLOGY IN RDF ==": {},
         "owl": "http://www.w3.org/2002/07/owl#",
 
         "owl:imports": {
@@ -173,12 +188,13 @@
         "includesSpecimens": {
             "@id": "testcase:includes_specimen",
             "@type": "@set"
+        }
+    }, {
+        "_comments": {
+          "_comments": "Properties of individual TUs: scientific name and specimens"
         },
 
-        "== Properties of individual TUs ==": {},
         "dwc": "http://rs.tdwg.org/dwc/terms/",
-
-        "=== Scientific names ===": {},
 
         "scientificName": {
             "@id": "dwc:scientificName",
@@ -196,8 +212,6 @@
             "@id": "dwc:specificEpithet",
             "@type": "xsd:string"
         },
-
-        "=== Specimen identifiers ===": {},
 
         "occurrenceID": "dwc:occurrenceID",
         "catalogNumber": "dwc:catalogNumber",
@@ -245,10 +259,11 @@
         "specifierWillNotMatch": {
             "@id": "testcase:specifier_will_not_match",
             "@type": "@set"
+        }
+    }, {
+        "_comments": {
+          "_comments": "TERMS FROM THE ANNOTATION ONTOLOGY"
         },
-
-
-        "== TERMS FROM THE ANNOTATION ONTOLOGY ==": {},
 
         "oa": "http://www.w3.org/ns/oa#",
 
@@ -270,12 +285,14 @@
         "annotationBody": {
             "@id": "oa:hasBody",
             "@type": "xsd:string"
+        }
+    }, {
+        "_comments": {
+          "_comments": "TERMS FROM THE PUBLISHING STATUS ONTOLOGY AND RELATED"
         },
-
-        "== TERMS FROM THE PUBLISHING STATUS ONTOLOGY AND RELATED ==": {},
 
         "pso": "http://purl.org/spar/pso/",
         "tvc": "http://www.essepuntato.it/2012/04/tvc/",
         "timeinterval": "http://www.ontologydesignpatterns.org/cp/owl/timeinterval.owl#"
-    }
+    }]
 }

--- a/test/phylogenies.js
+++ b/test/phylogenies.js
@@ -18,7 +18,7 @@ require('../lib/phylotree.js/phylotree.js');
 const chai = require('chai');
 const phyx = require('../js/phyx');
 
-const { assert } = chai;
+const assert = chai.assert;
 
 describe('PhylogenyWrapper', function () {
   describe('#constructor', function () {

--- a/test/phylorefs.js
+++ b/test/phylorefs.js
@@ -20,7 +20,7 @@ require('../lib/phylotree.js/phylotree.js');
 const chai = require('chai');
 const phyx = require('../js/phyx');
 
-const { assert } = chai;
+const assert = chai.assert;
 
 // Some phylogenies to use in testing.
 const phylogeny1 = {

--- a/test/scientific-names.js
+++ b/test/scientific-names.js
@@ -7,7 +7,7 @@
 const chai = require('chai');
 const phyx = require('../js/phyx');
 
-const { assert } = chai;
+const assert = chai.assert;
 
 describe('ScientificNameWrapper', function () {
   describe('#constructor', function () {

--- a/test/specimens.js
+++ b/test/specimens.js
@@ -7,7 +7,7 @@
 const chai = require('chai');
 const phyx = require('../js/phyx');
 
-const { assert } = chai;
+const assert = chai.assert;
 
 describe('SpecimenWrapper', function () {
   describe('#constructor', function () {

--- a/test/taxonomic-units.js
+++ b/test/taxonomic-units.js
@@ -7,7 +7,7 @@
 const chai = require('chai');
 const phyx = require('../js/phyx');
 
-const { assert } = chai;
+const assert = chai.assert;
 
 describe('TaxonomicUnitWrapper', function () {
   describe('#constructor', function () {


### PR DESCRIPTION
Added code that sends the JSON-LD export (implemented in #73) to a server hosted on your local laptop for reasoning (see phyloref/jphyloref#12), and then highlights the results on all included phylogenies by the use of CSS classes. Testing this revealed that the JSON-LD library being used by JPhyloRef couldn't read the JSON-LD context file in phyx.json, so this PR also modifies those so that the Curation Tool is well integrated with JPhyloRef.

I'm holding off on testing the JSON-LD file produced as we can perform ad-hoc testing by seeing if phyloreferences are resolved as expected using JPhyloRef, but this will be tracked by #83.