### PR TITLE
Fix the phylogeny spacing bug

### DIFF
--- a/index.html
+++ b/index.html
@@ -273,8 +273,8 @@
                             Vertical spacing: {{ getPhylogenySpacingX(phylogenyIndex) }}px <span class="caret"></span>
                           </button>
                           <ul class="dropdown-menu">
-                            <li><a :href="'#phylogeny-' + phylogenyIndex + '-footer'" @click="phylogenySpacingX[phylogenyIndex] += 10">Increase scale</a></li>
-                            <li><a :href="'#phylogeny-' + phylogenyIndex + '-footer'" @click="phylogenySpacingX[phylogenyIndex] = (phylogenySpacingX[phylogenyIndex] < 10 ? 0 : phylogenySpacingX[phylogenyIndex] - 10)">Decrease scale</a></li>
+                            <li><a :href="'#phylogeny-' + phylogenyIndex + '-footer'" @click="changePhylogenySpacingX(phylogenyIndex, +10)">Increase scale</a></li>
+                            <li><a :href="'#phylogeny-' + phylogenyIndex + '-footer'" @click="changePhylogenySpacingX(phylogenyIndex, -10)">Decrease scale</a></li>
                           </ul>
                         </div>
 
@@ -284,8 +284,8 @@
                             Horizontal spacing: {{ getPhylogenySpacingY(phylogenyIndex) }}px <span class="caret"></span>
                           </button>
                           <ul class="dropdown-menu">
-                            <li><a :href="'#phylogeny-' + phylogenyIndex + '-footer'" @click="phylogenySpacingY[phylogenyIndex] += 10">Increase scale</a></li>
-                            <li><a :href="'#phylogeny-' + phylogenyIndex + '-footer'" @click="phylogenySpacingY[phylogenyIndex] = (phylogenySpacingY[phylogenyIndex] < 10 ? 0 : phylogenySpacingY[phylogenyIndex] - 10)">Decrease scale</a></li>
+                            <li><a :href="'#phylogeny-' + phylogenyIndex + '-footer'" @click="changePhylogenySpacingY(phylogenyIndex, +10)">Increase scale</a></li>
+                            <li><a :href="'#phylogeny-' + phylogenyIndex + '-footer'" @click="changePhylogenySpacingY(phylogenyIndex, -10)">Decrease scale</a></li>
                           </ul>
                         </div>
 

--- a/index.html
+++ b/index.html
@@ -270,22 +270,22 @@
                         <!-- Dropdown button for vertical spacing -->
                         <div class="btn-group" role="group">
                           <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                            Vertical spacing: {{ phylogenySpacingX[phylogeny] }}px <span class="caret"></span>
+                            Vertical spacing: {{ getPhylogenySpacingX(phylogenyIndex) }}px <span class="caret"></span>
                           </button>
                           <ul class="dropdown-menu">
-                            <li><a :href="'#phylogeny-' + phylogenyIndex + '-footer'" @click="phylogenySpacingX[phylogeny] += 10">Increase scale</a></li>
-                            <li><a :href="'#phylogeny-' + phylogenyIndex + '-footer'" @click="phylogenySpacingX[phylogeny] = (phylogenySpacingX[phylogeny] < 10 ? 0 : phylogenySpacingX[phylogeny] - 10)">Decrease scale</a></li>
+                            <li><a :href="'#phylogeny-' + phylogenyIndex + '-footer'" @click="phylogenySpacingX[phylogenyIndex] += 10">Increase scale</a></li>
+                            <li><a :href="'#phylogeny-' + phylogenyIndex + '-footer'" @click="phylogenySpacingX[phylogenyIndex] = (phylogenySpacingX[phylogenyIndex] < 10 ? 0 : phylogenySpacingX[phylogenyIndex] - 10)">Decrease scale</a></li>
                           </ul>
                         </div>
 
                         <!-- Dropdown button for horizontal spacing -->
                         <div class="btn-group" role="group">
                           <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                            Horizontal spacing: {{ phylogenySpacingY[phylogeny] }}px <span class="caret"></span>
+                            Horizontal spacing: {{ getPhylogenySpacingY(phylogenyIndex) }}px <span class="caret"></span>
                           </button>
                           <ul class="dropdown-menu">
-                            <li><a :href="'#phylogeny-' + phylogenyIndex + '-footer'" @click="phylogenySpacingY[phylogeny] += 10">Increase scale</a></li>
-                            <li><a :href="'#phylogeny-' + phylogenyIndex + '-footer'" @click="phylogenySpacingY[phylogeny] = (phylogenySpacingY[phylogeny] < 10 ? 0 : phylogenySpacingY[phylogeny] - 10)">Decrease scale</a></li>
+                            <li><a :href="'#phylogeny-' + phylogenyIndex + '-footer'" @click="phylogenySpacingY[phylogenyIndex] += 10">Increase scale</a></li>
+                            <li><a :href="'#phylogeny-' + phylogenyIndex + '-footer'" @click="phylogenySpacingY[phylogenyIndex] = (phylogenySpacingY[phylogenyIndex] < 10 ? 0 : phylogenySpacingY[phylogenyIndex] - 10)">Decrease scale</a></li>
                           </ul>
                         </div>
 

--- a/js/curation-tool.js
+++ b/js/curation-tool.js
@@ -947,10 +947,6 @@ const vm = new Vue({
 
       let spacing = this.phylogenySpacingX[phylogenyIndex] + changeBy;
       this.phylogenySpacingX[phylogenyIndex] = spacing < MIN_SPACING_X ? MIN_SPACING_X : spacing;
-
-      if (this.phylogenySpacingX[phylogenyIndex] < MIN_SPACING_X) {
-        this.phylogenySpacingX[phylogenyIndex] = MIN_SPACING_X;
-      }
     },
 
     getPhylogenySpacingY(phylogenyIndex) {
@@ -973,10 +969,6 @@ const vm = new Vue({
 
       let spacing = this.phylogenySpacingY[phylogenyIndex] + changeBy;
       this.phylogenySpacingY[phylogenyIndex] = spacing < MIN_SPACING_Y ? MIN_SPACING_Y : spacing;
-
-      if (this.phylogenySpacingY[phylogenyIndex] < MIN_SPACING_Y) {
-        this.phylogenySpacingY[phylogenyIndex] = MIN_SPACING_Y;
-      }
     },
 
     // Methods for creating new, empty data model elements.

--- a/js/curation-tool.js
+++ b/js/curation-tool.js
@@ -43,6 +43,10 @@ const examplePHYXURLs = [
 // URL to be used to send JPhyloRef /reason requests.
 const JPHYLOREF_REASON_URL = 'http://localhost:34214/reason';
 
+// Default spacing X and Y for phyloreferences.
+const DEFAULT_SPACING_X = 20;
+const DEFAULT_SPACING_Y = 40;
+
 // Helper methods for this library.
 
 /**
@@ -160,6 +164,10 @@ const vm = new Vue({
     // testcase.
     phylogenySpacingX: {},
     phylogenySpacingY: {},
+
+    // Default spacing
+    DEFAULT_SPACING_X,
+    DEFAULT_SPACING_Y,
 
     // Example PHYX URLs to display.
     examplePHYXURLs,
@@ -375,6 +383,7 @@ const vm = new Vue({
         // Reset phylogeny scaling information.
         this.phylogenySpacingX = {};
         this.phylogenySpacingY = {};
+
       } catch (err) {
         throw new Error(`Error occurred while displaying new testcase: ${err}`);
       }
@@ -894,19 +903,43 @@ const vm = new Vue({
       // phylogeny itself. Therefore, I'm storing them elsewhere in the Vue
       // model -- users will need to set the scaling every time they open this
       // PHYX file.
-      if (!this.hasProperty(this.phylogenySpacingX, phylogeny)) {
-        Vue.set(this.phylogenySpacingX, phylogeny, 20);
+      const phylogenyIndex = this.testcase.phylogenies.indexOf(phylogeny);
+      if (!this.hasProperty(this.phylogenySpacingX, phylogenyIndex)) {
+        Vue.set(this.phylogenySpacingX, phylogenyIndex, DEFAULT_SPACING_X);
       }
-      if (!this.hasProperty(this.phylogenySpacingY, phylogeny)) {
-        Vue.set(this.phylogenySpacingY, phylogeny, 40);
+      if (!this.hasProperty(this.phylogenySpacingY, phylogenyIndex)) {
+        Vue.set(this.phylogenySpacingY, phylogenyIndex, DEFAULT_SPACING_Y);
       }
-
+      
       tree
-        .spacing_x(this.phylogenySpacingX[phylogeny])
-        .spacing_y(this.phylogenySpacingY[phylogeny])
+        .spacing_x(this.phylogenySpacingX[phylogenyIndex])
+        .spacing_y(this.phylogenySpacingY[phylogenyIndex])
         .placenodes()
         .update();
       return tree;
+    },
+
+    // Get and set phylogeny spacing information.
+    getPhylogenySpacingX(phylogenyIndex) {
+      // Return the phylogeny spacing in the X dimension for a particular phylogeny by index.
+      // Will set up the spacing variable if it has not been created yet, so this should be
+      // called before accessing this.phylogenySpacingX directly.
+      if (!this.hasProperty(this.phylogenySpacingX, phylogenyIndex)) {
+        Vue.set(this.phylogenySpacingX, phylogenyIndex, DEFAULT_SPACING_X);
+      }
+
+      return this.phylogenySpacingX[phylogenyIndex];
+    },
+
+    getPhylogenySpacingY(phylogenyIndex) {
+      // Return the phylogeny spacing in the Y dimension for a particular phylogeny by index.
+      // Will set up the spacing variable if it has not been created yet, so this should be
+      // called before accessing this.phylogenySpacingY directly.
+      if (!this.hasProperty(this.phylogenySpacingY, phylogenyIndex)) {
+        Vue.set(this.phylogenySpacingY, phylogenyIndex, DEFAULT_SPACING_Y);
+      }
+       
+      return this.phylogenySpacingY[phylogenyIndex];
     },
 
     // Methods for creating new, empty data model elements.

--- a/js/curation-tool.js
+++ b/js/curation-tool.js
@@ -971,7 +971,8 @@ const vm = new Vue({
         Vue.set(this.phylogenySpacingY, phylogenyIndex, DEFAULT_SPACING_Y);
       }
 
-      this.phylogenySpacingY[phylogenyIndex] += changeBy;
+      let spacing = this.phylogenySpacingY[phylogenyIndex] + changeBy;
+      this.phylogenySpacingY[phylogenyIndex] = spacing < MIN_SPACING_Y ? MIN_SPACING_Y : spacing;
 
       if (this.phylogenySpacingY[phylogenyIndex] < MIN_SPACING_Y) {
         this.phylogenySpacingY[phylogenyIndex] = MIN_SPACING_Y;

--- a/js/curation-tool.js
+++ b/js/curation-tool.js
@@ -945,7 +945,8 @@ const vm = new Vue({
         Vue.set(this.phylogenySpacingX, phylogenyIndex, DEFAULT_SPACING_X);
       }
 
-      this.phylogenySpacingX[phylogenyIndex] += changeBy;
+      let spacing = this.phylogenySpacingX[phylogenyIndex] + changeBy;
+      this.phylogenySpacingX[phylogenyIndex] = spacing < MIN_SPACING_X ? MIN_SPACING_X : spacing;
 
       if (this.phylogenySpacingX[phylogenyIndex] < MIN_SPACING_X) {
         this.phylogenySpacingX[phylogenyIndex] = MIN_SPACING_X;

--- a/js/curation-tool.js
+++ b/js/curation-tool.js
@@ -383,7 +383,6 @@ const vm = new Vue({
         // Reset phylogeny scaling information.
         this.phylogenySpacingX = {};
         this.phylogenySpacingY = {};
-
       } catch (err) {
         throw new Error(`Error occurred while displaying new testcase: ${err}`);
       }
@@ -910,7 +909,7 @@ const vm = new Vue({
       if (!this.hasProperty(this.phylogenySpacingY, phylogenyIndex)) {
         Vue.set(this.phylogenySpacingY, phylogenyIndex, DEFAULT_SPACING_Y);
       }
-      
+
       tree
         .spacing_x(this.phylogenySpacingX[phylogenyIndex])
         .spacing_y(this.phylogenySpacingY[phylogenyIndex])
@@ -938,7 +937,7 @@ const vm = new Vue({
       if (!this.hasProperty(this.phylogenySpacingY, phylogenyIndex)) {
         Vue.set(this.phylogenySpacingY, phylogenyIndex, DEFAULT_SPACING_Y);
       }
-       
+
       return this.phylogenySpacingY[phylogenyIndex];
     },
 

--- a/js/curation-tool.js
+++ b/js/curation-tool.js
@@ -945,7 +945,7 @@ const vm = new Vue({
         Vue.set(this.phylogenySpacingX, phylogenyIndex, DEFAULT_SPACING_X);
       }
 
-      let spacing = this.phylogenySpacingX[phylogenyIndex] + changeBy;
+      const spacing = this.phylogenySpacingX[phylogenyIndex] + changeBy;
       this.phylogenySpacingX[phylogenyIndex] = spacing < MIN_SPACING_X ? MIN_SPACING_X : spacing;
     },
 
@@ -967,7 +967,7 @@ const vm = new Vue({
         Vue.set(this.phylogenySpacingY, phylogenyIndex, DEFAULT_SPACING_Y);
       }
 
-      let spacing = this.phylogenySpacingY[phylogenyIndex] + changeBy;
+      const spacing = this.phylogenySpacingY[phylogenyIndex] + changeBy;
       this.phylogenySpacingY[phylogenyIndex] = spacing < MIN_SPACING_Y ? MIN_SPACING_Y : spacing;
     },
 

--- a/js/curation-tool.js
+++ b/js/curation-tool.js
@@ -43,9 +43,11 @@ const examplePHYXURLs = [
 // URL to be used to send JPhyloRef /reason requests.
 const JPHYLOREF_REASON_URL = 'http://localhost:34214/reason';
 
-// Default spacing X and Y for phyloreferences.
+// Default and minimal spacing X and Y for phylogenies.
 const DEFAULT_SPACING_X = 20;
+const MIN_SPACING_X = 10;
 const DEFAULT_SPACING_Y = 40;
+const MIN_SPACING_Y = 10;
 
 // Helper methods for this library.
 
@@ -936,6 +938,20 @@ const vm = new Vue({
       return this.phylogenySpacingX[phylogenyIndex];
     },
 
+    changePhylogenySpacingX(phylogenyIndex, changeBy) {
+      // Change the phylogeny spacing in the X dimension by the changeBy value.
+      // We prevent the value from going below MIN_SPACING_X.
+      if (!this.hasProperty(this.phylogenySpacingX, phylogenyIndex)) {
+        Vue.set(this.phylogenySpacingX, phylogenyIndex, DEFAULT_SPACING_X);
+      }
+
+      this.phylogenySpacingX[phylogenyIndex] += changeBy;
+
+      if (this.phylogenySpacingX[phylogenyIndex] < MIN_SPACING_X) {
+        this.phylogenySpacingX[phylogenyIndex] = MIN_SPACING_X;
+      }
+    },
+
     getPhylogenySpacingY(phylogenyIndex) {
       // Return the phylogeny spacing in the Y dimension for a particular phylogeny by index.
       // Will set up the spacing variable if it has not been created yet, so this should be
@@ -945,6 +961,20 @@ const vm = new Vue({
       }
 
       return this.phylogenySpacingY[phylogenyIndex];
+    },
+
+    changePhylogenySpacingY(phylogenyIndex, changeBy) {
+      // Change the phylogeny spacing in the Y dimension by the changeBy value.
+      // We prevent the value from going below MIN_SPACING_Y.
+      if (!this.hasProperty(this.phylogenySpacingY, phylogenyIndex)) {
+        Vue.set(this.phylogenySpacingY, phylogenyIndex, DEFAULT_SPACING_Y);
+      }
+
+      this.phylogenySpacingY[phylogenyIndex] += changeBy;
+
+      if (this.phylogenySpacingY[phylogenyIndex] < MIN_SPACING_Y) {
+        this.phylogenySpacingY[phylogenyIndex] = MIN_SPACING_Y;
+      }
     },
 
     // Methods for creating new, empty data model elements.

--- a/js/curation-tool.js
+++ b/js/curation-tool.js
@@ -1149,3 +1149,10 @@ const vm = new Vue({
     },
   },
 });
+
+/* Exports */
+if (!hasProperty(this, 'window')) {
+  module.exports = {
+    vm,
+  };
+}

--- a/js/curation-tool.js
+++ b/js/curation-tool.js
@@ -380,7 +380,7 @@ const vm = new Vue({
         this.selectedSpecifier = undefined;
         this.selectedTUnit = undefined;
 
-        // Reset phylogeny scaling information.
+        // Reset phylogeny spacing information.
         this.phylogenySpacingX = {};
         this.phylogenySpacingY = {};
       } catch (err) {
@@ -900,9 +900,14 @@ const vm = new Vue({
       // from computer to computer. However, they are specific to the display
       // on which the phylogeny was curated and are otherwise unrelated to the
       // phylogeny itself. Therefore, I'm storing them elsewhere in the Vue
-      // model -- users will need to set the scaling every time they open this
+      // model -- users will need to set the spacing every time they open this
       // PHYX file.
+
+      // Phylogeny-specific spacing is stored by the index number of the phylogeny.
       const phylogenyIndex = this.testcase.phylogenies.indexOf(phylogeny);
+
+      // If either spacingX or spacingY is not already set, we set them to their
+      // defaults.
       if (!this.hasProperty(this.phylogenySpacingX, phylogenyIndex)) {
         Vue.set(this.phylogenySpacingX, phylogenyIndex, DEFAULT_SPACING_X);
       }
@@ -910,6 +915,7 @@ const vm = new Vue({
         Vue.set(this.phylogenySpacingY, phylogenyIndex, DEFAULT_SPACING_Y);
       }
 
+      // Place and update the nodes on the phylogeny.
       tree
         .spacing_x(this.phylogenySpacingX[phylogenyIndex])
         .spacing_y(this.phylogenySpacingY[phylogenyIndex])

--- a/test/vue-model.js
+++ b/test/vue-model.js
@@ -1,0 +1,68 @@
+/*
+ * Test aspects of the Curation Tool Vue model.
+ */
+
+/* eslint-env mocha */
+
+// Load d3 as a global variable so it can be accessed by both phylotree.js (which
+// needs to add additional objects to it) and phyx (which needs to call it).
+global.d3 = require('d3');
+
+// phylotree.js does not export functions itself, but adds them to global.d3.layout.
+// So we set up a global.d3.layout object for them to be added to.
+if (!Object.prototype.hasOwnProperty.call(global.d3, 'layout')) {
+  global.d3.layout = {};
+}
+require('../lib/phylotree.js/phylotree.js');
+
+// Load the Curation Tool code, which exports only the Vue model as 'vm'.
+// Store that in a variable for easy access.
+const ct = require('../js/curation-tool.js');
+const vm = ct.vm;
+
+const chai = require('chai');
+const phyx = require('../js/phyx');
+
+const assert = chai.assert;
+
+// Test phylogeny spacingX and spacingY.
+describe('Phylogeny spacing', function () {
+  describe('spacingX', function () {
+    it('should be modifiable', function () {
+      // We can use phylogeny index 0, since the UI creates an initial phylogeny by default.
+      var spacingX = vm.getPhylogenySpacingX(0);
+      assert.isOk(spacingX);
+      assert.equal(spacingX, vm.DEFAULT_SPACING_X, 'Initial spacingX should be set to the default');
+
+      // To set the phylogeny, we need to set the variable directly.
+      vm.phylogenySpacingX[0] = 104;
+      assert.equal(vm.getPhylogenySpacingX(0), 104, 'spacingX can be changed by modifying the returned value');
+    });
+
+    it('should not be shared by all phylogenies', function () {
+      // Set the spacing value for the second phylogeny.
+      vm.phylogenySpacingX[1] = 208;
+      assert.equal(vm.getPhylogenySpacingX(1), 208, 'spacingX[1] has a new value');
+      assert.equal(vm.getPhylogenySpacingX(0), 104, 'spacingX[0] retains its existing value from the previous test');
+    });
+  });
+  describe('spacingY', function () {
+    it('should be modifiable', function () {
+      // We can use phylogeny index 0, since the UI creates an initial phylogeny by default.
+      var spacingY = vm.getPhylogenySpacingY(0);
+      assert.isOk(spacingY);
+      assert.equal(spacingY, vm.DEFAULT_SPACING_Y, 'Initial spacingY should be set to the default');
+
+      // To set the phylogeny, we need to set the variable directly.
+      vm.phylogenySpacingY[0] = 17;
+      assert.equal(vm.getPhylogenySpacingY(0), 17, 'spacingY can be changed by modifying the returned value');
+    });
+    
+    it('should not be shared by all phylogenies', function () {
+      // Set the spacing value for the second phylogeny.
+      vm.phylogenySpacingY[1] = 19;
+      assert.equal(vm.getPhylogenySpacingY(1), 19, 'spacingY[1] has a new value');
+      assert.equal(vm.getPhylogenySpacingY(0), 17, 'spacingY[0] retains its existing value from the previous test');
+    });
+  });
+});

--- a/test/vue-model.js
+++ b/test/vue-model.js
@@ -36,13 +36,13 @@ describe('Phylogeny spacing', function () {
       assert.equal(spacingX, vm.DEFAULT_SPACING_X, 'Initial spacingX should be set to the default');
 
       // To set the phylogeny, we need to update phylogenySpacingX directly.
-      vm.phylogenySpacingX[0] = 104;
+      vm.changePhylogenySpacingX(0, 104 - vm.DEFAULT_SPACING_X);
       assert.equal(vm.getPhylogenySpacingX(0), 104, 'spacingX can be changed by modifying the returned value');
     });
 
     it('should not be shared by all phylogenies', function () {
       // Set the spacing value for the second phylogeny (phylogenySpacingX[1]).
-      vm.phylogenySpacingX[1] = 208;
+      vm.changePhylogenySpacingX(1, 208 - vm.DEFAULT_SPACING_X);
       assert.equal(vm.getPhylogenySpacingX(1), 208, 'spacingX[1] has a new value');
       assert.equal(vm.getPhylogenySpacingX(0), 104, 'spacingX[0] retains its existing value from the previous test');
     });
@@ -56,13 +56,13 @@ describe('Phylogeny spacing', function () {
       assert.equal(spacingY, vm.DEFAULT_SPACING_Y, 'Initial spacingY should be set to the default');
 
       // To set the phylogeny, we need to update phylogenySpacingY directly.
-      vm.phylogenySpacingY[0] = 17;
+      vm.changePhylogenySpacingY(0, 17 - vm.DEFAULT_SPACING_Y);
       assert.equal(vm.getPhylogenySpacingY(0), 17, 'spacingY can be changed by modifying the returned value');
     });
     
     it('should not be shared by all phylogenies', function () {
       // Set the spacing value for the second phylogeny (phylogenySpacingY[1]).
-      vm.phylogenySpacingY[1] = 19;
+      vm.changePhylogenySpacingY(1, 19 - vm.DEFAULT_SPACING_Y);
       assert.equal(vm.getPhylogenySpacingY(1), 19, 'spacingY[1] has a new value');
       assert.equal(vm.getPhylogenySpacingY(0), 17, 'spacingY[0] retains its existing value from the previous test');
     });

--- a/test/vue-model.js
+++ b/test/vue-model.js
@@ -29,18 +29,19 @@ const assert = chai.assert;
 describe('Phylogeny spacing', function () {
   describe('spacingX', function () {
     it('should be modifiable', function () {
-      // We can use phylogeny index 0, since the UI creates an initial phylogeny by default.
+      // getPhylogenySpacing...() doesn't actually need the phylogeny to exist
+      // when getting the values. In this test, we use only phylogenySpacingX[0].
       var spacingX = vm.getPhylogenySpacingX(0);
       assert.isOk(spacingX);
       assert.equal(spacingX, vm.DEFAULT_SPACING_X, 'Initial spacingX should be set to the default');
 
-      // To set the phylogeny, we need to set the variable directly.
+      // To set the phylogeny, we need to update phylogenySpacingX directly.
       vm.phylogenySpacingX[0] = 104;
       assert.equal(vm.getPhylogenySpacingX(0), 104, 'spacingX can be changed by modifying the returned value');
     });
 
     it('should not be shared by all phylogenies', function () {
-      // Set the spacing value for the second phylogeny.
+      // Set the spacing value for the second phylogeny (phylogenySpacingX[1]).
       vm.phylogenySpacingX[1] = 208;
       assert.equal(vm.getPhylogenySpacingX(1), 208, 'spacingX[1] has a new value');
       assert.equal(vm.getPhylogenySpacingX(0), 104, 'spacingX[0] retains its existing value from the previous test');
@@ -48,18 +49,19 @@ describe('Phylogeny spacing', function () {
   });
   describe('spacingY', function () {
     it('should be modifiable', function () {
-      // We can use phylogeny index 0, since the UI creates an initial phylogeny by default.
+      // getPhylogenySpacing...() doesn't actually need the phylogeny to exist
+      // when getting the values. In this test, we use only phylogenySpacingY[0].
       var spacingY = vm.getPhylogenySpacingY(0);
       assert.isOk(spacingY);
       assert.equal(spacingY, vm.DEFAULT_SPACING_Y, 'Initial spacingY should be set to the default');
 
-      // To set the phylogeny, we need to set the variable directly.
+      // To set the phylogeny, we need to update phylogenySpacingY directly.
       vm.phylogenySpacingY[0] = 17;
       assert.equal(vm.getPhylogenySpacingY(0), 17, 'spacingY can be changed by modifying the returned value');
     });
     
     it('should not be shared by all phylogenies', function () {
-      // Set the spacing value for the second phylogeny.
+      // Set the spacing value for the second phylogeny (phylogenySpacingY[1]).
       vm.phylogenySpacingY[1] = 19;
       assert.equal(vm.getPhylogenySpacingY(1), 19, 'spacingY[1] has a new value');
       assert.equal(vm.getPhylogenySpacingY(0), 17, 'spacingY[0] retains its existing value from the previous test');


### PR DESCRIPTION
A bug in the current code causes all phylogenies to share the same spacingX and spacingY variables. This PR updates the code to ensure that spacingX and spacingY can be modified on a per-phylogeny basis, and adds a test to ensure that spacingX and spacingY can be set individually for each phylogeny.

Ready for review!