### PR TITLE
Standardized to 'http' URIs in exported JSON-LD files

### DIFF
--- a/js/phyx.js
+++ b/js/phyx.js
@@ -1593,7 +1593,7 @@ class PHYXWrapper {
     jsonld['owl:imports'] = [
       'https://raw.githubusercontent.com/phyloref/curation-workflow/develop/ontologies/phyloref_testcase.owl',
       // - Will become 'http://vocab.phyloref.org/phyloref/testcase.owl'
-      'https://ontology.phyloref.org/phyloref.owl',
+      'http://ontology.phyloref.org/phyloref.owl',
       // - The Phyloreferencing ontology.
       'http://purl.obolibrary.org/obo/bco.owl',
       // - Contains OWL definitions for Darwin Core terms

--- a/js/phyx.js
+++ b/js/phyx.js
@@ -1591,7 +1591,7 @@ class PHYXWrapper {
     jsonld['@id'] = PHYXWrapper.BASE_URI;
     jsonld['@type'] = [PHYLOREFERENCE_TEST_CASE, 'owl:Ontology'];
     jsonld['owl:imports'] = [
-      'https://raw.githubusercontent.com/phyloref/curation-workflow/develop/ontologies/phyloref_testcase.owl',
+      'http://raw.githubusercontent.com/phyloref/curation-workflow/develop/ontologies/phyloref_testcase.owl',
       // - Will become 'http://vocab.phyloref.org/phyloref/testcase.owl'
       'http://ontology.phyloref.org/phyloref.owl',
       // - The Phyloreferencing ontology.
@@ -1601,7 +1601,7 @@ class PHYXWrapper {
 
     // If the '@context' is missing, add it here.
     if (!hasOwnProperty(jsonld, '@context')) {
-      jsonld['@context'] = 'https://www.phyloref.org/curation-tool/json/phyx.json';
+      jsonld['@context'] = 'http://www.phyloref.org/curation-tool/json/phyx.json';
     }
 
     return jsonld;


### PR DESCRIPTION
Where ontologies and JSON-LD context files referred to from the JSON-LD export are served over HTTPS, I'd previously been using URIs that started with `https:`. This is clearly wrong in the case of [the Phyloref Ontology](http://ontology.phyloref.org/phyloref.owl), whose base URI uses `http:`. It is also unnecessary in the other URIs, as they can be automatically redirected to HTTPS where necessary. This PR modifies the exported JSON-LD to use `http:` URIs consistently.