### PR TITLE
Improve test suite by making expected results clearer

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "lib": "lib"
   },
   "scripts": {
-    "lint": "eslint \"js/**\" \"examples/**\" --ext .js,.json",
+    "lint": "eslint \"js/**\" \"examples/**\" \"test/**\" --ext .js,.json",
     "pretest": "npm run lint",
     "test": "mocha"
   },

--- a/test/.eslintrc.json
+++ b/test/.eslintrc.json
@@ -1,6 +1,10 @@
 {
+  "env": {
+    "mocha": true
+  },
   "rules": {
     "prefer-arrow-callback": "off",
-    "func-names": "off"
+    "func-names": "off",
+    "no-unused-expressions": "off"
   }
 }

--- a/test/phylogenies.js
+++ b/test/phylogenies.js
@@ -1,4 +1,4 @@
-/*
+ /*
  * Test phylogenies.
  */
 
@@ -126,17 +126,17 @@ describe('PhylogenyWrapper', function () {
       tests.forEach((test) => {
         const wrapper = new phyx.PhylogenyWrapper({ newick: test.newick });
 
-        it('should be able to return a list of all node labels in this phylogeny', function () {
+        it('should return a list of all node labels in this phylogeny', function () {
           expect(wrapper.getNodeLabels().sort())
             .to.have.members(test.nodeLabels.sort());
         });
 
-        it('should be able to return a list of all internal labels in this phylogeny', function () {
+        it('should return a list of all internal labels in this phylogeny', function () {
           expect(wrapper.getNodeLabels('internal').sort())
             .to.have.members(test.internalNodeLabels.sort());
         });
 
-        it('should be able to return a list of all terminal labels in this phylogeny', function () {
+        it('should return a list of all terminal labels in this phylogeny', function () {
           expect(wrapper.getNodeLabels('terminal').sort())
             .to.have.members(test.terminalNodeLabels.sort());
         });
@@ -163,8 +163,8 @@ describe('PhylogenyWrapper', function () {
       },
     });
 
-    describe('#getTaxonomicUnitsForNodeLabel', function () {
-      it('should be able to return the list of node labels', function () {
+    describe('#getNodeLabels', function () {
+      it('should return the list of node labels', function () {
         expect(wrapper.getNodeLabels().sort())
           .to.have.members([
             'MVZ191016',
@@ -173,8 +173,10 @@ describe('PhylogenyWrapper', function () {
             'root',
           ]);
       });
+    });
 
-      it('should be able to return the list of taxonomic units for each node', function () {
+    describe('#getTaxonomicUnitsForNodeLabel', function () {
+      it('should return the list of expected taxonomic units for each node', function () {
         expect(wrapper.getTaxonomicUnitsForNodeLabel('MVZ191016')).to.deep.equal([{
           scientificNames: [{ scientificName: 'Rana luteiventris' }],
           includesSpecimens: [{ occurrenceID: 'MVZ:191016' }],
@@ -197,7 +199,7 @@ describe('PhylogenyWrapper', function () {
     });
 
     describe('#getNodeLabelsMatchedBySpecifier', function () {
-      it('should match specifiers by specimen identifier', function () {
+      it('should match nodes to specifiers and return the matched node labels', function () {
         const specifier1 = {
           referencesTaxonomicUnits: [{
             includesSpecimens: [{

--- a/test/phylogenies.js
+++ b/test/phylogenies.js
@@ -111,121 +111,124 @@ describe('PhylogenyWrapper', function () {
       });
     });
   });
+
   describe('#getNodeLabels', function () {
-    it('should be able extract all node labels in a phylogeny', function () {
-      const wrapper = new phyx.PhylogenyWrapper({
-        newick: '(A, (B, (C, D))E, F, (G, (H, I, J)K, L)M, N)O',
+    describe('given a valid phylogeny', function () {
+      const tests = [
+        {
+          newick: '(A, (B, (C, D))E, F, (G, (H, I, J)K, L)M, N)O',
+          nodeLabels: ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O'],
+          internalNodeLabels: ['E', 'K', 'M', 'O'],
+          terminalNodeLabels: ['A', 'B', 'C', 'D', 'F', 'G', 'H', 'I', 'J', 'L', 'N'],
+        },
+      ];
+
+      tests.forEach((test) => {
+        const wrapper = new phyx.PhylogenyWrapper({ newick: test.newick });
+
+        it('should be able to return a list of all node labels in this phylogeny', function () {
+          expect(wrapper.getNodeLabels().sort())
+            .to.have.members(test.nodeLabels.sort());
+        });
+
+        it('should be able to return a list of all internal labels in this phylogeny', function () {
+          expect(wrapper.getNodeLabels('internal').sort())
+            .to.have.members(test.internalNodeLabels.sort());
+        });
+
+        it('should be able to return a list of all terminal labels in this phylogeny', function () {
+          expect(wrapper.getNodeLabels('terminal').sort())
+            .to.have.members(test.terminalNodeLabels.sort());
+        });
       });
-      assert.deepEqual(wrapper.getNodeLabels().sort(), [
-        'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O',
-      ]);
-      assert.deepEqual(wrapper.getNodeLabels('internal').sort(), [
-        'E', 'K', 'M', 'O',
-      ]);
-      assert.deepEqual(wrapper.getNodeLabels('terminal').sort(), [
-        'A', 'B', 'C', 'D', 'F', 'G', 'H', 'I', 'J', 'L', 'N',
-      ]);
     });
   });
-  describe('#getTaxonomicUnitsForNodeLabel', function () {
-    it('should be able to combine additional node properties with node labels', function () {
-      const wrapper = new phyx.PhylogenyWrapper({
-        newick: '((MVZ225749, MVZ191016), "Rana boylii")',
-        additionalNodeProperties: {
-          MVZ225749: {
-            representsTaxonomicUnits: [{
-              scientificNames: [{ scientificName: 'Rana luteiventris' }],
-              includesSpecimens: [{ occurrenceID: 'MVZ:225749' }],
-            }],
-          },
-          MVZ191016: {
-            representsTaxonomicUnits: [{
-              scientificNames: [{ scientificName: 'Rana luteiventris' }],
-              includesSpecimens: [{ occurrenceID: 'MVZ:191016' }],
-            }],
-          },
+
+  describe('given a particular phylogeny with additional node properties', function () {
+    const wrapper = new phyx.PhylogenyWrapper({
+      newick: '((MVZ225749, MVZ191016), "Rana boylii")',
+      additionalNodeProperties: {
+        MVZ225749: {
+          representsTaxonomicUnits: [{
+            scientificNames: [{ scientificName: 'Rana luteiventris' }],
+            includesSpecimens: [{ occurrenceID: 'MVZ:225749' }],
+          }],
         },
-      });
-
-      assert.deepEqual(wrapper.getNodeLabels().sort(), [
-        'MVZ191016',
-        'MVZ225749',
-        'Rana boylii',
-        'root',
-      ]);
-
-      assert.deepEqual(wrapper.getTaxonomicUnitsForNodeLabel('MVZ191016'), [{
-        scientificNames: [{ scientificName: 'Rana luteiventris' }],
-        includesSpecimens: [{ occurrenceID: 'MVZ:191016' }],
-      }]);
-      assert.deepEqual(wrapper.getTaxonomicUnitsForNodeLabel('MVZ225749'), [{
-        scientificNames: [{ scientificName: 'Rana luteiventris' }],
-        includesSpecimens: [{ occurrenceID: 'MVZ:225749' }],
-      }]);
-      assert.deepEqual(wrapper.getTaxonomicUnitsForNodeLabel('Rana boylii'), [{
-        scientificNames: [{
-          scientificName: 'Rana boylii',
-          binomialName: 'Rana boylii',
-          genus: 'Rana',
-          specificEpithet: 'boylii',
-        }],
-      }]);
+        MVZ191016: {
+          representsTaxonomicUnits: [{
+            scientificNames: [{ scientificName: 'Rana luteiventris' }],
+            includesSpecimens: [{ occurrenceID: 'MVZ:191016' }],
+          }],
+        },
+      },
     });
-  });
-  describe('#getNodeLabelsMatchedBySpecifier', function () {
-    it('should match specifiers by specimen identifier', function () {
-      const wrapper = new phyx.PhylogenyWrapper({
-        newick: '((MVZ225749, MVZ191016), "Rana boylii")',
-        additionalNodeProperties: {
-          MVZ225749: {
-            representsTaxonomicUnits: [{
-              scientificNames: [{ scientificName: 'Rana luteiventris' }],
-              includesSpecimens: [{ occurrenceID: 'MVZ:225749' }],
-            }],
-          },
-          MVZ191016: {
-            representsTaxonomicUnits: [{
-              scientificNames: [{ scientificName: 'Rana luteiventris' }],
-              includesSpecimens: [{ occurrenceID: 'MVZ:191016' }],
-            }],
-          },
-        },
+
+    describe('#getTaxonomicUnitsForNodeLabel', function () {
+      it('should be able to return the list of node labels', function () {
+        expect(wrapper.getNodeLabels().sort())
+          .to.have.members([
+            'MVZ191016',
+            'MVZ225749',
+            'Rana boylii',
+            'root',
+          ]);
       });
 
-      const specifier1 = {
-        referencesTaxonomicUnits: [{
-          includesSpecimens: [{
-            occurrenceID: 'MVZ:225749',
-          }],
-        }],
-      };
-      const specifier2 = {
-        referencesTaxonomicUnits: [{
-          includesSpecimens: [{
-            occurrenceID: 'MVZ:191016',
-          }],
-        }],
-      };
-      const specifier3 = {
-        referencesTaxonomicUnits: [{
+      it('should be able to return the list of taxonomic units for each node', function () {
+        expect(wrapper.getTaxonomicUnitsForNodeLabel('MVZ191016')).to.deep.equal([{
+          scientificNames: [{ scientificName: 'Rana luteiventris' }],
+          includesSpecimens: [{ occurrenceID: 'MVZ:191016' }],
+        }]);
+
+        expect(wrapper.getTaxonomicUnitsForNodeLabel('MVZ225749')).to.deep.equal([{
+          scientificNames: [{ scientificName: 'Rana luteiventris' }],
+          includesSpecimens: [{ occurrenceID: 'MVZ:225749' }],
+        }]);
+
+        expect(wrapper.getTaxonomicUnitsForNodeLabel('Rana boylii')).to.deep.equal([{
           scientificNames: [{
-            scientificName: 'Rana boyli',
+            scientificName: 'Rana boylii',
+            binomialName: 'Rana boylii',
+            genus: 'Rana',
+            specificEpithet: 'boylii',
           }],
-        }],
-      };
+        }]);
+      });
+    });
 
-      assert.deepEqual(
-        wrapper.getNodeLabelsMatchedBySpecifier(specifier1),
-        ['MVZ225749'],
-      );
-      assert.deepEqual(
-        wrapper.getNodeLabelsMatchedBySpecifier(specifier2),
-        ['MVZ191016'],
-      );
-      assert.deepEqual(
-        wrapper.getNodeLabelsMatchedBySpecifier(specifier3),
-        [],
-      );
+    describe('#getNodeLabelsMatchedBySpecifier', function () {
+      it('should match specifiers by specimen identifier', function () {
+        const specifier1 = {
+          referencesTaxonomicUnits: [{
+            includesSpecimens: [{
+              occurrenceID: 'MVZ:225749',
+            }],
+          }],
+        };
+        const specifier2 = {
+          referencesTaxonomicUnits: [{
+            includesSpecimens: [{
+              occurrenceID: 'MVZ:191016',
+            }],
+          }],
+        };
+        const specifier3 = {
+          referencesTaxonomicUnits: [{
+            scientificNames: [{
+              scientificName: 'Rana boyli',
+            }],
+          }],
+        };
+
+        expect(wrapper.getNodeLabelsMatchedBySpecifier(specifier1))
+          .to.have.members(['MVZ225749']);
+
+        expect(wrapper.getNodeLabelsMatchedBySpecifier(specifier2))
+          .to.have.members(['MVZ191016']);
+
+        expect(wrapper.getNodeLabelsMatchedBySpecifier(specifier3))
+          .to.have.members([]);
+      });
     });
   });
 });

--- a/test/phylogenies.js
+++ b/test/phylogenies.js
@@ -18,7 +18,6 @@ require('../lib/phylotree.js/phylotree.js');
 const chai = require('chai');
 const phyx = require('../js/phyx');
 
-const assert = chai.assert;
 const expect = chai.expect;
 
 describe('PhylogenyWrapper', function () {
@@ -54,8 +53,8 @@ describe('PhylogenyWrapper', function () {
       it('should return a single "No phylogeny entered" error', function () {
         emptyNewickStrings.forEach((newick) => {
           const errors = phyx.PhylogenyWrapper.getErrorsInNewickString(newick);
-          assert.equal(errors.length, 1);
-          assert.equal(errors[0].title, 'No phylogeny entered');
+          expect(errors).to.have.length(1);
+          expect(errors[0].title).to.equal('No phylogeny entered');
         });
       });
     });
@@ -81,15 +80,15 @@ describe('PhylogenyWrapper', function () {
           const errors = phyx.PhylogenyWrapper.getErrorsInNewickString(entry.newick);
 
           // We should get two errors.
-          assert.equal(errors.length, 2);
+          expect(errors).to.have.lengthOf(2);
 
           // Should include an error about the unbalanced parentheses.
-          assert.equal(errors[0].title, 'Unbalanced parentheses in Newick string');
-          assert.equal(errors[0].message, entry.expected);
+          expect(errors[0].title).to.equal('Unbalanced parentheses in Newick string');
+          expect(errors[0].message).to.equal(entry.expected);
 
           // Should include an error passed on from the Newick parser.
-          assert.equal(errors[1].title, 'Error parsing phylogeny');
-          assert(errors[1].message.startsWith('An error occured while parsing this phylogeny:'));
+          expect(errors[1].title).to.equal('Error parsing phylogeny');
+          expect(errors[1].message).to.include('An error occured while parsing this phylogeny:');
         });
       });
     });
@@ -104,9 +103,9 @@ describe('PhylogenyWrapper', function () {
         incompleteNewickStrings.forEach((newick) => {
           const errors = phyx.PhylogenyWrapper.getErrorsInNewickString(newick);
 
-          assert.equal(errors.length, 1);
-          assert.equal(errors[0].title, 'Error parsing phylogeny');
-          assert(errors[0].message.startsWith('An error occured while parsing this phylogeny:'));
+          expect(errors).to.have.lengthOf(1);
+          expect(errors[0].title).to.equal('Error parsing phylogeny');
+          expect(errors[0].message).to.include('An error occured while parsing this phylogeny:');
         });
       });
     });

--- a/test/phylogenies.js
+++ b/test/phylogenies.js
@@ -94,14 +94,21 @@ describe('PhylogenyWrapper', function () {
       });
     });
 
-    it('should be able to identify an incomplete Newick string', function () {
-      let errors = phyx.PhylogenyWrapper.getErrorsInNewickString('(;)');
-      assert.equal(errors.length, 1);
-      assert.equal(errors[0].title, 'Error parsing phylogeny');
+    describe('when given an incomplete Newick string', function () {
+      const incompleteNewickStrings = [
+        '(;)',
+        '))(A, (B, ',
+      ];
 
-      errors = phyx.PhylogenyWrapper.getErrorsInNewickString('))(A, (B, ');
-      assert.equal(errors.length, 1);
-      assert.equal(errors[0].title, 'Error parsing phylogeny');
+      it('should report an error parsing the phylogeny', function () {
+        incompleteNewickStrings.forEach((newick) => {
+          const errors = phyx.PhylogenyWrapper.getErrorsInNewickString(newick);
+
+          assert.equal(errors.length, 1);
+          assert.equal(errors[0].title, 'Error parsing phylogeny');
+          assert(errors[0].message.startsWith('An error occured while parsing this phylogeny:'));
+        });
+      });
     });
   });
   describe('#getNodeLabels', function () {

--- a/test/phylogenies.js
+++ b/test/phylogenies.js
@@ -123,33 +123,33 @@ describe('PhylogenyWrapper', function () {
   });
 
   describe('#getNodeLabels', function () {
-    describe('given a valid phylogeny', function () {
-      const tests = [
-        {
-          // Note that 'newick' is the input for this test.
-          newick: '(A, (B, (C, D))E, F, (G, (H, I, J)K, L)M, N)O',
-          // The following keys indicate the expected all/internal/terminal node labels
-          // for the given Newick string.
-          nodeLabels: ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O'],
-          internalNodeLabels: ['E', 'K', 'M', 'O'],
-          terminalNodeLabels: ['A', 'B', 'C', 'D', 'F', 'G', 'H', 'I', 'J', 'L', 'N'],
-        },
-      ];
+    const tests = [
+      {
+        // Note that 'newick' is the input for this test.
+        newick: '(A, (B, (C, D))E, F, (G, (H, I, J)K, L)M, N)O',
+        // The following keys indicate the expected all/internal/terminal node labels
+        // for the given Newick string.
+        nodeLabels: ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O'],
+        internalNodeLabels: ['E', 'K', 'M', 'O'],
+        terminalNodeLabels: ['A', 'B', 'C', 'D', 'F', 'G', 'H', 'I', 'J', 'L', 'N'],
+      },
+    ];
 
-      tests.forEach((test) => {
-        const wrapper = new phyx.PhylogenyWrapper({ newick: test.newick });
+    tests.forEach((test) => {
+      const wrapper = new phyx.PhylogenyWrapper({ newick: test.newick });
 
-        it('should return a list of all node labels in this phylogeny', function () {
+      describe('For a particular Newick phylogeny', function () {
+        it('should return a list of all node labels by default', function () {
           expect(wrapper.getNodeLabels().sort())
             .to.have.members(test.nodeLabels.sort());
         });
 
-        it('should return a list of all internal labels in this phylogeny', function () {
+        it('should return a list of internal labels when asked for internal labels', function () {
           expect(wrapper.getNodeLabels('internal').sort())
             .to.have.members(test.internalNodeLabels.sort());
         });
 
-        it('should return a list of all terminal labels in this phylogeny', function () {
+        it('should return a list of terminal labels when asked for terminal labels', function () {
           expect(wrapper.getNodeLabels('terminal').sort())
             .to.have.members(test.terminalNodeLabels.sort());
         });

--- a/test/phylorefs.js
+++ b/test/phylorefs.js
@@ -24,7 +24,6 @@ const chai = require('chai');
 const phyx = require('../js/phyx');
 
 // Testing methods.
-const assert = chai.assert;
 const expect = chai.expect;
 
 // Some phylogenies to use in testing.
@@ -209,12 +208,12 @@ describe('PhylorefWrapper', function () {
 
           // And see if we get the statuses back in the correct order.
           const statusChanges = wrapper.getStatusChanges();
-          assert.equal(statusChanges.length, 5);
-          assert.equal(statusChanges[0].statusCURIE, 'pso:final-draft');
-          assert.equal(statusChanges[1].statusCURIE, 'pso:under-review');
-          assert.equal(statusChanges[2].statusCURIE, 'pso:submitted');
-          assert.equal(statusChanges[3].statusCURIE, 'pso:published');
-          assert.equal(statusChanges[4].statusCURIE, 'pso:retracted-from-publication');
+          expect(statusChanges.length, 'number of status changes should be 5').to.equal(5);
+          expect(statusChanges[0].statusCURIE, 'first status change should be "pso:final-draft"').to.equal('pso:final-draft');
+          expect(statusChanges[1].statusCURIE, 'second status change should be "pso:under-review"').to.equal('pso:under-review');
+          expect(statusChanges[2].statusCURIE, 'third status change should be a "pso:submitted"').to.equal('pso:submitted');
+          expect(statusChanges[3].statusCURIE, 'fourth status change should be a "pso:published"').to.equal('pso:published');
+          expect(statusChanges[4].statusCURIE, 'fifth status change should be a "pso:retracted-from-publication"').to.equal('pso:retracted-from-publication');
         });
       });
     });

--- a/test/phylorefs.js
+++ b/test/phylorefs.js
@@ -23,7 +23,9 @@ require('../lib/phylotree.js/phylotree.js');
 const chai = require('chai');
 const phyx = require('../js/phyx');
 
+// Testing methods.
 const assert = chai.assert;
+const expect = chai.expect;
 
 // Some phylogenies to use in testing.
 const phylogeny1 = {
@@ -71,93 +73,150 @@ const specifier3 = {
 };
 
 describe('PhylorefWrapper', function () {
-  describe('#constructor', function () {
-    it('should wrap a blank object', function () {
-      const wrapper = new phyx.PhylogenyWrapper({});
-      assert.isOk(wrapper);
-      assert.isUndefined(wrapper.label);
-    });
-  });
+  describe('given an empty phyloreference', function () {
+    const wrapper = new phyx.PhylorefWrapper({});
 
-  describe('#specifiers', function () {
-    it('should be able to insert and delete specifiers', function () {
-      const wrapper = new phyx.PhylorefWrapper({});
-      assert.isUndefined(wrapper.label);
-
-      wrapper.phyloref.label = 'phyloref1';
-      assert.equal(wrapper.label, 'phyloref1');
-
-      assert.deepEqual(wrapper.specifiers, []);
-
-      wrapper.phyloref.externalSpecifiers.push(specifier3);
-      assert.deepEqual(wrapper.specifiers, [specifier3]);
-
-      wrapper.phyloref.externalSpecifiers.push(specifier2);
-      assert.deepEqual(wrapper.specifiers, [specifier3, specifier2]);
-
-      wrapper.deleteSpecifier(specifier2);
-      assert.deepEqual(wrapper.specifiers, [specifier3]);
-
-      wrapper.phyloref.externalSpecifiers.push(specifier1);
-      assert.deepEqual(wrapper.specifiers, [specifier3, specifier1]);
-
-      wrapper.setSpecifierType(specifier1, 'Internal');
-      assert.deepEqual(wrapper.specifiers, [specifier1, specifier3]);
-
-      wrapper.phyloref.internalSpecifiers.push(specifier2);
-      assert.deepEqual(wrapper.specifiers, [specifier1, specifier2, specifier3]);
-
-      assert.equal(wrapper.getSpecifierType(specifier1), 'Internal');
-      assert.equal(wrapper.getSpecifierType(specifier2), 'Internal');
-      assert.equal(wrapper.getSpecifierType(specifier3), 'External');
-
-      assert.equal(phyx.PhylorefWrapper.getSpecifierLabel(specifier1), 'Specimen MVZ:225749');
-      assert.equal(phyx.PhylorefWrapper.getSpecifierLabel(specifier2), 'Specimen MVZ:191016');
-      assert.equal(phyx.PhylorefWrapper.getSpecifierLabel(specifier3), 'Rana boylii');
+    describe('#constructor', function () {
+      it('should return a PhylorefWrapper', function () {
+        expect(wrapper).to.be.an.instanceOf(phyx.PhylorefWrapper);
+      });
     });
 
-    it('should be able to determine expected node labels for a phylogeny', function () {
-      const phyloref1 = new phyx.PhylorefWrapper({
-        label: 'phyloref1',
-        internalSpecifiers: [specifier1, specifier2],
-        externalSpecifiers: [specifier3],
+    describe('#label', function () {
+      it('should return undefined', function () {
+        expect(wrapper.label).to.be.undefined;
       });
 
-      assert.deepEqual(
-        phyloref1.getExpectedNodeLabels(phylogeny1),
-        ['Test'],
-      );
+      it('should be settable by assigning to .label', function () {
+        wrapper.label = 'phyloref1';
+        expect(wrapper.label).equals('phyloref1');
+      });
+    });
+
+    describe('#specifiers', function () {
+      it('should initially return an empty list', function () {
+        expect(wrapper.specifiers).to.be.empty;
+      });
+
+      describe('when a new external specifier is added using .externalSpecifiers', function () {
+        it('should return a list with the new specifier', function () {
+          wrapper.phyloref.externalSpecifiers.push(specifier3);
+          expect(wrapper.specifiers).to.deep.equal([specifier3]);
+        });
+      });
+
+      describe('when a new external specifier is added using .externalSpecifiers', function () {
+        it('should return a list with the new specifier', function () {
+          wrapper.phyloref.externalSpecifiers.push(specifier2);
+          expect(wrapper.specifiers).to.deep.equal([specifier3, specifier2]);
+        });
+      });
+
+      describe('when a specifier is deleted using .deleteSpecifier', function () {
+        it('should return the updated list', function () {
+          wrapper.deleteSpecifier(specifier2);
+          expect(wrapper.specifiers).to.deep.equal([specifier3]);
+        });
+      });
+
+      describe('when a specifier is added using .externalSpecifiers', function () {
+        it('should return the updated list', function () {
+          wrapper.phyloref.externalSpecifiers.push(specifier1);
+          expect(wrapper.specifiers).to.deep.equal([specifier3, specifier1]);
+        });
+      });
+
+      describe('when a specifier is changed to an internal specifier using .setSpecifierType', function () {
+        it('should remain in the list of specifiers', function () {
+          wrapper.setSpecifierType(specifier1, 'Internal');
+          expect(wrapper.specifiers).to.deep.equal([specifier1, specifier3]);
+        });
+      });
+
+      describe('when a specifier is added using .internalSpecifiers', function () {
+        it('should be included in the list of all specifiers', function () {
+          wrapper.phyloref.internalSpecifiers.push(specifier2);
+          expect(wrapper.specifiers).to.deep.equal([specifier1, specifier2, specifier3]);
+        });
+      });
+    });
+
+    describe('#getSpecifierType', function () {
+      it('should return the correct specifier type for each specifier', function () {
+        expect(wrapper.getSpecifierType(specifier1)).to.equal('Internal');
+        expect(wrapper.getSpecifierType(specifier2)).to.equal('Internal');
+        expect(wrapper.getSpecifierType(specifier3)).to.equal('External');
+      });
+    });
+
+    describe('#getSpecifierLabel', function () {
+      it('should return the correct label for each specifier', function () {
+        expect(phyx.PhylorefWrapper.getSpecifierLabel(specifier1)).to.equal('Specimen MVZ:225749');
+        expect(phyx.PhylorefWrapper.getSpecifierLabel(specifier2)).to.equal('Specimen MVZ:191016');
+        expect(phyx.PhylorefWrapper.getSpecifierLabel(specifier3)).to.equal('Rana boylii');
+      });
     });
   });
 
-  describe('#statuses', function () {
-    it('should be able to update statuses while tracking them', function () {
-      const wrapper = new phyx.PhylorefWrapper({});
+  describe('given a particular phylogeny', function () {
+    describe('#getExpectedNodeLabels', function () {
+      it('should be able to determine expected node labels for a phylogeny', function () {
+        const phyloref1 = new phyx.PhylorefWrapper({
+          label: 'phyloref1',
+          internalSpecifiers: [specifier1, specifier2],
+          externalSpecifiers: [specifier3],
+        });
 
-      // Initially, an empty phyloref should report a status of 'pso:draft'.
-      assert.equal(wrapper.getCurrentStatus().statusCURIE, 'pso:draft');
+        expect(phyloref1.getExpectedNodeLabels(phylogeny1))
+          .to.deep.equal(['Test']);
+      });
+    });
+  });
 
-      // Let's try updating a bunch of status.
-      wrapper.setStatus('pso:final-draft');
-      wrapper.setStatus('pso:under-review');
-      wrapper.setStatus('pso:submitted');
-      wrapper.setStatus('pso:published');
-      wrapper.setStatus('pso:retracted-from-publication');
-      assert.throws(
-        function () { wrapper.setStatus('pso:retracted-from_publication'); },
-        TypeError,
-        'setStatus() called with invalid status CURIE \'pso:retracted-from_publication\'',
-        'PhylorefWrapper throws TypeError on a mistyped status',
-      );
+  describe('given an empty phyloreference', function () {
+    const wrapper = new phyx.PhylorefWrapper({});
 
-      // And see if we get the statuses back in the correct order.
-      const statusChanges = wrapper.getStatusChanges();
-      assert.equal(statusChanges.length, 5);
-      assert.equal(statusChanges[0].statusCURIE, 'pso:final-draft');
-      assert.equal(statusChanges[1].statusCURIE, 'pso:under-review');
-      assert.equal(statusChanges[2].statusCURIE, 'pso:submitted');
-      assert.equal(statusChanges[3].statusCURIE, 'pso:published');
-      assert.equal(statusChanges[4].statusCURIE, 'pso:retracted-from-publication');
+    describe('#getCurrentStatus', function () {
+      it('should return "pso:draft" as the default initial status', function () {
+        // Initially, an empty phyloref should report a status of 'pso:draft'.
+        expect(wrapper.getCurrentStatus().statusCURIE).to.equal('pso:draft');
+      });
+    });
+
+    describe('#setStatus', function () {
+      it('should throw an error if given a mistyped status', function () {
+        expect(function () { wrapper.setStatus('pso:retracted-from_publication'); })
+          .to.throw(
+            TypeError,
+            'setStatus() called with invalid status CURIE \'pso:retracted-from_publication\'',
+            'PhylorefWrapper throws TypeError on a mistyped status',
+          );
+      });
+    });
+
+    describe('#getStatusChanges', function () {
+      it('should return the empty list', function () {
+        expect(wrapper.getStatusChanges()).to.be.empty;
+      });
+
+      describe('when modified by using .setStatus', function () {
+        it('should return the updated list', function () {
+          wrapper.setStatus('pso:final-draft');
+          wrapper.setStatus('pso:under-review');
+          wrapper.setStatus('pso:submitted');
+          wrapper.setStatus('pso:published');
+          wrapper.setStatus('pso:retracted-from-publication');
+
+          // And see if we get the statuses back in the correct order.
+          const statusChanges = wrapper.getStatusChanges();
+          assert.equal(statusChanges.length, 5);
+          assert.equal(statusChanges[0].statusCURIE, 'pso:final-draft');
+          assert.equal(statusChanges[1].statusCURIE, 'pso:under-review');
+          assert.equal(statusChanges[2].statusCURIE, 'pso:submitted');
+          assert.equal(statusChanges[3].statusCURIE, 'pso:published');
+          assert.equal(statusChanges[4].statusCURIE, 'pso:retracted-from-publication');
+        });
+      });
     });
   });
 });

--- a/test/scientific-names.js
+++ b/test/scientific-names.js
@@ -2,12 +2,14 @@
  * Test scientific name processing.
  */
 
-/* eslint-env mocha */
-
 const chai = require('chai');
 const phyx = require('../js/phyx');
 
 const expect = chai.expect;
+
+/*
+ * Test whether ScientificNameWrapper parses scientific names correctly.
+ */
 
 describe('ScientificNameWrapper', function () {
   describe('#constructor', function () {

--- a/test/scientific-names.js
+++ b/test/scientific-names.js
@@ -7,35 +7,39 @@
 const chai = require('chai');
 const phyx = require('../js/phyx');
 
-const assert = chai.assert;
+const expect = chai.expect;
 
 describe('ScientificNameWrapper', function () {
   describe('#constructor', function () {
-    it('should wrap a blank object', function () {
+    it('should accept empty scientific names without errors', function () {
       const wrapper = new phyx.ScientificNameWrapper({});
-      assert.exists(wrapper);
-      assert.isUndefined(wrapper.scientificName);
+
+      expect(wrapper).to.be.an.instanceOf(phyx.ScientificNameWrapper);
+      expect(wrapper.scientificName).to.be.undefined;
     });
-    it('should handle uninomial names', function () {
+    it('should be able to parse uninomial names as genus names without a specific epithet', function () {
       const wrapper = new phyx.ScientificNameWrapper({
         scientificName: 'Mus',
       });
-      assert.equal(wrapper.genus, 'Mus');
-      assert.isUndefined(wrapper.specificEpithet);
+
+      expect(wrapper.genus).to.equal('Mus');
+      expect(wrapper.specificEpithet).to.be.undefined;
     });
-    it('should handle binomial names', function () {
+    it('should be able to parse binomial names into genus and specific epithet', function () {
       const wrapper = new phyx.ScientificNameWrapper({
         scientificName: 'Mus musculus',
       });
-      assert.equal(wrapper.genus, 'Mus');
-      assert.equal(wrapper.specificEpithet, 'musculus');
+
+      expect(wrapper.genus).to.equal('Mus');
+      expect(wrapper.specificEpithet).to.equal('musculus');
     });
-    it('should handle scientific names with authority', function () {
+    it('should ignore authority after a binomial name', function () {
       const wrapper = new phyx.ScientificNameWrapper({
         scientificName: 'Mus musculus Linnaeus, 1758',
       });
-      assert.equal(wrapper.genus, 'Mus');
-      assert.equal(wrapper.specificEpithet, 'musculus');
+
+      expect(wrapper.genus).to.equal('Mus');
+      expect(wrapper.specificEpithet).to.equal('musculus');
     });
   });
 });

--- a/test/specimens.js
+++ b/test/specimens.js
@@ -2,19 +2,23 @@
  * Test specimen processing.
  */
 
-/* eslint-env mocha */
-
 const chai = require('chai');
 const phyx = require('../js/phyx');
 
 const expect = chai.expect;
+
+/*
+ * Test whether SpecimenWrapper can parse specimen identifiers from simple specimen
+ * identifiers, from institutionCode:catalogNumber format, and from Darwin Core triples.
+ * However, URNs and HTTP URLs should not be accidentally parsed as Darwin Core triples.
+ */
 
 describe('SpecimenWrapper', function () {
   describe('#constructor', function () {
     it('should be able to wrap an empty specimen', function () {
       const wrapped = new phyx.SpecimenWrapper({});
 
-      expect(wrapped).to.be.an.instanceOf(phyx.SpecimenWrapper)
+      expect(wrapped).to.be.an.instanceOf(phyx.SpecimenWrapper);
       expect(wrapped.occurrenceID).to.equal('urn:catalog:::');
     });
     it('should be able to extract an occurenceID and catalogNumber from simple specimen IDs', function () {
@@ -24,7 +28,7 @@ describe('SpecimenWrapper', function () {
       expect(wrapper.occurrenceID).to.equal('Wall 2527, Fiji (uc)');
       expect(wrapper.catalogNumber).to.equal('Wall 2527, Fiji (uc)');
     });
-    it('should extract occurenceID, institutionCode and catalogNumber from Darwin Core doubles', function () {
+    it('should extract institutionCode and catalogNumber from a institutionCode:catalogNumber combination', function () {
       const wrapper = new phyx.SpecimenWrapper({
         occurrenceID: 'FMNH:PR 2081',
       });

--- a/test/specimens.js
+++ b/test/specimens.js
@@ -7,69 +7,63 @@
 const chai = require('chai');
 const phyx = require('../js/phyx');
 
-const assert = chai.assert;
+const expect = chai.expect;
 
 describe('SpecimenWrapper', function () {
   describe('#constructor', function () {
-    it('should wrap a blank object', function () {
-      const wrapper = new phyx.SpecimenWrapper({});
-      assert.exists(wrapper);
-      assert.equal(wrapper.occurrenceID, 'urn:catalog:::');
+    it('should be able to wrap an empty specimen', function () {
+      const wrapped = new phyx.SpecimenWrapper({});
+
+      expect(wrapped).to.be.an.instanceOf(phyx.SpecimenWrapper)
+      expect(wrapped.occurrenceID).to.equal('urn:catalog:::');
     });
-    it('should handle simple specimen IDs', function () {
+    it('should be able to extract an occurenceID and catalogNumber from simple specimen IDs', function () {
       const wrapper = new phyx.SpecimenWrapper({
         occurrenceID: 'Wall 2527, Fiji (uc)',
       });
-      assert.equal(wrapper.occurrenceID, 'Wall 2527, Fiji (uc)');
-      assert.equal(wrapper.catalogNumber, 'Wall 2527, Fiji (uc)');
+      expect(wrapper.occurrenceID).to.equal('Wall 2527, Fiji (uc)');
+      expect(wrapper.catalogNumber).to.equal('Wall 2527, Fiji (uc)');
     });
-    it('should handle Darwin Core doubles', function () {
+    it('should extract occurenceID, institutionCode and catalogNumber from Darwin Core doubles', function () {
       const wrapper = new phyx.SpecimenWrapper({
         occurrenceID: 'FMNH:PR 2081',
       });
-      assert.equal(wrapper.occurrenceID, 'FMNH:PR 2081');
-      assert.equal(wrapper.institutionCode, 'FMNH');
-      assert.equal(wrapper.catalogNumber, 'PR 2081');
+      expect(wrapper.occurrenceID).to.equal('FMNH:PR 2081');
+      expect(wrapper.institutionCode).to.equal('FMNH');
+      expect(wrapper.catalogNumber).to.equal('PR 2081');
     });
-    it('should handle Darwin Core triples', function () {
+    it('should extract occurenceID, institutionCode and catalogNumber from Darwin Core triples', function () {
       const wrapper = new phyx.SpecimenWrapper({
         occurrenceID: 'FMNH:PR:2081',
       });
-      assert.equal(wrapper.occurrenceID, 'FMNH:PR:2081');
-      assert.equal(wrapper.institutionCode, 'FMNH');
-      assert.equal(wrapper.collectionCode, 'PR');
-      assert.equal(wrapper.catalogNumber, '2081');
+      expect(wrapper.occurrenceID).to.equal('FMNH:PR:2081');
+      expect(wrapper.institutionCode).to.equal('FMNH');
+      expect(wrapper.collectionCode).to.equal('PR');
+      expect(wrapper.catalogNumber).to.equal('2081');
     });
-    it('should be able to split occurrenceID in different ways', function () {
-      const specimen1 = { occurrenceID: 'MVZ225749' };
-      const specimen2 = { catalogNumber: 'MVZ225749' };
-      const specimen3 = { occurrenceID: 'urn:catalog:::MVZ225749' };
-
-      const wrapper1 = new phyx.SpecimenWrapper(specimen1);
-      const wrapper2 = new phyx.SpecimenWrapper(specimen2);
-      const wrapper3 = new phyx.SpecimenWrapper(specimen3);
-
-      assert.equal(wrapper1.catalogNumber, 'MVZ225749');
-      assert.equal(wrapper2.catalogNumber, 'MVZ225749');
-      assert.equal(wrapper3.catalogNumber, 'MVZ225749');
+    it('should be able to extract the same occurrenceID from different representations', function () {
+      expect(new phyx.SpecimenWrapper({ occurrenceID: 'urn:catalog:::MVZ225749' }).occurrenceID)
+        .to.equal('urn:catalog:::MVZ225749');
+      expect(new phyx.SpecimenWrapper({ catalogNumber: 'MVZ225749' }).occurrenceID)
+        .to.equal('urn:catalog:::MVZ225749');
     });
-    it("shouldn't get confused by URNs", function () {
+    it('should not attempt to split a URN into occurenceID, institutionCode and catalogNumber', function () {
       const wrapper = new phyx.SpecimenWrapper({
         occurrenceID: 'urn:lsid:biocol.org:col:34777',
       });
-      assert.equal(wrapper.occurrenceID, 'urn:lsid:biocol.org:col:34777');
-      assert.isUndefined(wrapper.institutionCode);
-      assert.isUndefined(wrapper.collectionCode);
-      assert.isUndefined(wrapper.catalogNumber);
+      expect(wrapper.occurrenceID).to.equal('urn:lsid:biocol.org:col:34777');
+      expect(wrapper.institutionCode).to.be.undefined;
+      expect(wrapper.collectionCode).to.be.undefined;
+      expect(wrapper.catalogNumber).to.be.undefined;
     });
-    it("shouldn't get confused by URLs", function () {
+    it('should not attempt to split a URL into occurenceID, institutionCode and catalogNumber', function () {
       const wrapper = new phyx.SpecimenWrapper({
         occurrenceID: 'http://arctos.database.museum/guid/MVZ:Herp:148929?seid=886464',
       });
-      assert.equal(wrapper.occurrenceID, 'http://arctos.database.museum/guid/MVZ:Herp:148929?seid=886464');
-      assert.isUndefined(wrapper.institutionCode);
-      assert.isUndefined(wrapper.collectionCode);
-      assert.isUndefined(wrapper.catalogNumber);
+      expect(wrapper.occurrenceID).to.equal('http://arctos.database.museum/guid/MVZ:Herp:148929?seid=886464');
+      expect(wrapper.institutionCode).to.be.undefined;
+      expect(wrapper.collectionCode).to.be.undefined;
+      expect(wrapper.catalogNumber).to.be.undefined;
     });
   });
 });

--- a/test/taxonomic-units.js
+++ b/test/taxonomic-units.js
@@ -2,23 +2,30 @@
  * Test taxonomic unit construction and matching.
  */
 
-/* eslint-env mocha */
-
 const chai = require('chai');
 const phyx = require('../js/phyx');
 
 // Use Chai's expect API.
 const expect = chai.expect;
 
+/*
+ * We primarily test two classes here:
+ *  - TaxonomicUnitWrapper, which wraps a taxonomic unit and determines if it
+ *    refers to a scientific name, specimen identifier or external reference,
+ *    or a combination of these.
+ *  - TaxonomicUnitMatcher, which accepts two taxonomic units and determines
+ *    whether and for what reason the two can be matched.
+ */
+
 describe('TaxonomicUnitWrapper', function () {
-  describe('#constructor', function () {
-    it('should wrap a blank object with an undefined label', function () {
+  describe('#constructor given no arguments', function () {
+    it('should create an empty TaxonomicUnitWrapper without a defined label', function () {
       const wrapper = new phyx.TaxonomicUnitWrapper({});
       expect(wrapper).to.be.instanceOf(phyx.TaxonomicUnitWrapper);
       expect(wrapper.label).to.be.undefined;
     });
   });
-  describe('#label', function () {
+  describe('#label given a taxonomic unit', function () {
     it('should return a wrapped scientific name', function () {
       const wrapper = new phyx.TaxonomicUnitWrapper({
         scientificNames: [{
@@ -66,7 +73,7 @@ describe('TaxonomicUnitWrapper', function () {
       });
       expect(wrapper.label).to.equal('<http://arctos.database.museum/guid/MVZ:Herp:225749>');
     });
-    it('should return a concatenated label for a taxonomic unit', function () {
+    it('should concatenate specimen identifiers, external references and scientific names with "or"', function () {
       const wrapper = new phyx.TaxonomicUnitWrapper({
         externalReferences: [
           'http://arctos.database.museum/guid/MVZ:Herp:225749',
@@ -91,7 +98,7 @@ describe('TaxonomicUnitWrapper', function () {
       expect(phyx.TaxonomicUnitWrapper.getTaxonomicUnitsFromNodeLabel('')).to.be.empty;
       expect(phyx.TaxonomicUnitWrapper.getTaxonomicUnitsFromNodeLabel('    ')).to.be.empty;
     });
-    it('when given a scientific name: should return a list of a single TU wrapping a scientific name', function () {
+    it('when given a scientific name, it should return a list of a single TU wrapping a scientific name', function () {
       expect(phyx.TaxonomicUnitWrapper.getTaxonomicUnitsFromNodeLabel('Rana luteiventris MVZ225749'))
         .to.be.deep.equal([{
           scientificNames: [{
@@ -102,7 +109,7 @@ describe('TaxonomicUnitWrapper', function () {
           }],
         }]);
     });
-    it('when given a scientific name separated with underscores: should return a list of a single TU wrapping the scientific name', function () {
+    it('when given a scientific name separated with underscores, it should return a list of a single TU wrapping the scientific name', function () {
       expect(phyx.TaxonomicUnitWrapper.getTaxonomicUnitsFromNodeLabel('Rana_luteiventris_MVZ_225749'))
         .to.be.deep.equal([{
           scientificNames: [{
@@ -116,57 +123,63 @@ describe('TaxonomicUnitWrapper', function () {
   });
 });
 
-// To test matching, let's set up some taxonomic units.
-// Note that:
-//  tunit1 and tunit2 should match by scientific name.
-//  tunit2 and tunit3 should match by specimen identifier.
-//  tunit3 and tunit4 should match by external references.
-const tunit1 = { scientificNames: [{ scientificName: 'Rana luteiventris' }] };
-const tunit2 = {
-  scientificNames: [{ scientificName: 'Rana luteiventris MVZ225749' }],
-  includesSpecimens: [{ occurrenceID: 'urn:catalog:::MVZ225749' }],
-};
-const tunit3 = {
-  includesSpecimens: [{ catalogNumber: 'MVZ225749' }],
-  externalReferences: ['http://arctos.database.museum/guid/MVZ:Herp:225749'],
-};
-const tunit4 = {
-  externalReferences: ['http://arctos.database.museum/guid/MVZ:Herp:225749'],
-};
-
 describe('TaxonomicUnitMarcher', function () {
+  // To test matching, let's set up some taxonomic units.
+  // Note that:
+  //  tunit1 and tunit2 should match by scientific name.
+  //  tunit2 and tunit3 should match by specimen identifier.
+  //  tunit3 and tunit4 should match by external references.
+  const tunit1 = { scientificNames: [{ scientificName: 'Rana luteiventris' }] };
+  const tunit2 = {
+    scientificNames: [{ scientificName: 'Rana luteiventris MVZ225749' }],
+    includesSpecimens: [{ occurrenceID: 'urn:catalog:::MVZ225749' }],
+  };
+  const tunit3 = {
+    includesSpecimens: [{ catalogNumber: 'MVZ225749' }],
+    externalReferences: ['http://arctos.database.museum/guid/MVZ:Herp:225749'],
+  };
+  const tunit4 = {
+    externalReferences: ['http://arctos.database.museum/guid/MVZ:Herp:225749'],
+  };
+
   describe('#matchByBinomialName', function () {
-    it('should be able to match taxonomic units by binomial name', function () {
+    it('should be able to match tunit1 and tunit2 by binomial name', function () {
       expect(new phyx.TaxonomicUnitMatcher(tunit1, tunit2).matchByExternalReferences()).to.be.false;
       expect(new phyx.TaxonomicUnitMatcher(tunit1, tunit2).matchBySpecimenIdentifier()).to.be.false;
       expect(new phyx.TaxonomicUnitMatcher(tunit1, tunit2).matchByBinomialName()).to.be.true;
     });
   });
   describe('#matchByExternalReferences', function () {
-    it('should match by external references', function () {
+    it('should be able to match tunit3 and tunit4 by external references', function () {
       expect(new phyx.TaxonomicUnitMatcher(tunit3, tunit4).matchByExternalReferences()).to.be.true;
       expect(new phyx.TaxonomicUnitMatcher(tunit3, tunit4).matchBySpecimenIdentifier()).to.be.false;
       expect(new phyx.TaxonomicUnitMatcher(tunit3, tunit4).matchByBinomialName()).to.be.false;
     });
   });
   describe('#matchBySpecimenIdentifier', function () {
-    it('should match by specimen identifiers', function () {
+    it('should be able to match tunit2 and tunit3 by specimen identifiers', function () {
       expect(new phyx.TaxonomicUnitMatcher(tunit2, tunit3).matchByExternalReferences()).to.be.false;
       expect(new phyx.TaxonomicUnitMatcher(tunit2, tunit3).matchBySpecimenIdentifier()).to.be.true;
       expect(new phyx.TaxonomicUnitMatcher(tunit2, tunit3).matchByBinomialName()).to.be.false;
     });
   });
   describe('#matched and #matchReason', function () {
-    let matcher = new phyx.TaxonomicUnitMatcher(tunit1, tunit2);
-    expect(matcher.matched).to.be.true;
-    expect(matcher.matchReason).to.include('share the same binomial name');
+    it('should match tunit1 and tunit2 on the basis of identical binomial name', function () {
+      const matcher = new phyx.TaxonomicUnitMatcher(tunit1, tunit2);
+      expect(matcher.matched).to.be.true;
+      expect(matcher.matchReason).to.include('share the same binomial name');
+    });
 
-    matcher = new phyx.TaxonomicUnitMatcher(tunit3, tunit4);
-    expect(matcher.matched).to.be.true;
-    expect(matcher.matchReason).to.include('External reference');
+    it('should match tunit3 and tunit4 by identical external reference', function () {
+      const matcher = new phyx.TaxonomicUnitMatcher(tunit3, tunit4);
+      expect(matcher.matched).to.be.true;
+      expect(matcher.matchReason).to.include('External reference');
+    });
 
-    matcher = new phyx.TaxonomicUnitMatcher(tunit2, tunit3);
-    expect(matcher.matched).to.be.true;
-    expect(matcher.matchReason).to.include('Specimen identifier');
+    it('should match tunit2 and tunit3 by identical specimen identifier', function () {
+      const matcher = new phyx.TaxonomicUnitMatcher(tunit2, tunit3);
+      expect(matcher.matched).to.be.true;
+      expect(matcher.matchReason).to.include('Specimen identifier');
+    });
   });
 });

--- a/test/taxonomic-units.js
+++ b/test/taxonomic-units.js
@@ -7,7 +7,7 @@
 const chai = require('chai');
 const phyx = require('../js/phyx');
 
-const assert = chai.assert;
+// Use Chai's expect API.
 const expect = chai.expect;
 
 describe('TaxonomicUnitWrapper', function () {
@@ -44,7 +44,7 @@ describe('TaxonomicUnitWrapper', function () {
           catalogNumber: '225749',
         }],
       });
-      assert.equal(wrapper.label, 'Specimen urn:catalog:MVZ::225749');
+      expect(wrapper.label).to.equal('Specimen urn:catalog:MVZ::225749');
     });
     it('should return specimen identifiers and scientific names concatenated with "or"', function () {
       const wrapper = new phyx.TaxonomicUnitWrapper({
@@ -117,6 +117,10 @@ describe('TaxonomicUnitWrapper', function () {
 });
 
 // To test matching, let's set up some taxonomic units.
+// Note that:
+//  tunit1 and tunit2 should match by scientific name.
+//  tunit2 and tunit3 should match by specimen identifier.
+//  tunit3 and tunit4 should match by external references.
 const tunit1 = { scientificNames: [{ scientificName: 'Rana luteiventris' }] };
 const tunit2 = {
   scientificNames: [{ scientificName: 'Rana luteiventris MVZ225749' }],

--- a/test/taxonomic-units.js
+++ b/test/taxonomic-units.js
@@ -8,29 +8,26 @@ const chai = require('chai');
 const phyx = require('../js/phyx');
 
 const assert = chai.assert;
+const expect = chai.expect;
 
 describe('TaxonomicUnitWrapper', function () {
   describe('#constructor', function () {
-    it('should wrap a blank object', function () {
+    it('should wrap a blank object with an undefined label', function () {
       const wrapper = new phyx.TaxonomicUnitWrapper({});
-      assert.exists(wrapper);
-      assert.isUndefined(wrapper.label);
+      expect(wrapper).to.be.instanceOf(phyx.TaxonomicUnitWrapper);
+      expect(wrapper.label).to.be.undefined;
     });
   });
   describe('#label', function () {
-    it('should wrap a taxonomic unit with a scientific name', function () {
+    it('should return a wrapped scientific name', function () {
       const wrapper = new phyx.TaxonomicUnitWrapper({
         scientificNames: [{
           scientificName: 'Ornithorhynchus anatinus (Shaw, 1799)',
         }],
       });
-      assert.equal(wrapper.label, 'Ornithorhynchus anatinus (Shaw, 1799)');
-
-      const scname0 = new phyx.ScientificNameWrapper(wrapper.scientificNames[0]);
-      assert.equal(scname0.genus, 'Ornithorhynchus');
-      assert.equal(scname0.specificEpithet, 'anatinus');
+      expect(wrapper.label).to.equal('Ornithorhynchus anatinus (Shaw, 1799)');
     });
-    it('should wrap a taxonomic unit with two scientific names', function () {
+    it('should return two wrapped scientific names separated by "or"', function () {
       const wrapper = new phyx.TaxonomicUnitWrapper({
         scientificNames: [{
           scientificName: 'Ornithorhynchus anatinus (Shaw, 1799)',
@@ -38,20 +35,18 @@ describe('TaxonomicUnitWrapper', function () {
           scientificName: 'Ornithorhynchus paradoxus Blumenbach, 1800',
         }],
       });
-      assert.equal(wrapper.label, 'Ornithorhynchus anatinus (Shaw, 1799) or Ornithorhynchus paradoxus Blumenbach, 1800');
-
-      const scname0 = new phyx.ScientificNameWrapper(wrapper.scientificNames[0]);
-      const scname1 = new phyx.ScientificNameWrapper(wrapper.scientificNames[1]);
-
-      assert.equal(scname0.scientificName, 'Ornithorhynchus anatinus (Shaw, 1799)');
-      assert.equal(scname1.scientificName, 'Ornithorhynchus paradoxus Blumenbach, 1800');
-
-      assert.equal(scname0.genus, 'Ornithorhynchus');
-      assert.equal(scname1.genus, 'Ornithorhynchus');
-      assert.equal(scname0.specificEpithet, 'anatinus');
-      assert.equal(scname1.specificEpithet, 'paradoxus');
+      expect(wrapper.label).to.equal('Ornithorhynchus anatinus (Shaw, 1799) or Ornithorhynchus paradoxus Blumenbach, 1800');
     });
-    it('should wrap a taxonomic unit with a species name and a specimen identifier', function () {
+    it('should return a wrapped specimen identifier preceded by "Specimen"', function () {
+      const wrapper = new phyx.TaxonomicUnitWrapper({
+        includesSpecimens: [{
+          institutionCode: 'MVZ',
+          catalogNumber: '225749',
+        }],
+      });
+      assert.equal(wrapper.label, 'Specimen urn:catalog:MVZ::225749');
+    });
+    it('should return specimen identifiers and scientific names concatenated with "or"', function () {
       const wrapper = new phyx.TaxonomicUnitWrapper({
         scientificNames: [{
           scientificName: 'Rana luteiventris',
@@ -61,17 +56,17 @@ describe('TaxonomicUnitWrapper', function () {
           catalogNumber: '225749',
         }],
       });
-      assert.equal(wrapper.label, 'Specimen urn:catalog:MVZ::225749 or Rana luteiventris');
+      expect(wrapper.label).to.equal('Specimen urn:catalog:MVZ::225749 or Rana luteiventris');
     });
-    it('should wrap a taxonomic unit with an external reference', function () {
+    it('should return a wrapped external reference by surrounding it with "<>"', function () {
       const wrapper = new phyx.TaxonomicUnitWrapper({
         externalReferences: [
           'http://arctos.database.museum/guid/MVZ:Herp:225749',
         ],
       });
-      assert.equal(wrapper.label, '<http://arctos.database.museum/guid/MVZ:Herp:225749>');
+      expect(wrapper.label).to.equal('<http://arctos.database.museum/guid/MVZ:Herp:225749>');
     });
-    it('should wrap a taxonomic unit with a specimen identifier, external reference and a scientific name', function () {
+    it('should return a concatenated label for a taxonomic unit', function () {
       const wrapper = new phyx.TaxonomicUnitWrapper({
         externalReferences: [
           'http://arctos.database.museum/guid/MVZ:Herp:225749',
@@ -84,48 +79,39 @@ describe('TaxonomicUnitWrapper', function () {
           catalogNumber: '225749',
         }],
       });
-      assert.equal(wrapper.label, 'Specimen urn:catalog:MVZ::225749 or <http://arctos.database.museum/guid/MVZ:Herp:225749> or Rana luteiventris');
+      expect(wrapper.label)
+        .to.equal('Specimen urn:catalog:MVZ::225749 or <http://arctos.database.museum/guid/MVZ:Herp:225749> or Rana luteiventris');
     });
   });
   describe('#getTaxonomicUnitsFromNodeLabel', function () {
-    it('should catch invalid inputs', function () {
-      assert.deepEqual(phyx.TaxonomicUnitWrapper.getTaxonomicUnitsFromNodeLabel(), []);
-      assert.deepEqual(phyx.TaxonomicUnitWrapper.getTaxonomicUnitsFromNodeLabel(undefined), []);
-      assert.deepEqual(phyx.TaxonomicUnitWrapper.getTaxonomicUnitsFromNodeLabel(null), []);
-      assert.deepEqual(phyx.TaxonomicUnitWrapper.getTaxonomicUnitsFromNodeLabel(''), []);
-      assert.deepEqual(phyx.TaxonomicUnitWrapper.getTaxonomicUnitsFromNodeLabel('    '), []);
+    it('should return empty lists when inputs are empty or undefined', function () {
+      expect(phyx.TaxonomicUnitWrapper.getTaxonomicUnitsFromNodeLabel()).to.be.empty;
+      expect(phyx.TaxonomicUnitWrapper.getTaxonomicUnitsFromNodeLabel(undefined)).to.be.empty;
+      expect(phyx.TaxonomicUnitWrapper.getTaxonomicUnitsFromNodeLabel(null)).to.be.empty;
+      expect(phyx.TaxonomicUnitWrapper.getTaxonomicUnitsFromNodeLabel('')).to.be.empty;
+      expect(phyx.TaxonomicUnitWrapper.getTaxonomicUnitsFromNodeLabel('    ')).to.be.empty;
     });
-    it('should work for a scientific name with specimen label', function () {
-      assert.deepEqual(phyx.TaxonomicUnitWrapper.getTaxonomicUnitsFromNodeLabel('Rana luteiventris MVZ225749'), [{
-        scientificNames: [{
-          scientificName: 'Rana luteiventris MVZ225749',
-          genus: 'Rana',
-          specificEpithet: 'luteiventris',
-          binomialName: 'Rana luteiventris',
-        }],
-      }]);
+    it('when given a scientific name: should return a list of a single TU wrapping a scientific name', function () {
+      expect(phyx.TaxonomicUnitWrapper.getTaxonomicUnitsFromNodeLabel('Rana luteiventris MVZ225749'))
+        .to.be.deep.equal([{
+          scientificNames: [{
+            scientificName: 'Rana luteiventris MVZ225749',
+            genus: 'Rana',
+            specificEpithet: 'luteiventris',
+            binomialName: 'Rana luteiventris',
+          }],
+        }]);
     });
-    it('should work for a scientific name separated with underscores', function () {
-      assert.deepEqual(phyx.TaxonomicUnitWrapper.getTaxonomicUnitsFromNodeLabel('Rana_luteiventris_MVZ_225749'), [{
-        scientificNames: [{
-          scientificName: 'Rana luteiventris MVZ_225749',
-          genus: 'Rana',
-          specificEpithet: 'luteiventris',
-          binomialName: 'Rana luteiventris',
-        }],
-      }]);
-    });
-    it('should update the cache manager as it works', function () {
-      assert.deepEqual(phyx.TaxonomicUnitWrapper.getTaxonomicUnitsFromNodeLabel('Rana_luteiventris_MVZ_225749'), [{
-        scientificNames: [{
-          scientificName: 'Rana luteiventris MVZ_225749',
-          genus: 'Rana',
-          specificEpithet: 'luteiventris',
-          binomialName: 'Rana luteiventris',
-        }],
-      }]);
-      assert.isNotEmpty(phyx.phyxCacheManager.caches);
-      assert.isNotEmpty(phyx.phyxCacheManager.caches['TaxonomicUnitWrapper.taxonomicUnitsFromNodeLabelCache']);
+    it('when given a scientific name separated with underscores: should return a list of a single TU wrapping the scientific name', function () {
+      expect(phyx.TaxonomicUnitWrapper.getTaxonomicUnitsFromNodeLabel('Rana_luteiventris_MVZ_225749'))
+        .to.be.deep.equal([{
+          scientificNames: [{
+            scientificName: 'Rana luteiventris MVZ_225749',
+            genus: 'Rana',
+            specificEpithet: 'luteiventris',
+            binomialName: 'Rana luteiventris',
+          }],
+        }]);
     });
   });
 });
@@ -146,39 +132,37 @@ const tunit4 = {
 
 describe('TaxonomicUnitMarcher', function () {
   describe('#matchByBinomialName', function () {
-    it('should match by binomial name', function () {
-      assert.isNotOk(new phyx.TaxonomicUnitMatcher(tunit1, tunit2).matchByExternalReferences());
-      assert.isNotOk(new phyx.TaxonomicUnitMatcher(tunit1, tunit2).matchBySpecimenIdentifier());
-      assert.isOk(new phyx.TaxonomicUnitMatcher(tunit1, tunit2).matchByBinomialName());
-
-      const matcher = new phyx.TaxonomicUnitMatcher(tunit1, tunit2);
-      assert.isOk(matcher.matched);
-      assert.isDefined(matcher.matchReason);
-      assert.include(matcher.matchReason, 'share the same binomial name');
+    it('should be able to match taxonomic units by binomial name', function () {
+      expect(new phyx.TaxonomicUnitMatcher(tunit1, tunit2).matchByExternalReferences()).to.be.false;
+      expect(new phyx.TaxonomicUnitMatcher(tunit1, tunit2).matchBySpecimenIdentifier()).to.be.false;
+      expect(new phyx.TaxonomicUnitMatcher(tunit1, tunit2).matchByBinomialName()).to.be.true;
     });
   });
   describe('#matchByExternalReferences', function () {
     it('should match by external references', function () {
-      assert.isOk(new phyx.TaxonomicUnitMatcher(tunit3, tunit4).matchByExternalReferences());
-      assert.isNotOk(new phyx.TaxonomicUnitMatcher(tunit3, tunit4).matchBySpecimenIdentifier());
-      assert.isNotOk(new phyx.TaxonomicUnitMatcher(tunit3, tunit4).matchByBinomialName());
-
-      const matcher = new phyx.TaxonomicUnitMatcher(tunit3, tunit4);
-      assert.isOk(matcher.matched);
-      assert.isDefined(matcher.matchReason);
-      assert.include(matcher.matchReason, 'External reference');
+      expect(new phyx.TaxonomicUnitMatcher(tunit3, tunit4).matchByExternalReferences()).to.be.true;
+      expect(new phyx.TaxonomicUnitMatcher(tunit3, tunit4).matchBySpecimenIdentifier()).to.be.false;
+      expect(new phyx.TaxonomicUnitMatcher(tunit3, tunit4).matchByBinomialName()).to.be.false;
     });
   });
   describe('#matchBySpecimenIdentifier', function () {
     it('should match by specimen identifiers', function () {
-      assert.isNotOk(new phyx.TaxonomicUnitMatcher(tunit2, tunit3).matchByExternalReferences());
-      assert.isOk(new phyx.TaxonomicUnitMatcher(tunit2, tunit3).matchBySpecimenIdentifier());
-      assert.isNotOk(new phyx.TaxonomicUnitMatcher(tunit2, tunit3).matchByBinomialName());
-
-      const matcher = new phyx.TaxonomicUnitMatcher(tunit2, tunit3);
-      assert.isOk(matcher.matched);
-      assert.isDefined(matcher.matchReason);
-      assert.include(matcher.matchReason, 'Specimen identifier');
+      expect(new phyx.TaxonomicUnitMatcher(tunit2, tunit3).matchByExternalReferences()).to.be.false;
+      expect(new phyx.TaxonomicUnitMatcher(tunit2, tunit3).matchBySpecimenIdentifier()).to.be.true;
+      expect(new phyx.TaxonomicUnitMatcher(tunit2, tunit3).matchByBinomialName()).to.be.false;
     });
+  });
+  describe('#matched and #matchReason', function () {
+    let matcher = new phyx.TaxonomicUnitMatcher(tunit1, tunit2);
+    expect(matcher.matched).to.be.true;
+    expect(matcher.matchReason).to.include('share the same binomial name');
+
+    matcher = new phyx.TaxonomicUnitMatcher(tunit3, tunit4);
+    expect(matcher.matched).to.be.true;
+    expect(matcher.matchReason).to.include('External reference');
+
+    matcher = new phyx.TaxonomicUnitMatcher(tunit2, tunit3);
+    expect(matcher.matched).to.be.true;
+    expect(matcher.matchReason).to.include('Specimen identifier');
   });
 });

--- a/test/vue-model.js
+++ b/test/vue-model.js
@@ -17,54 +17,61 @@ require('../lib/phylotree.js/phylotree.js');
 
 // Load the Curation Tool code, which exports only the Vue model as 'vm'.
 // Store that in a variable for easy access.
-const ct = require('../js/curation-tool.js');
-const vm = ct.vm;
-
+const vm = require('../js/curation-tool.js').vm;
 const chai = require('chai');
-const phyx = require('../js/phyx');
 
 const assert = chai.assert;
+const expect = chai.expect;
 
 // Test phylogeny spacingX and spacingY.
 describe('Phylogeny spacing', function () {
   describe('spacingX', function () {
-    it('should be modifiable', function () {
+    it('should initially be set to vm.DEFAULT_SPACING_X', function () {
       // getPhylogenySpacing...() doesn't actually need the phylogeny to exist
       // when getting the values. In this test, we use only phylogenySpacingX[0].
-      var spacingX = vm.getPhylogenySpacingX(0);
-      assert.isOk(spacingX);
-      assert.equal(spacingX, vm.DEFAULT_SPACING_X, 'Initial spacingX should be set to the default');
-
-      // To set the phylogeny, we need to update phylogenySpacingX directly.
-      vm.changePhylogenySpacingX(0, 104 - vm.DEFAULT_SPACING_X);
-      assert.equal(vm.getPhylogenySpacingX(0), 104, 'spacingX can be changed by modifying the returned value');
+      const spacingX = vm.getPhylogenySpacingX(0);
+      expect(spacingX).to.equal(vm.DEFAULT_SPACING_X);
     });
 
-    it('should not be shared by all phylogenies', function () {
+    it('should be changeable using .changePhylogenySpacingX', function () {
+      // To set the phylogeny, we need to update phylogenySpacingX directly.
+      // We change the spacingX so it should equal 104 (an arbitrary number).
+      vm.changePhylogenySpacingX(0, 104 - vm.DEFAULT_SPACING_X);
+      expect(vm.getPhylogenySpacingX(0)).to.equal(104);
+    });
+
+    it('changing spacing for one phylogeny should not change it for another', function () {
       // Set the spacing value for the second phylogeny (phylogenySpacingX[1]).
+      // We'll set it to 208 (another arbitrary number). We then make sure
+      // that the first phylogeny spacingX remains at 104.
       vm.changePhylogenySpacingX(1, 208 - vm.DEFAULT_SPACING_X);
-      assert.equal(vm.getPhylogenySpacingX(1), 208, 'spacingX[1] has a new value');
-      assert.equal(vm.getPhylogenySpacingX(0), 104, 'spacingX[0] retains its existing value from the previous test');
+      expect(vm.getPhylogenySpacingX(1)).to.equal(208);
+      expect(vm.getPhylogenySpacingX(0)).to.equal(104);
     });
   });
+
   describe('spacingY', function () {
-    it('should be modifiable', function () {
+    it('should initially be set to vm.DEFAULT_SPACING_Y', function () {
       // getPhylogenySpacing...() doesn't actually need the phylogeny to exist
       // when getting the values. In this test, we use only phylogenySpacingY[0].
-      var spacingY = vm.getPhylogenySpacingY(0);
-      assert.isOk(spacingY);
-      assert.equal(spacingY, vm.DEFAULT_SPACING_Y, 'Initial spacingY should be set to the default');
-
-      // To set the phylogeny, we need to update phylogenySpacingY directly.
-      vm.changePhylogenySpacingY(0, 17 - vm.DEFAULT_SPACING_Y);
-      assert.equal(vm.getPhylogenySpacingY(0), 17, 'spacingY can be changed by modifying the returned value');
+      const spacingY = vm.getPhylogenySpacingY(0);
+      expect(spacingY).to.equal(vm.DEFAULT_SPACING_Y);
     });
-    
-    it('should not be shared by all phylogenies', function () {
+
+    it('should be changeable using .changePhylogenySpacingY', function () {
+      // To set the phylogeny, we need to update phylogenySpacingY directly.
+      // We change the spacingY so it should equal 35 (an arbitrary number).
+      vm.changePhylogenySpacingY(0, 35 - vm.DEFAULT_SPACING_Y);
+      expect(vm.getPhylogenySpacingY(0)).to.equal(35);
+    });
+
+    it('changing spacing for one phylogeny should not change it for another', function () {
       // Set the spacing value for the second phylogeny (phylogenySpacingY[1]).
-      vm.changePhylogenySpacingY(1, 19 - vm.DEFAULT_SPACING_Y);
-      assert.equal(vm.getPhylogenySpacingY(1), 19, 'spacingY[1] has a new value');
-      assert.equal(vm.getPhylogenySpacingY(0), 17, 'spacingY[0] retains its existing value from the previous test');
+      // We'll set it to 55 (another arbitrary number). We then make sure
+      // that the first phylogeny spacingY remains at 35.
+      vm.changePhylogenySpacingY(1, 55 - vm.DEFAULT_SPACING_Y);
+      expect(vm.getPhylogenySpacingY(1)).to.equal(55);
+      expect(vm.getPhylogenySpacingY(0)).to.equal(35);
     });
   });
 });

--- a/test/vue-model.js
+++ b/test/vue-model.js
@@ -2,7 +2,10 @@
  * Test aspects of the Curation Tool Vue model.
  */
 
-/* eslint-env mocha */
+// Use the Chai library's Expect API for testing.
+const chai = require('chai');
+
+const expect = chai.expect;
 
 // Load d3 as a global variable so it can be accessed by both phylotree.js (which
 // needs to add additional objects to it) and phyx (which needs to call it).
@@ -18,30 +21,31 @@ require('../lib/phylotree.js/phylotree.js');
 // Load the Curation Tool code, which exports only the Vue model as 'vm'.
 // Store that in a variable for easy access.
 const vm = require('../js/curation-tool.js').vm;
-const chai = require('chai');
 
-const assert = chai.assert;
-const expect = chai.expect;
+/*
+ * Vue model tests are not intended to be comprehensive for now, but for tracking
+ * previously identified bugs to ensure that they don't regress. We currently
+ * test:
+ *  - The phylogeny spacing bug (https://github.com/phyloref/curation-tool/pull/100)
+ */
 
 // Test phylogeny spacingX and spacingY.
 describe('Phylogeny spacing', function () {
   describe('spacingX', function () {
     it('should initially be set to vm.DEFAULT_SPACING_X', function () {
-      // getPhylogenySpacing...() doesn't actually need the phylogeny to exist
+      // getPhylogenySpacing...() doesn't actually need a phylogeny to exist
       // when getting the values. In this test, we use only phylogenySpacingX[0].
       const spacingX = vm.getPhylogenySpacingX(0);
       expect(spacingX).to.equal(vm.DEFAULT_SPACING_X);
     });
 
     it('should be changeable using .changePhylogenySpacingX', function () {
-      // To set the phylogeny, we need to update phylogenySpacingX directly.
       // We change the spacingX so it should equal 104 (an arbitrary number).
       vm.changePhylogenySpacingX(0, 104 - vm.DEFAULT_SPACING_X);
       expect(vm.getPhylogenySpacingX(0)).to.equal(104);
     });
 
     it('changing spacing for one phylogeny should not change it for another', function () {
-      // Set the spacing value for the second phylogeny (phylogenySpacingX[1]).
       // We'll set it to 208 (another arbitrary number). We then make sure
       // that the first phylogeny spacingX remains at 104.
       vm.changePhylogenySpacingX(1, 208 - vm.DEFAULT_SPACING_X);
@@ -59,14 +63,12 @@ describe('Phylogeny spacing', function () {
     });
 
     it('should be changeable using .changePhylogenySpacingY', function () {
-      // To set the phylogeny, we need to update phylogenySpacingY directly.
       // We change the spacingY so it should equal 35 (an arbitrary number).
       vm.changePhylogenySpacingY(0, 35 - vm.DEFAULT_SPACING_Y);
       expect(vm.getPhylogenySpacingY(0)).to.equal(35);
     });
 
     it('changing spacing for one phylogeny should not change it for another', function () {
-      // Set the spacing value for the second phylogeny (phylogenySpacingY[1]).
       // We'll set it to 55 (another arbitrary number). We then make sure
       // that the first phylogeny spacingY remains at 35.
       vm.changePhylogenySpacingY(1, 55 - vm.DEFAULT_SPACING_Y);


### PR DESCRIPTION
Updated test suite to use [Chai's Expect API](https://www.chaijs.com/api/bdd/) to make individual tests more readable and used a when-should framing that should clarify what is being tested and what is expected. This should result in clearer tests and [more readable test results](https://travis-ci.org/phyloref/curation-tool/builds/471446557), and should be a first step towards behavior-based testing (#75).

I switched from the [Assert API](https://www.chaijs.com/api/bdd/) to the Expect API mainly because the Chai documentation promised that this [was a more behavior-based approach to testing](https://www.chaijs.com/guide/styles/), but I found that in practice the two are pretty similar and are generally equally readable. Since it is clearly better in a few cases -- such as where an array could be expected to have a particular length or when we want to test booleans to be true or false -- and since the tests will be more readable if they are consistently structured, I've moved all the tests over to the Expect API. In the future, I don't think we need to replace the Assert API unless there is a clear benefit from doing so.

Ready for review. Should be merged after PR #134 has been merged.