### PR TITLE
Revert making `phyloref:Phyloreference` the superclass of all phyloreferences

### DIFF
--- a/js/phyx.js
+++ b/js/phyx.js
@@ -1206,9 +1206,10 @@ class PhylorefWrapper {
     phylorefAsJSONLD['@id'] = phylorefURI;
 
     // These classes are phyloreferences, and so should be classified as such.
-    phylorefAsJSONLD['rdfs:subClassOf'] = 'phyloref:Phyloreference';
+    // phylorefAsJSONLD['subClassOf'] = 'phyloref:Phyloreference';
 
     phylorefAsJSONLD['@type'] = [
+      'phyloref:Phyloreference',
       // Since we're writing this in RDF, just adding a '@type' of
       // phyloref:Phyloreference would imply that phylorefURI is a named
       // individual of class phyloref:Phyloreference. We need to explicitly

--- a/js/phyx.js
+++ b/js/phyx.js
@@ -1205,10 +1205,10 @@ class PhylorefWrapper {
     // Set the @id and @type.
     phylorefAsJSONLD['@id'] = phylorefURI;
 
-    // These classes are phyloreferences, and so should be classified as such.
-    // phylorefAsJSONLD['subClassOf'] = 'phyloref:Phyloreference';
-
     phylorefAsJSONLD['@type'] = [
+      // We pun this as an instance that is a Phyloreference.
+      // (We need this to ensure that the object properties that store
+      // information on specifiers will work correctly)
       'phyloref:Phyloreference',
       // Since we're writing this in RDF, just adding a '@type' of
       // phyloref:Phyloreference would imply that phylorefURI is a named


### PR DESCRIPTION
Setting `phyloref:Phyloreference` to the superclass of all phyloreferences messed something up in JPhyloRef, which now won't reason over them correctly. This ought to be a priority, but since we're going to replace this entire model with phyloref/phyloref-ontology#29 pretty soon, I'm just going to revert it for now and then overhaul the entire model later.