### PR TITLE
Delete taxonomic units in the Taxonomy Unit Editor panel

### DIFF
--- a/index.html
+++ b/index.html
@@ -368,9 +368,7 @@
 
                                 <!-- List of taxonomic units -->
                                 <div id="tunits-panel" class="panel panel-info" style="margin-top: 1em">
-                                    <div class="panel-heading">Taxonomic Units
-                                      <a v-if="selectedTUnit" href="#" class="close glyphicon glyphicon-remove" onclick="vm.confirm('Are you sure you want to delete this taxonomic unit? This cannot be undone!', () => vm.selectedTUnitListContainer.list.splice(vm.selectedTUnitListContainer.list.indexOf(vm.selectedTUnit), 1)); vm.selectedTUnit = undefined; return false;"></a>
-                                    </div>
+                                    <div class="panel-heading">Taxonomic Units</div>
                                     <div class="panel-body" v-if="!selectedTUnit">
                                         <p><em>Select a taxonomic unit or create a new one.</em></p>
                                     </div>
@@ -493,12 +491,19 @@
 
                                     <!-- List of taxonomic units, including the option to add new taxonomic units -->
                                     <div class="list-group">
-                                        <a class="list-group-item"
+                                        <div class="list-group-item"
                                             v-for="(tunit, tunitIndex) of selectedTUnitListContainer.list"
                                             :class="{active: selectedTUnit === tunit}"
                                             @click="selectedTUnit = tunit"
                                             :title="getTaxonomicUnitLabel(tunit)"
-                                        >{{getTaxonomicUnitLabel(tunit)}}</a>
+                                        >{{getTaxonomicUnitLabel(tunit)}}
+                                        
+                                        <a href="#" 
+                                            :title="'Delete ' + getTaxonomicUnitLabel(tunit)" 
+                                            href="javascript: void(0)"
+                                            class="icon-danger close glyphicon glyphicon-remove" 
+                                            @click="deleteTUnit(tunit)"></a>
+                                        </div>
                                         <a class="list-group-item"
                                             href="javascript: void(0)"
                                             onclick="vm.selectedTUnitListContainer.list.push(vm.createEmptyTaxonomicUnit(vm.selectedTUnitListContainer.list.length + 1))"

--- a/index.html
+++ b/index.html
@@ -368,7 +368,9 @@
 
                                 <!-- List of taxonomic units -->
                                 <div id="tunits-panel" class="panel panel-info" style="margin-top: 1em">
-                                    <div class="panel-heading">Taxonomic Units</div>
+                                    <div class="panel-heading">Taxonomic Units
+                                      <a v-if="selectedTUnit" href="#" class="close glyphicon glyphicon-remove" onclick="vm.confirm('Are you sure you want to delete this taxonomic unit? This cannot be undone!', () => vm.selectedTUnitListContainer.list.splice(vm.selectedTUnitListContainer.list.indexOf(vm.selectedTUnit), 1)); vm.selectedTUnit = undefined; return false;"></a>
+                                    </div>
                                     <div class="panel-body" v-if="!selectedTUnit">
                                         <p><em>Select a taxonomic unit or create a new one.</em></p>
                                     </div>

--- a/js/curation-tool.js
+++ b/js/curation-tool.js
@@ -476,12 +476,13 @@ const vm = new Vue({
       // We've set up a data-dismiss to do that, so we don't need to do
       // anything here, but the function is here in case we need it later.
     },
-    deleteTUnit(tunit) {
+    deleteTUnit(tunitToDelete) {
+      const tunit = tunitToDelete;
+
       // Delete the specified taxonomic unit from the selectedTUnitListContainer.
       this.confirm('Are you sure you want to delete this taxonomic unit? This cannot be undone!', () => {
         // Is this the selectedTUnit? If so, reset it.
-        if (this.selectedTUnit === tunit)
-            this.selectedTUnit = undefined;
+        if (this.selectedTUnit === tunit) this.selectedTUnit = undefined;
 
         // Before deleting this taxonomic unit from its list, let's wipe it in
         // the UI. Otherwise, Vue uses the values in the UI to set the values
@@ -491,9 +492,8 @@ const vm = new Vue({
         tunit.specimens = [];
 
         // Delete it from its list.
-        this.selectedTUnitListContainer.list.splice(
-          this.selectedTUnitListContainer.list.indexOf(tunit), 1
-        )
+        const list = this.selectedTUnitListContainer.list;
+        list.splice(list.indexOf(tunit), 1);
       });
     },
 

--- a/js/curation-tool.js
+++ b/js/curation-tool.js
@@ -516,10 +516,14 @@ const vm = new Vue({
 
     // Methods for building human-readable labels for model elements.
     getTaxonomicUnitLabel(tu) {
-      return new TaxonomicUnitWrapper(tu).label;
+      const label = new TaxonomicUnitWrapper(tu).label;
+      if (label === undefined) return 'Empty taxonomic unit';
+      return label;
     },
     getSpecifierLabel(specifier) {
-      return PhylorefWrapper.getSpecifierLabel(specifier);
+      const label = PhylorefWrapper.getSpecifierLabel(specifier);
+      if (label === undefined) return 'Empty specifier';
+      return label;
     },
     getPhylorefStatus(phyloref) {
       return new PhylorefWrapper(phyloref).getCurrentStatus();

--- a/js/curation-tool.js
+++ b/js/curation-tool.js
@@ -476,6 +476,26 @@ const vm = new Vue({
       // We've set up a data-dismiss to do that, so we don't need to do
       // anything here, but the function is here in case we need it later.
     },
+    deleteTUnit(tunit) {
+      // Delete the specified taxonomic unit from the selectedTUnitListContainer.
+      this.confirm('Are you sure you want to delete this taxonomic unit? This cannot be undone!', () => {
+        // Is this the selectedTUnit? If so, reset it.
+        if (this.selectedTUnit === tunit)
+            this.selectedTUnit = undefined;
+
+        // Before deleting this taxonomic unit from its list, let's wipe it in
+        // the UI. Otherwise, Vue uses the values in the UI to set the values
+        // in the this.selectedTUnit.
+        tunit.scientificNames = [];
+        tunit.externalReferences = [];
+        tunit.specimens = [];
+
+        // Delete it from its list.
+        this.selectedTUnitListContainer.list.splice(
+          this.selectedTUnitListContainer.list.indexOf(tunit), 1
+        )
+      });
+    },
 
     // Methods for listing and modifying specifiers.
     getSpecifiers(phylorefWithSpecifiers) {

--- a/js/phyx.js
+++ b/js/phyx.js
@@ -368,8 +368,8 @@ class TaxonomicUnitWrapper {
       });
     }
 
-    // If we don't have any properties of a taxonomic unit, return 'Empty taxonomic unit'.
-    if (labels.length === 0) return 'Empty taxonomic unit';
+    // If we don't have any properties of a taxonomic unit, return undefined.
+    if (labels.length === 0) return undefined;
 
     return labels.join(' or ');
   }
@@ -985,8 +985,8 @@ class PhylorefWrapper {
     // this is a static method.
 
     // Is this specifier even non-null?
-    if (specifier === undefined) return '(undefined)';
-    if (specifier === null) return '(null)';
+    if (specifier === undefined) return undefined;
+    if (specifier === null) return undefined;
 
     // Maybe there is a label or description right there?
     if (hasOwnProperty(specifier, 'label')) return specifier.label;
@@ -995,12 +995,13 @@ class PhylorefWrapper {
     // Look at the individual taxonomic units.
     if (hasOwnProperty(specifier, 'referencesTaxonomicUnits')) {
       const labels = specifier.referencesTaxonomicUnits
-        .map(tu => new TaxonomicUnitWrapper(tu).label);
+        .map(tu => new TaxonomicUnitWrapper(tu).label)
+        .filter(label => (label !== undefined));
       if (labels.length > 0) return labels.join('; ');
     }
 
     // No idea!
-    return 'Unnamed specifier';
+    return undefined;
   }
 
   getExpectedNodeLabels(phylogeny) {

--- a/js/phyx.js
+++ b/js/phyx.js
@@ -368,8 +368,8 @@ class TaxonomicUnitWrapper {
       });
     }
 
-    // If we don't have any properties of a taxonomic unit, return undefined.
-    if (labels.length === 0) return undefined;
+    // If we don't have any properties of a taxonomic unit, return 'Empty taxonomic unit'.
+    if (labels.length === 0) return 'Empty taxonomic unit';
 
     return labels.join(' or ');
   }

--- a/test/taxonomic-units.js
+++ b/test/taxonomic-units.js
@@ -14,7 +14,7 @@ describe('TaxonomicUnitWrapper', function () {
     it('should wrap a blank object', function () {
       const wrapper = new phyx.TaxonomicUnitWrapper({});
       assert.exists(wrapper);
-      assert.isUndefined(wrapper.label);
+      assert.equal(wrapper.label, 'Empty taxonomic unit');
     });
   });
   describe('#label', function () {

--- a/test/taxonomic-units.js
+++ b/test/taxonomic-units.js
@@ -14,7 +14,7 @@ describe('TaxonomicUnitWrapper', function () {
     it('should wrap a blank object', function () {
       const wrapper = new phyx.TaxonomicUnitWrapper({});
       assert.exists(wrapper);
-      assert.equal(wrapper.label, 'Empty taxonomic unit');
+      assert.isUndefined(wrapper.label);
     });
   });
   describe('#label', function () {


### PR DESCRIPTION
Updates the Taxonomic Unit Editor to include delete buttons for individual taxonomic units, so they can be deleted if necessary. Closes #54.