### PR TITLE
Moved Phyloref status code to phyx.js

### DIFF
--- a/js/curation-tool.js
+++ b/js/curation-tool.js
@@ -9,7 +9,6 @@
 /* global Vue */ // From https://vuejs.org/
 /* global _ */ // From http://underscorejs.org/
 /* global d3 */ // From https://d3js.org/
-/* global moment */ // From https://momentjs.com/
 /* global saveAs */ // From https://github.com/eligrey/FileSaver.js
 
 // These globals are from phyx.js. Eventually, we will replace this with
@@ -469,127 +468,21 @@ const vm = new Vue({
       return PhylorefWrapper.getSpecifierLabel(specifier);
     },
     getPhylorefStatus(phyloref) {
-      // Return a result object that contains:
-      //  - status: phyloreference status as a short URI (CURIE)
-      //  - statusInEnglish: an English representation of the phyloref status
-      //  - intervalStart: the start of the interval
-      //  - intervalEnd: the end of the interval
-
-      if (
-        this.hasProperty(phyloref, 'pso:holdsStatusInTime') &&
-        Array.isArray(phyloref['pso:holdsStatusInTime']) &&
-        phyloref['pso:holdsStatusInTime'].length > 0
-      ) {
-        // If we have any pso:holdsStatusInTime entries, pick the first one and
-        // extract the CURIE and time interval information from it.
-        const lastStatusInTime = phyloref['pso:holdsStatusInTime'][phyloref['pso:holdsStatusInTime'].length - 1];
-        const statusCURIE = lastStatusInTime['pso:withStatus']['@id'];
-
-        // Look for time interval information
-        let intervalStart;
-        let intervalEnd;
-
-        if (this.hasProperty(lastStatusInTime, 'tvc:atTime')) {
-          const atTime = lastStatusInTime['tvc:atTime'];
-          if (this.hasProperty(atTime, 'timeinterval:hasIntervalStartDate')) intervalStart = atTime['timeinterval:hasIntervalStartDate'];
-          if (this.hasProperty(atTime, 'timeinterval:hasIntervalEndDate')) intervalEnd = atTime['timeinterval:hasIntervalEndDate'];
-        }
-
-        // Return result object
-        return {
-          status: statusCURIE,
-          statusInEnglish: this.getPhylorefStatusCURIEsInEnglish()[statusCURIE],
-          intervalStart,
-          intervalEnd,
-        };
-      }
-
-      // If we couldn't figure out a status for this phyloref, assume it's a draft.
-      return {
-        status: 'pso:draft',
-        statusInEnglish: this.getPhylorefStatusCURIEsInEnglish()['pso:draft'],
-      };
+      return new PhylorefWrapper(phyloref).getCurrentStatus();
     },
     getPhylorefStatusCURIEsInEnglish() {
-      // Return dictionary of all phyloref statuses in English
-      return {
-        'pso:draft': 'Draft',
-        'pso:final-draft': 'Final draft',
-        'pso:under-review': 'Under review',
-        'pso:submitted': 'Tested',
-        'pso:published': 'Published',
-        'pso:retracted-from-publication': 'Retracted',
-      };
+      return PhylorefWrapper.getStatusCURIEsInEnglish();
     },
     getPhylorefStatusChanges(phyloref) {
-      // Return a list of status changes for a particular phyloreference
-      if (this.hasProperty(phyloref, 'pso:holdsStatusInTime')) {
-        return phyloref['pso:holdsStatusInTime'].map((entry) => {
-          const result = {};
-
-          // Create a statusCURIE convenience field.
-          if (this.hasProperty(entry, 'pso:withStatus')) {
-            result.statusCURIE = entry['pso:withStatus']['@id'];
-            result.statusInEnglish = this.getPhylorefStatusCURIEsInEnglish()[result.statusCURIE];
-          }
-
-          // Create intervalStart/intervalEnd convenient fields
-          if (this.hasProperty(entry, 'tvc:atTime')) {
-            const atTime = entry['tvc:atTime'];
-            if (this.hasProperty(atTime, 'timeinterval:hasIntervalStartDate')) {
-              result.intervalStart = atTime['timeinterval:hasIntervalStartDate'];
-              result.intervalStartAsCalendar = moment(result.intervalStart).calendar();
-            }
-
-            if (this.hasProperty(atTime, 'timeinterval:hasIntervalEndDate')) {
-              result.intervalEnd = atTime['timeinterval:hasIntervalEndDate'];
-              result.intervalEndAsCalendar = moment(result.intervalEnd).calendar();
-            }
-          }
-
-          return result;
-        });
-      }
-
-      // No changes? Return an empty list.
-      return [];
+      return new PhylorefWrapper(phyloref).getStatusChanges();
     },
-    setPhylorefStatus(phylorefToChange, status) {
-      // Set the status of a phyloreference
-      const phyloref = phylorefToChange;
-
-      if (!this.hasProperty(this.getPhylorefStatusCURIEsInEnglish(), status)) {
+    setPhylorefStatus(phyloref, status) {
+      if (!this.hasProperty(PhylorefWrapper.getStatusCURIEsInEnglish(), status)) {
         this.alert(`Status '${status}' is not a possible status for a Phyloreference`);
         return;
       }
 
-      // See if we can end the previous interval.
-      const currentTime = new Date(Date.now()).toISOString();
-
-      if (!this.hasProperty(phyloref, 'pso:holdsStatusInTime')) Vue.set(phyloref, 'pso:holdsStatusInTime', []);
-
-      // Check to see if there's a previous time interval we should end.
-      if (
-        Array.isArray(phyloref['pso:holdsStatusInTime']) &&
-        phyloref['pso:holdsStatusInTime'].length > 0
-      ) {
-        const lastStatusInTime = phyloref['pso:holdsStatusInTime'][phyloref['pso:holdsStatusInTime'].length - 1];
-
-        if (!this.hasProperty(lastStatusInTime, 'tvc:atTime')) Vue.set(lastStatusInTime, 'tvc:atTime', {});
-        if (!this.hasProperty(lastStatusInTime['tvc:atTime'], 'timeinterval:hasIntervalEndDate')) {
-          // If the last time entry doesn't already have an interval end date, set it to now.
-          lastStatusInTime['tvc:atTime']['timeinterval:hasIntervalEndDate'] = currentTime;
-        }
-      }
-
-      // Create new entry.
-      phyloref['pso:holdsStatusInTime'].push({
-        '@type': 'http://purl.org/spar/pso/StatusInTime',
-        'pso:withStatus': { '@id': status },
-        'tvc:atTime': {
-          'timeinterval:hasIntervalStartDate': currentTime,
-        },
-      });
+      new PhylorefWrapper(phyloref).setStatus(status);
     },
     getPhylorefLabel(phyloref) {
       // Try to determine what the label of a particular phyloreference is,

--- a/js/curation-tool.js
+++ b/js/curation-tool.js
@@ -476,13 +476,13 @@ const vm = new Vue({
     getPhylorefStatusChanges(phyloref) {
       return new PhylorefWrapper(phyloref).getStatusChanges();
     },
-    setPhylorefStatus(phyloref, status) {
-      if (!this.hasProperty(PhylorefWrapper.getStatusCURIEsInEnglish(), status)) {
-        this.alert(`Status '${status}' is not a possible status for a Phyloreference`);
+    setPhylorefStatus(phyloref, statusCURIE) {
+      if (!this.hasProperty(PhylorefWrapper.getStatusCURIEsInEnglish(), statusCURIE)) {
+        this.alert(`Status '${statusCURIE}' is not a possible status for a Phyloreference`);
         return;
       }
 
-      new PhylorefWrapper(phyloref).setStatus(status);
+      new PhylorefWrapper(phyloref).setStatus(statusCURIE);
     },
     getPhylorefLabel(phyloref) {
       // Try to determine what the label of a particular phyloreference is,

--- a/js/phyx.js
+++ b/js/phyx.js
@@ -23,6 +23,7 @@
 // Tell ESLint about globals imported in the HTML page.
 /* global Vue */ // From https://vuejs.org/
 /* global d3 */ // From https://d3js.org/
+/* global moment */ // From https://momentjs.com/
 
 // Our global variables
 // eslint-disable-next-line no-var
@@ -964,6 +965,129 @@ class PhylorefWrapper {
 
     // Return node labels sorted alphabetically.
     return Array.from(nodeLabels).sort();
+  }
+
+  static getStatusCURIEsInEnglish() {
+    // Return dictionary of all phyloref statuses in English
+    return {
+      'pso:draft': 'Draft',
+      'pso:final-draft': 'Final draft',
+      'pso:under-review': 'Under review',
+      'pso:submitted': 'Tested',
+      'pso:published': 'Published',
+      'pso:retracted-from-publication': 'Retracted',
+    };
+  }
+
+  getCurrentStatus() {
+    // Return a result object that contains:
+    //  - status: phyloreference status as a short URI (CURIE)
+    //  - statusInEnglish: an English representation of the phyloref status
+    //  - intervalStart: the start of the interval
+    //  - intervalEnd: the end of the interval
+
+    if (
+      hasOwnProperty(this.phyloref, 'pso:holdsStatusInTime') &&
+      Array.isArray(this.phyloref['pso:holdsStatusInTime']) &&
+      this.phyloref['pso:holdsStatusInTime'].length > 0
+    ) {
+      // If we have any pso:holdsStatusInTime entries, pick the first one and
+      // extract the CURIE and time interval information from it.
+      const lastStatusInTime = this.phyloref['pso:holdsStatusInTime'][this.phyloref['pso:holdsStatusInTime'].length - 1];
+      const statusCURIE = lastStatusInTime['pso:withStatus']['@id'];
+
+      // Look for time interval information
+      let intervalStart;
+      let intervalEnd;
+
+      if (hasOwnProperty(lastStatusInTime, 'tvc:atTime')) {
+        const atTime = lastStatusInTime['tvc:atTime'];
+        if (hasOwnProperty(atTime, 'timeinterval:hasIntervalStartDate')) intervalStart = atTime['timeinterval:hasIntervalStartDate'];
+        if (hasOwnProperty(atTime, 'timeinterval:hasIntervalEndDate')) intervalEnd = atTime['timeinterval:hasIntervalEndDate'];
+      }
+
+      // Return result object
+      return {
+        status: statusCURIE,
+        statusInEnglish: PhylorefWrapper.getStatusCURIEsInEnglish()[statusCURIE],
+        intervalStart,
+        intervalEnd,
+      };
+    }
+
+    // If we couldn't figure out a status for this phyloref, assume it's a draft.
+    return {
+      status: 'pso:draft',
+      statusInEnglish: PhylorefWrapper.getStatusCURIEsInEnglish()['pso:draft'],
+    };
+  }
+
+  getStatusChanges() {
+    // Return a list of status changes for a particular phyloreference
+    if (hasOwnProperty(this.phyloref, 'pso:holdsStatusInTime')) {
+      return this.phyloref['pso:holdsStatusInTime'].map((entry) => {
+        const result = {};
+
+        // Create a statusCURIE convenience field.
+        if (hasOwnProperty(entry, 'pso:withStatus')) {
+          result.statusCURIE = entry['pso:withStatus']['@id'];
+          result.statusInEnglish = PhylorefWrapper.getStatusCURIEsInEnglish()[result.statusCURIE];
+        }
+
+        // Create intervalStart/intervalEnd convenient fields
+        if (hasOwnProperty(entry, 'tvc:atTime')) {
+          const atTime = entry['tvc:atTime'];
+          if (hasOwnProperty(atTime, 'timeinterval:hasIntervalStartDate')) {
+            result.intervalStart = atTime['timeinterval:hasIntervalStartDate'];
+            result.intervalStartAsCalendar = moment(result.intervalStart).calendar();
+          }
+
+          if (hasOwnProperty(atTime, 'timeinterval:hasIntervalEndDate')) {
+            result.intervalEnd = atTime['timeinterval:hasIntervalEndDate'];
+            result.intervalEndAsCalendar = moment(result.intervalEnd).calendar();
+          }
+        }
+
+        return result;
+      });
+    }
+
+    // No changes? Return an empty list.
+    return [];
+  }
+
+  setStatus(status) {
+    // Set the status of a phyloreference
+    //
+    // See if we can end the previous interval.
+    const currentTime = new Date(Date.now()).toISOString();
+
+    if (!hasOwnProperty(this.phyloref, 'pso:holdsStatusInTime')) {
+      Vue.set(this.phyloref, 'pso:holdsStatusInTime', []);
+    }
+
+    // Check to see if there's a previous time interval we should end.
+    if (
+      Array.isArray(this.phyloref['pso:holdsStatusInTime']) &&
+      this.phyloref['pso:holdsStatusInTime'].length > 0
+    ) {
+      const lastStatusInTime = this.phyloref['pso:holdsStatusInTime'][this.phyloref['pso:holdsStatusInTime'].length - 1];
+
+      if (!hasOwnProperty(lastStatusInTime, 'tvc:atTime')) Vue.set(lastStatusInTime, 'tvc:atTime', {});
+      if (!hasOwnProperty(lastStatusInTime['tvc:atTime'], 'timeinterval:hasIntervalEndDate')) {
+        // If the last time entry doesn't already have an interval end date, set it to now.
+        lastStatusInTime['tvc:atTime']['timeinterval:hasIntervalEndDate'] = currentTime;
+      }
+    }
+
+    // Create new entry.
+    this.phyloref['pso:holdsStatusInTime'].push({
+      '@type': 'http://purl.org/spar/pso/StatusInTime',
+      'pso:withStatus': { '@id': status },
+      'tvc:atTime': {
+        'timeinterval:hasIntervalStartDate': currentTime,
+      },
+    });
   }
 
   exportAsJSONLD(phylorefURI) {

--- a/js/phyx.js
+++ b/js/phyx.js
@@ -1059,6 +1059,11 @@ class PhylorefWrapper {
   setStatus(status) {
     // Set the status of a phyloreference
     //
+    // Check whether we have a valid status CURIE.
+    if (!hasOwnProperty(PhylorefWrapper.getStatusCURIEsInEnglish(), status)) {
+      throw new TypeError(`setStatus() called with invalid status CURIE '${status}'`);
+    }
+
     // See if we can end the previous interval.
     const currentTime = new Date(Date.now()).toISOString();
 

--- a/js/phyx.js
+++ b/js/phyx.js
@@ -1008,7 +1008,7 @@ class PhylorefWrapper {
 
       // Return result object
       return {
-        status: statusCURIE,
+        statusCURIE,
         statusInEnglish: PhylorefWrapper.getStatusCURIEsInEnglish()[statusCURIE],
         intervalStart,
         intervalEnd,
@@ -1017,7 +1017,7 @@ class PhylorefWrapper {
 
     // If we couldn't figure out a status for this phyloref, assume it's a draft.
     return {
-      status: 'pso:draft',
+      statusCURIE: 'pso:draft',
       statusInEnglish: PhylorefWrapper.getStatusCURIEsInEnglish()['pso:draft'],
     };
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1641,6 +1641,12 @@
         }
       }
     },
+    "moment": {
+      "version": "2.22.2",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.22.2.tgz",
+      "integrity": "sha1-PCV/mDn8DpP/UxSWMiOeuQeD/2Y=",
+      "dev": true
+    },
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "eslint-plugin-json": "^1.2.0",
     "eslint-plugin-mocha": "^5.0.0",
     "eslint-plugin-vue": "^4.5.0",
-    "mocha": "^5.2.0"
+    "mocha": "^5.2.0",
+    "moment": "^2.22.2"
   },
   "dependencies": {
     "d3": "^5.5.0",

--- a/test/phylorefs.js
+++ b/test/phylorefs.js
@@ -6,6 +6,9 @@
 
 global.Vue = require('vue');
 
+// Load moment as a global variable so it can be accessed by phyx.js.
+global.moment = require('moment');
+
 // Load d3 as a global variable so it can be accessed by both phylotree.js (which
 // needs to add additional objects to it) and phyx (which needs to call it).
 global.d3 = require('d3');
@@ -123,5 +126,34 @@ describe('PhylorefWrapper', function () {
         ['Test'],
       );
     });
+  });
+
+  describe('#statuses', function () {
+    const wrapper = new phyx.PhylorefWrapper({});
+
+    // Initially, an empty phyloref should report a status of 'pso:draft'.
+    assert.equal(wrapper.getCurrentStatus().status, 'pso:draft');
+
+    // Let's try updating a bunch of status.
+    wrapper.setStatus('pso:final-draft');
+    wrapper.setStatus('pso:under-review');
+    wrapper.setStatus('pso:submitted');
+    wrapper.setStatus('pso:published');
+    wrapper.setStatus('pso:retracted-from-publication');
+    assert.throws(
+      function () { wrapper.setStatus('pso:retracted-from_publication'); },
+      TypeError,
+      'setStatus() called with invalid status CURIE \'pso:retracted-from_publication\'',
+      'PhylorefWrapper throws TypeError on a mistyped status',
+    );
+
+    // And see if we get the statuses back in the correct order.
+    const statusChanges = wrapper.getStatusChanges();
+    assert.equal(statusChanges.length, 5);
+    assert.equal(statusChanges[0].statusCURIE, 'pso:final-draft');
+    assert.equal(statusChanges[1].statusCURIE, 'pso:under-review');
+    assert.equal(statusChanges[2].statusCURIE, 'pso:submitted');
+    assert.equal(statusChanges[3].statusCURIE, 'pso:published');
+    assert.equal(statusChanges[4].statusCURIE, 'pso:retracted-from-publication');
   });
 });

--- a/test/phylorefs.js
+++ b/test/phylorefs.js
@@ -129,31 +129,33 @@ describe('PhylorefWrapper', function () {
   });
 
   describe('#statuses', function () {
-    const wrapper = new phyx.PhylorefWrapper({});
+    it('should be able to update statuses while tracking them', function () {
+      const wrapper = new phyx.PhylorefWrapper({});
 
-    // Initially, an empty phyloref should report a status of 'pso:draft'.
-    assert.equal(wrapper.getCurrentStatus().status, 'pso:draft');
+      // Initially, an empty phyloref should report a status of 'pso:draft'.
+      assert.equal(wrapper.getCurrentStatus().status, 'pso:draft');
 
-    // Let's try updating a bunch of status.
-    wrapper.setStatus('pso:final-draft');
-    wrapper.setStatus('pso:under-review');
-    wrapper.setStatus('pso:submitted');
-    wrapper.setStatus('pso:published');
-    wrapper.setStatus('pso:retracted-from-publication');
-    assert.throws(
-      function () { wrapper.setStatus('pso:retracted-from_publication'); },
-      TypeError,
-      'setStatus() called with invalid status CURIE \'pso:retracted-from_publication\'',
-      'PhylorefWrapper throws TypeError on a mistyped status',
-    );
+      // Let's try updating a bunch of status.
+      wrapper.setStatus('pso:final-draft');
+      wrapper.setStatus('pso:under-review');
+      wrapper.setStatus('pso:submitted');
+      wrapper.setStatus('pso:published');
+      wrapper.setStatus('pso:retracted-from-publication');
+      assert.throws(
+        function () { wrapper.setStatus('pso:retracted-from_publication'); },
+        TypeError,
+        'setStatus() called with invalid status CURIE \'pso:retracted-from_publication\'',
+        'PhylorefWrapper throws TypeError on a mistyped status',
+      );
 
-    // And see if we get the statuses back in the correct order.
-    const statusChanges = wrapper.getStatusChanges();
-    assert.equal(statusChanges.length, 5);
-    assert.equal(statusChanges[0].statusCURIE, 'pso:final-draft');
-    assert.equal(statusChanges[1].statusCURIE, 'pso:under-review');
-    assert.equal(statusChanges[2].statusCURIE, 'pso:submitted');
-    assert.equal(statusChanges[3].statusCURIE, 'pso:published');
-    assert.equal(statusChanges[4].statusCURIE, 'pso:retracted-from-publication');
+      // And see if we get the statuses back in the correct order.
+      const statusChanges = wrapper.getStatusChanges();
+      assert.equal(statusChanges.length, 5);
+      assert.equal(statusChanges[0].statusCURIE, 'pso:final-draft');
+      assert.equal(statusChanges[1].statusCURIE, 'pso:under-review');
+      assert.equal(statusChanges[2].statusCURIE, 'pso:submitted');
+      assert.equal(statusChanges[3].statusCURIE, 'pso:published');
+      assert.equal(statusChanges[4].statusCURIE, 'pso:retracted-from-publication');
+    });
   });
 });

--- a/test/phylorefs.js
+++ b/test/phylorefs.js
@@ -133,7 +133,7 @@ describe('PhylorefWrapper', function () {
       const wrapper = new phyx.PhylorefWrapper({});
 
       // Initially, an empty phyloref should report a status of 'pso:draft'.
-      assert.equal(wrapper.getCurrentStatus().status, 'pso:draft');
+      assert.equal(wrapper.getCurrentStatus().statusCURIE, 'pso:draft');
 
       // Let's try updating a bunch of status.
       wrapper.setStatus('pso:final-draft');


### PR DESCRIPTION
Determining phyloref status should be handled in phyx.js and properly tested there as per #72. This PR does that.

**Do not merge** until after #73 and #77 have been merged and reviewed.