### PR TITLE
UI improvements to phylogeny 

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -36,8 +36,6 @@
 
 /* Node label for a terminal node without taxonomic units */
 .terminal-node-without-tunits {
-    font-style: italic;
-    font-weight: bolder;
 }
 
 /* Labels for internal nodes, whether phylorefs or not */

--- a/css/main.css
+++ b/css/main.css
@@ -23,20 +23,19 @@
  /* Node label for an internal specifier */
 .internal-specifier-node text {
     font-weight: bolder;
-    fill: green !important;
+    fill: rgb(0, 24, 168) !important;
     font-size: 12pt;
 }
 
 /* Node label for an external specifier */
 .external-specifier-node-label {
     font-weight: bolder;
-    fill: green;
+    fill: rgb(0, 24, 168) !important;
     font-size: 12pt;
 }
 
 /* Node label for a terminal node without taxonomic units */
 .terminal-node-without-tunits {
-    fill: rgb(169, 17, 1);
     font-style: italic;
     font-weight: bolder;
 }
@@ -47,12 +46,13 @@
     font-size: 12pt;
     font-style: italic;
 
-    text-anchor: start; /* Display text starting at the node */
+    text-anchor: end; /* Display text starting at the node */
 }
 
 /* The selected internal label on a phylogeny, whether determined to be the pinning node or not. */
 .selected-internal-label {
-  font-size: 16pt;
+    font-size: 16pt;
+    fill: rgb(0, 24, 168);
 }
 
 /*
@@ -61,8 +61,7 @@
  * than as an .internal-specifier-node.
  */
 .pinning-node text {
-  font-size: 16pt;
-  fill: rgb(0, 24, 168) !important;
+    font-weight: bolder;
 }
 
 /*
@@ -82,7 +81,6 @@
 }
 
 .descendant-of-pinning-node-node text {
-  fill: rgb(0, 24, 168);
 }
 
 .descendant-of-pinning-node-branch {

--- a/js/curation-tool.js
+++ b/js/curation-tool.js
@@ -661,6 +661,7 @@ const vm = new Vue({
         .svg(d3.select(nodeExpr))
         .options({
           transitions: false,
+          'left-offset': 100,
         })
         .style_nodes((element, data) => {
           // Instructions used to style nodes in Phylotree
@@ -680,7 +681,7 @@ const vm = new Vue({
               // Place internal label .3em to the right and below the node itself.
               textLabel.classed('internal-label', true)
                 .text(data.name)
-                .attr('dx', '.6em')
+                .attr('dx', '-.5em')
                 .attr('dy', '.3em');
 
               // If the internal label has the same label as the currently


### PR DESCRIPTION
This PR makes some improvements to the phylogeny UI:
* The expected clade name, the pinning node, the reasoned clade and the terminal nodes included in it are now all colored blue.
* Internal labels are drawn to the left of the corresponding node, not to the right. We also add a 100px offset to the left of the phylogeny so that there is space to draw a long label on the root node.
* The selected clade name is drawn in 16pt text, not 12pt. If it is also the pinning node (i.e. if the clade as reasoned corresponds to the clade as expected), then the text will be bolded.
* Italicization and red colored text to indicate that a terminal node could not be parsed as a scientific name has been eliminated.