### PR TITLE
Added support for jumping to the node that a phyloref is expected to/actually resolves to

### DIFF
--- a/index.html
+++ b/index.html
@@ -567,7 +567,13 @@
                             <!-- If phylogenies were loaded, we need to display a selector for each phylogeny -->
                             <div class="input-group" v-for="(phylogeny, phylogenyIndex) of testcase['phylogenies']">
                                 <!-- Display the phylogeny where this node is expected to match -->
-                                <span class="input-group-addon" :title="phylogeny['description']">Phylogeny {{phylogenyIndex + 1}}</span>
+                                <span class="input-group-btn">
+                                    <a
+                                        class="btn btn-default" 
+                                        :href="'#expected_phyloref_node_' + phylogenyIndex"
+                                        title="Click here to jump to this expected node"
+                                        type="button">Phylogeny {{phylogenyIndex + 1}}</a>
+                                </span>
 
                                 <!-- Display the matching node(s) -->
                                 <template v-if="getPhylorefExpectedNodeLabels(phylogeny, selectedPhyloref).length === 0">
@@ -625,7 +631,13 @@
                             <!-- If phylogenies were loaded, we need to display a selector for each phylogeny -->
                             <div class="input-group" v-for="(phylogeny, phylogenyIndex) of testcase['phylogenies']">
                                 <!-- Display the phylogeny where this node is expected to match -->
-                                <span class="input-group-addon" :title="phylogeny['description']">Phylogeny {{phylogenyIndex + 1}}</span>
+                                <span class="input-group-btn">
+                                    <a
+                                        class="btn btn-default" 
+                                        :href="'#pinning_node_' + phylogenyIndex"
+                                        title="Click here to jump to this node"
+                                        type="button">Phylogeny {{phylogenyIndex + 1}}</a>
+                                </span>
 
                                 <!-- Display the matching node(s) -->
                                 <template v-if="!hasProperty(reasoningResults, 'phylorefs')">

--- a/index.html
+++ b/index.html
@@ -570,8 +570,8 @@
                                 <span class="input-group-btn">
                                     <a
                                         class="btn btn-default" 
-                                        :href="'#expected_phyloref_node_' + phylogenyIndex"
-                                        title="Click here to jump to this expected node"
+                                        :href="'#current_expected_label_phylogeny' + phylogenyIndex"
+                                        title="Click here to jump to the expected label"
                                         type="button">Phylogeny {{phylogenyIndex + 1}}</a>
                                 </span>
 
@@ -634,7 +634,7 @@
                                 <span class="input-group-btn">
                                     <a
                                         class="btn btn-default" 
-                                        :href="'#pinning_node_' + phylogenyIndex"
+                                        :href="'#current_pinning_node_phylogeny' + phylogenyIndex"
                                         title="Click here to jump to this node"
                                         type="button">Phylogeny {{phylogenyIndex + 1}}</a>
                                 </span>

--- a/js/curation-tool.js
+++ b/js/curation-tool.js
@@ -686,14 +686,15 @@ const vm = new Vue({
                 .attr('dy', '.3em');
 
               // If the internal label has the same label as the currently
-              // selected phyloreference, make it bolder and turn it blue.
+              // selected phyloreference, add an 'id' so we can jump to it
+              // and a CSS class to render it differently from other labels.
               if (
                 this.selectedPhyloref !== undefined &&
                 hasProperty(this.selectedPhyloref, 'label') &&
                 new PhylorefWrapper(this.selectedPhyloref).getExpectedNodeLabels(phylogeny)
                   .includes(data.name)
               ) {
-                textLabel.attr('id', `expected_phyloref_node_${phylogenyIndex}`);
+                textLabel.attr('id', `current_expected_label_phylogeny${phylogenyIndex}`);
                 textLabel.classed('selected-internal-label', true);
               }
             }
@@ -719,8 +720,8 @@ const vm = new Vue({
             // Make the pinning node circle larger (twice its usual size of 3).
             element.select('circle').attr('r', 6);
 
-            // Set its id to 'pinning_node_{{phylogenyIndex}}'
-            element.attr('id', `pinning_node_${phylogenyIndex}`);
+            // Set its id to 'current_pinning_node_phylogeny{{phylogenyIndex}}'
+            element.attr('id', `current_pinning_node_phylogeny${phylogenyIndex}`);
           }
 
           // Maybe this isn't a pinning node, but it is a child of a pinning node.

--- a/js/curation-tool.js
+++ b/js/curation-tool.js
@@ -671,7 +671,7 @@ const vm = new Vue({
           const wrappedPhylogeny = new PhylogenyWrapper(phylogeny);
 
           // Make sure we don't already have an internal label node on this SVG node!
-          let textLabel = element.selectAll('.internal-label');
+          let textLabel = element.selectAll('text');
 
           if (hasProperty(data, 'name') && data.name !== '' && data.children) {
             // If the node has a label and has children (i.e. is an internal node),
@@ -741,7 +741,18 @@ const vm = new Vue({
             if (tunits.length === 0) {
               element.classed('terminal-node-without-tunits', true);
             } else if (this.selectedPhyloref !== undefined) {
-              // We should highlight specifiers.
+              // If this is a terminal node, we should set its ID to
+              // `current_expected_label_phylogeny${phylogenyIndex}` if it is
+              // the currently expected node label.
+              if (
+                hasProperty(this.selectedPhyloref, 'label') &&
+                new PhylorefWrapper(this.selectedPhyloref).getExpectedNodeLabels(phylogeny)
+                  .includes(data.name)
+              ) {
+                textLabel.attr('id', `current_expected_label_phylogeny${phylogenyIndex}`);
+              }
+
+              // We should highlight internal specifiers.
               if (hasProperty(this.selectedPhyloref, 'internalSpecifiers')) {
                 if (this.selectedPhyloref.internalSpecifiers
                   .some(specifier => wrappedPhylogeny.getNodeLabelsMatchedBySpecifier(specifier)
@@ -750,6 +761,8 @@ const vm = new Vue({
                   element.classed('node internal-specifier-node', true);
                 }
               }
+
+              // We should highlight external specifiers.
               if (hasProperty(this.selectedPhyloref, 'externalSpecifiers')) {
                 if (this.selectedPhyloref.externalSpecifiers
                   .some(specifier => wrappedPhylogeny.getNodeLabelsMatchedBySpecifier(specifier)

--- a/js/curation-tool.js
+++ b/js/curation-tool.js
@@ -628,6 +628,7 @@ const vm = new Vue({
 
       // Extract the Newick string to render.
       const phylogeny = phylogenyToRender;
+      const phylogenyIndex = this.testcase.phylogenies.indexOf(phylogeny);
       const newick = phylogeny.newick || '()';
 
       // Once we identify one or more pinning nodes in this phylogeny,
@@ -692,6 +693,7 @@ const vm = new Vue({
                 new PhylorefWrapper(this.selectedPhyloref).getExpectedNodeLabels(phylogeny)
                   .includes(data.name)
               ) {
+                textLabel.attr('id', `expected_phyloref_node_${phylogenyIndex}`);
                 textLabel.classed('selected-internal-label', true);
               }
             }
@@ -716,6 +718,9 @@ const vm = new Vue({
 
             // Make the pinning node circle larger (twice its usual size of 3).
             element.select('circle').attr('r', 6);
+
+            // Set its id to 'pinning_node_{{phylogenyIndex}}'
+            element.attr('id', `pinning_node_${phylogenyIndex}`);
           }
 
           // Maybe this isn't a pinning node, but it is a child of a pinning node.


### PR DESCRIPTION
Added a button to the expected/actually resolved node display that can be clicked to jump to that node in the phylogeny. These elements are identified in the SVG display as `#expected_phyloref_node_${phylogenyIndex}` and `#pinning_node_${phylogenyIndex}` in line with existing class/variable names. Closes #13.