### PR TITLE
Added individual warnings to save individual components

### DIFF
--- a/index.html
+++ b/index.html
@@ -231,11 +231,11 @@
                     <a href="#" class="close glyphicon glyphicon-collapse-up" onclick="vm.toggleButtonAndPanel(this, $(this).parent().parent().find('.panel-body, .panel-footer'))"></a>
 
                     <!-- Add a warning if this phylogeny has changed -->
-                    <a href="#" onclose="return false;"
+                    <span
                       v-if="!isEqualJSON(phylogeny, testcaseAsLoaded.phylogenies[phylogenyIndex])"
                       data-toggle="tooltip" data-placement="bottom" title="This phylogeny has been modified since being loaded! Please save it locally."
                       style="padding: 0em 1em"
-                      class="close glyphicon glyphicon-warning-sign"></a>
+                      class="close glyphicon glyphicon-warning-sign"></span>
 
                     <template v-if="phylogenyDescriptionBeingEdited !== phylogeny">
                         <span role="button" @click="phylogenyDescriptionBeingEdited = phylogeny" title="Click to edit">
@@ -549,6 +549,14 @@
                 <div id="selected-phyloref" class="panel-heading">
                   <!-- Minimize button for panel -->
                   <a href="#" class="close glyphicon glyphicon-collapse-up" onclick="vm.toggleButtonAndPanel(this, $(this).parent().parent().find('.panel-body, .panel-footer, .list-group'))"></a>
+
+                  <!-- Add a warning if this phyloref has changed -->
+                  <span
+                    v-if="selectedPhyloref !== undefined && !isEqualJSON(selectedPhyloref, testcaseAsLoaded.phylorefs[testcase.phylorefs.indexOf(selectedPhyloref)])"
+                    data-toggle="tooltip" data-placement="bottom" title="This phyloreference has been modified since being loaded! Please save it locally."
+                    style="padding: 0em 1em"
+                    class="close glyphicon glyphicon-warning-sign"></span>
+
                   Phyloreferences
                 </div>
                 <div v-if="selectedPhyloref" class="panel-body">
@@ -860,7 +868,15 @@
                         v-for="(phyloref, phylorefIndex) of testcase.phylorefs"
                         :class="{active: selectedPhyloref === phyloref}"
                         @click="selectedPhyloref = phyloref"
-                    >{{hasProperty(phyloref, 'label') ? phyloref.label : 'Phyloreference ' + (phylorefIndex + 1)}}</a>
+                    >{{hasProperty(phyloref, 'label') ? phyloref.label : 'Phyloreference ' + (phylorefIndex + 1)}}
+
+                    <!-- Add a warning if this phylogeny has changed -->
+                    <span
+                      v-if="!isEqualJSON(phyloref, testcaseAsLoaded.phylorefs[phylorefIndex])"
+                      data-toggle="tooltip" data-placement="bottom" title="This phyloreference has been modified since being loaded! Please save it locally."
+                      class="close glyphicon glyphicon-warning-sign"></span>
+
+                    </a>
                     <a class="list-group-item" href="javascript: void(0)" @click="testcase.phylorefs.push(createEmptyPhyloref(testcase.phylorefs.length + 1))"><strong>Add phyloreference</strong></a>
                 </div>
             </div>

--- a/index.html
+++ b/index.html
@@ -382,6 +382,11 @@
                     <!-- Body of specifier editor modal dialog box -->
                     <div class="modal-body col-md-12">
                             <div id="tunit-editor-form">
+                                <p>Changes made to taxonomic units in this dialog box will
+                                immediately change the {{selectedTUnitListContainer.type}}
+                                in the main display.
+                                </p>
+
                                 <div v-if="selectedTUnitListContainer.type == 'specifier'">
                                     <label for="verbatim-specifier" class="control-label">Verbatim specifier</label>
                                     <input id="verbatim-specifier" type="text" class="form-control" v-model.trim="selectedTUnitListContainer.container['verbatimSpecifier']" placeholder="Enter the verbatim description of this specifier">

--- a/index.html
+++ b/index.html
@@ -233,7 +233,7 @@
                     <!-- Add a warning if this phylogeny has changed -->
                     <span
                       v-if="!isEqualJSON(phylogeny, testcaseAsLoaded.phylogenies[phylogenyIndex])"
-                      data-toggle="tooltip" data-placement="bottom" title="This phylogeny has been modified since being loaded! Please save it locally."
+                      data-toggle="tooltip" data-placement="bottom" title="This phylogeny has been modified since being loaded! Use 'Save as JSON' to save your changes."
                       style="padding: 0em 1em"
                       class="close glyphicon glyphicon-warning-sign"></span>
 
@@ -558,7 +558,7 @@
                   <!-- Add a warning if this phyloref has changed -->
                   <span
                     v-if="selectedPhyloref !== undefined && !isEqualJSON(selectedPhyloref, testcaseAsLoaded.phylorefs[testcase.phylorefs.indexOf(selectedPhyloref)])"
-                    data-toggle="tooltip" data-placement="bottom" title="This phyloreference has been modified since being loaded! Please save it locally."
+                    data-toggle="tooltip" data-placement="bottom" title="This phyloreference has been modified since being loaded! Use 'Save as JSON' to save your changes."
                     style="padding: 0em 1em"
                     class="close glyphicon glyphicon-warning-sign"></span>
 
@@ -878,7 +878,7 @@
                     <!-- Add a warning if this phylogeny has changed -->
                     <span
                       v-if="!isEqualJSON(phyloref, testcaseAsLoaded.phylorefs[phylorefIndex])"
-                      data-toggle="tooltip" data-placement="bottom" title="This phyloreference has been modified since being loaded! Please save it locally."
+                      data-toggle="tooltip" data-placement="bottom" title="This phyloreference has been modified since being loaded! Use 'Save as JSON' to save your changes."
                       class="close glyphicon glyphicon-warning-sign"></span>
 
                     </a>

--- a/index.html
+++ b/index.html
@@ -230,6 +230,13 @@
                     <!-- Minimize button for panel -->
                     <a href="#" class="close glyphicon glyphicon-collapse-up" onclick="vm.toggleButtonAndPanel(this, $(this).parent().parent().find('.panel-body, .panel-footer'))"></a>
 
+                    <!-- Add a warning if this phylogeny has changed -->
+                    <a href="#" onclose="return false;"
+                      v-if="!isEqualJSON(phylogeny, testcaseAsLoaded.phylogenies[phylogenyIndex])"
+                      data-toggle="tooltip" data-placement="bottom" title="This phylogeny has been modified since being loaded! Please save it locally."
+                      style="padding: 0em 1em"
+                      class="close glyphicon glyphicon-warning-sign"></a>
+
                     <template v-if="phylogenyDescriptionBeingEdited !== phylogeny">
                         <span role="button" @click="phylogenyDescriptionBeingEdited = phylogeny" title="Click to edit">
                             <template v-if="hasProperty(phylogeny, 'description')">

--- a/js/curation-tool.js
+++ b/js/curation-tool.js
@@ -285,6 +285,14 @@ const vm = new Vue({
       $(button).toggleClass(buttonClasses);
       $(panel).toggle(300);
     },
+    isEqualJSON(json1, json2) {
+      // Compare two JSON objects and determine if they are identical.
+      if (json1 === undefined) return false;
+      if (json2 === undefined) return false;
+
+      // _.isEqual will compare the two objects using a recursive comparison.
+      return _.isEqual(json1, json2);
+    },
 
     // Data model management methods.
     loadPHYXFromURL(url) {


### PR DESCRIPTION
This PR adds individual warnings on phylogenies and phyloreferences that warns the user that changes made to this component have not yet been saved. Clicking the "Save as JSON" button resets these warnings, giving users a better idea of what changes have been saved and what remains to be saved. It also adds some text to the TUnit Editor to ensure that users are aware that the contents of that dialog box do not need to be saved separately.