### PR TITLE
Add support for editing citations

### DIFF
--- a/src/components/citations/Citation.vue
+++ b/src/components/citations/Citation.vue
@@ -1,11 +1,42 @@
 <template>
-  <div>
-    <div class="input-group" v-for="citation of citations">
-      <input type="text" class="form-control" placeholder="Citation" :value="asText(citation)">
-      <div class="input-group-append">
-        <a class="btn btn-outline-secondary" target="_blank" :href="doiFor(citation)" :disabled="!doiFor(citation)">Open in new window</a>
-      </div>
-    </div>R
+  <div class="form-group row">
+    <label class="col-form-label col-md-2">
+      {{label}}
+    </label>
+    <div class="col-md-10">
+      <template v-if="citations.length === 0">
+        <a href="javascript:;" @click="citations.push({})">Add citation</a>
+      </template>
+      <template v-for="(citation, citationIndex) of citations">
+        <div class="input-group">
+          <input type="text" class="form-control" placeholder="Citation" :value="asText(citation)">
+          <div class="input-group-append">
+            <a class="btn btn-secondary" @click="toggleCitationExpanded(citationIndex)" href="javascript:;">Expand</a>
+          </div>
+        </div>
+        <div class="card mt-1" v-if="citationsExpanded.includes(citationIndex)">
+          <div class="card-body">
+            <h5 class="card-title">Citation details</h5>
+            <div class="form-group row">
+              <label class="col-form-label col-md-2" for="doi">DOIs (one per line)</label>
+              <div class="input-group col-md-10">
+                <textarea id="doi" rows="3" class="form-control"
+                  placeholder="Enter DOIs here"
+                  :value="wrappedCitation(citation).dois.join('\n')"
+                  @change="setDOIs(citation, $event.target.value.split(/\s*\n\s*/))"
+                ></textarea>
+                <div class="input-group-append">
+                  <a class="btn btn-outline-secondary" target="_blank"
+                    :href="'http://doi.org/' + wrappedCitation(citation).firstDOI"
+                    :class="{disabled: !wrappedCitation(citation).firstDOI}"
+                    >Open in new window</a>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </template>
+    </div>
   </div>
 </template>
 
@@ -14,26 +45,80 @@
  * Displays a citation as a textfield/expanded field.
  */
 
-import { has, isEmpty } from 'lodash';
+import Vue from 'vue';
+import { has, isEmpty, isEqual, cloneDeep } from 'lodash';
 
 export default {
   name: 'Citation',
   props: {
-    citations: { /* The citations to display and edit */
-      type: Array,
+    label: { /* The label for this citation */
+      type: String,
+      default: 'Citation',
+    },
+    object: { /* The object containing the citation to display and edit */
+      type: Object,
       required: true,
+    },
+    citationKey: { /* The key on the object containing the citation to display and edit */
+      type: String,
+      required: true
+    }
+  },
+  data() {
+    return {
+      // Which citations have been expanded (by index).
+      citationsExpanded: [],
+
+      // Copy of the citations provided to this component.
+      citations: cloneDeep(this.object[this.citationKey] || []),
+
+      // Items used to store new items.
+      newDOI: "",
+    };
+  },
+  watch: {
+    citations() {
+      console.log('citations()');
+
+      // If our citations change, we should reflect them back to the
+      // original object.
+      if (isEmpty(this.citations)) return;
+      if (isEqual(this.citations, this.object[this.citationKey])) return;
+
+      console.log('setCitations:', this.object, this.citationKey, this.citations);
+
+      this.$store.commit('setCitations', {
+        object: this.object,
+        citationKey: this.citationKey,
+        citations: this.citations,
+      })
     },
   },
   methods: {
-    asText(citation) {
-      // console.log(asCite(citation).format('data'));
-      // return asCite(citation).format('citation');
-      return '';
+    toggleCitationExpanded(citationIndex) {
+      console.log('Checking', citationIndex, 'against', this.citationsExpanded);
+
+      if (this.citationsExpanded.includes(citationIndex))
+        this.citationsExpanded = this.citationsExpanded.filter(index => index !== citationIndex);
+      else
+        this.citationsExpanded.push(citationIndex);
+
+      console.log('Now at', this.citationsExpanded);
     },
-    doiFor(citation) {
-      //return citation['bibo:doi'] || undefined;
-      return '';
-    }
+    wrappedCitation(citation) {
+      return this.$store.getters.getWrappedCitation(citation);
+    },
+    asText(citation) {
+      return this.$store.getters.getWrappedCitation(citation).toString();
+    },
+    doisFor(citation) {
+      return this.$store.getters.getWrappedCitation(citation).dois;
+    },
+    setDOIs(citation, dois) {
+      console.log("Setting citation", citation, "to DOIs", dois);
+      Vue.set(citation, 'identifier', dois.map(doi => { return { type: 'doi', id: doi }; }));
+      console.log("Citations now at:", this.citations);
+    },
   }
 };
 </script>

--- a/src/components/citations/Citation.vue
+++ b/src/components/citations/Citation.vue
@@ -28,6 +28,16 @@
               </div>
             </div>
             <div class="form-group row">
+              <label class="col-form-label col-md-2" for="title">Title</label>
+              <div class="col-md-10">
+                <input id="title" type="text" class="form-control"
+                  placeholder="Enter title here"
+                  v-model="citation.title"
+                  @change="updateCitations()"
+                />
+              </div>
+            </div>
+            <div class="form-group row">
               <label class="col-form-label col-md-2" for="doi">DOIs (one per line)</label>
               <div class="col-md-10">
                 <div class="input-group">

--- a/src/components/citations/Citation.vue
+++ b/src/components/citations/Citation.vue
@@ -20,7 +20,7 @@
             readonly
             class="form-control hand-cursor"
             placeholder="Citation"
-            :value="wrappedCitation(citation).toString()"
+            :value="wrappedCitation(citation).toString() || 'Empty citation, click to enter'"
             @click="toggleCitationExpanded(citationIndex)"
           >
           <div class="input-group-append">
@@ -118,6 +118,105 @@
               </div>
             </div>
 
+            <!-- Section title -->
+            <div v-if="citation.type === 'book_section'" class="form-group row">
+              <label
+                class="col-form-label col-md-2"
+                for="section-title"
+              >
+                Section title
+              </label>
+              <div class="col-md-10">
+                <input
+                  id="section-title"
+                  v-model="citation.section_title"
+                  type="text"
+                  class="form-control"
+                  placeholder="Enter section title here"
+                  @change="updateCitations()"
+                >
+              </div>
+            </div>
+
+            <!-- Publication year -->
+            <div class="form-group row">
+              <label
+                class="col-form-label col-md-2"
+                for="year"
+              >
+                Year
+              </label>
+              <div class="col-md-4">
+                <input
+                  id="year"
+                  v-model="citation.year"
+                  type="text"
+                  class="form-control"
+                  placeholder="Enter year here"
+                  @change="updateCitations()"
+                >
+              </div>
+
+              <!-- Edition -->
+              <template v-if="citation.type !== 'journal'">
+                <label
+                  class="col-form-label col-md-2"
+                  for="edition"
+                >
+                  Edition
+                </label>
+                <div class="col-md-4">
+                  <input
+                    id="edition"
+                    v-model="citation.edition"
+                    type="text"
+                    class="form-control"
+                    placeholder="Enter edition here"
+                    @change="updateCitations()"
+                  >
+                </div>
+              </template>
+            </div>
+
+            <!-- Pages and figure -->
+            <div class="form-group row">
+              <!-- Pages -->
+              <label
+                class="col-form-label col-md-2"
+                for="pages"
+              >
+                Pages
+              </label>
+              <div class="col-md-4">
+                <input
+                  id="pages"
+                  v-model="wrappedCitation(citation).journal.pages"
+                  type="text"
+                  class="form-control"
+                  placeholder="Enter pages here"
+                  @change="updateCitations()"
+                >
+              </div>
+
+              <!-- Figure -->
+              <label
+                class="col-form-label col-md-2"
+                for="figure"
+              >
+                Figure
+              </label>
+              <div class="col-md-4">
+                <input
+                  id="figure"
+                  v-model="citation.figure"
+                  type="text"
+                  class="form-control"
+                  placeholder="Enter figure number here"
+                  @change="updateCitations()"
+                >
+              </div>
+            </div>
+
             <!-- Only for journal entries! -->
             <template v-if="citation.type === 'journal'">
               <!-- Journal title -->
@@ -140,15 +239,16 @@
                 </div>
               </div>
 
-              <!-- Journal volume -->
+              <!-- Journal volume and issue -->
               <div class="form-group row">
+                <!-- Journal volume -->
                 <label
                   class="col-form-label col-md-2"
                   for="journal-volume"
                 >
                   Volume
                 </label>
-                <div class="col-md-10">
+                <div class="col-md-4">
                   <input
                     id="journal-volume"
                     v-model="wrappedCitation(citation).journal.volume"
@@ -158,62 +258,27 @@
                     @change="updateCitations()"
                   >
                 </div>
-              </div>
 
-              <!-- Journal pages -->
-              <div class="form-group row">
+                <!-- Journal issue/number -->
                 <label
                   class="col-form-label col-md-2"
-                  for="journal-pages"
+                  for="journal-issue"
                 >
-                  Pages
+                  Issue number
                 </label>
-                <div class="col-md-10">
+                <div class="col-md-4">
                   <input
-                    id="journal-pages"
-                    v-model="wrappedCitation(citation).journal.pages"
+                    id="journal-issue"
+                    v-model="wrappedCitation(citation).journal.number"
                     type="text"
                     class="form-control"
-                    placeholder="Enter journal pages here"
+                    placeholder="Enter journal issue number here"
                     @change="updateCitations()"
                   >
                 </div>
               </div>
 
-              <!-- ISBNs (one per line) -->
-              <div class="form-group row">
-                <label
-                  class="col-form-label col-md-2"
-                  for="isbns"
-                >
-                  ISBNs (one per line)
-                </label>
-                <div class="col-md-10">
-                  <div class="input-group">
-                    <textarea
-                      id="isbns"
-                      rows="1"
-                      class="form-control"
-                      placeholder="Enter ISBNs here"
-                      :value="wrappedCitation(wrappedCitation(citation).journal).isbns.join('\n')"
-                      @change="wrappedCitation(wrappedCitation(citation).journal).isbns = $event.target.value.split(/\s*\n\s*/); updateCitations()"
-                    />
-                    <div class="input-group-append">
-                      <a
-                        class="btn btn-outline-secondary align-middle"
-                        target="_blank"
-                        style="vertical-align: middle"
-                        :href="'https://www.worldcat.org/search?q=bn%3A' + wrappedCitation(wrappedCitation(citation).journal).isbns[0]"
-                        :class="{disabled: (wrappedCitation(wrappedCitation(citation).journal).isbns || []).length === 0}"
-                      >
-                        Open in new window
-                      </a>
-                    </div>
-                  </div>
-                </div>
-              </div>
-
-              <!-- ISBNs (one per line) -->
+              <!-- ISSNs (one per line) -->
               <div class="form-group row">
                 <label
                   class="col-form-label col-md-2"
@@ -246,6 +311,78 @@
                 </div>
               </div>
             </template>
+
+            <!-- ISBNs (one per line) -->
+            <div class="form-group row">
+              <label
+                class="col-form-label col-md-2"
+                for="isbns"
+              >
+                ISBNs (one per line)
+              </label>
+              <div class="col-md-10">
+                <div class="input-group">
+                  <textarea
+                    id="isbns"
+                    rows="1"
+                    class="form-control"
+                    placeholder="Enter ISBNs here"
+                    :value="wrappedCitation(wrappedCitation(citation).journal).isbns.join('\n')"
+                    @change="wrappedCitation(wrappedCitation(citation).journal).isbns = $event.target.value.split(/\s*\n\s*/); updateCitations()"
+                  />
+                  <div class="input-group-append">
+                    <a
+                      class="btn btn-outline-secondary align-middle"
+                      target="_blank"
+                      style="vertical-align: middle"
+                      :href="'https://www.worldcat.org/search?q=bn%3A' + wrappedCitation(wrappedCitation(citation).journal).isbns[0]"
+                      :class="{disabled: (wrappedCitation(wrappedCitation(citation).journal).isbns || []).length === 0}"
+                    >
+                      Open in new window
+                    </a>
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            <!-- Publisher and city -->
+            <div class="form-group row">
+              <!-- Publisher -->
+              <label
+                class="col-form-label col-md-2"
+                for="publisher"
+              >
+                Publisher
+              </label>
+              <div class="col-md-4">
+                <input
+                  id="publisher"
+                  v-model="citation.publisher"
+                  type="text"
+                  class="form-control"
+                  placeholder="Enter publisher here"
+                  @change="updateCitations()"
+                >
+              </div>
+
+              <!-- Publication city -->
+              <label
+                class="col-form-label col-md-2"
+                for="city"
+              >
+                City
+              </label>
+              <div class="col-md-4">
+                <input
+                  id="city"
+                  v-model="citation.city"
+                  type="text"
+                  class="form-control"
+                  placeholder="Enter publication city here"
+                  @change="updateCitations()"
+                >
+              </div>
+            </div>
 
             <!-- DOIs (one per line) -->
             <div class="form-group row">

--- a/src/components/citations/Citation.vue
+++ b/src/components/citations/Citation.vue
@@ -65,8 +65,8 @@
                   class="form-control"
                   @change="updateCitations()"
                 >
-                  <option value="journal">
-                    Journal
+                  <option value="article">
+                    Article
                   </option>
                   <option value="book">
                     Book
@@ -201,7 +201,7 @@
               </div>
 
               <!-- Edition -->
-              <template v-if="citation.type !== 'journal'">
+              <template v-if="citation.type !== 'article'">
                 <label
                   class="col-form-label col-md-2"
                   for="edition"
@@ -260,8 +260,8 @@
               </div>
             </div>
 
-            <!-- Only for journal entries! -->
-            <template v-if="citation.type === 'journal'">
+            <!-- Only for article entries! -->
+            <template v-if="citation.type === 'article'">
               <!-- Journal title -->
               <div class="form-group row">
                 <label

--- a/src/components/citations/Citation.vue
+++ b/src/components/citations/Citation.vue
@@ -1,117 +1,213 @@
 <template>
   <div class="form-group row">
     <label class="col-form-label col-md-2">
-      {{label}}
+      {{ label }}
     </label>
     <div class="col-md-10">
       <template v-if="citations.length === 0">
-        <a class="form-control-plaintext" href="javascript:;" @click="citations.push({})">Add citation</a>
+        <a
+          class="form-control-plaintext"
+          href="javascript:;"
+          @click="citations.push({})"
+        >
+          Add citation
+        </a>
       </template>
       <template v-for="(citation, citationIndex) of citations">
         <div class="input-group">
-          <input @click="toggleCitationExpanded(citationIndex)" type="text" readonly class="form-control hand-cursor" placeholder="Citation" :value="wrappedCitation(citation).toString()">
+          <input
+            type="text"
+            readonly
+            class="form-control hand-cursor"
+            placeholder="Citation"
+            :value="wrappedCitation(citation).toString()"
+            @click="toggleCitationExpanded(citationIndex)"
+          >
           <div class="input-group-append">
-            <a v-if="wrappedCitation(citation).firstURL" class="btn btn-primary" target="_blank" :href="wrappedCitation(citation).firstURL">Open in new window</a>
-            <a class="btn btn-secondary" @click="toggleCitationExpanded(citationIndex)" href="javascript:;">Expand</a>
+            <a
+              v-if="wrappedCitation(citation).firstURL"
+              class="btn btn-primary"
+              target="_blank"
+              :href="wrappedCitation(citation).firstURL"
+            >
+              Open in new window
+            </a>
+            <a
+              class="btn btn-secondary"
+              href="javascript:;"
+              @click="toggleCitationExpanded(citationIndex)"
+            >
+              Expand
+            </a>
           </div>
         </div>
-        <div class="card mt-1" v-if="citationsExpanded.includes(citationIndex)">
+        <div
+          v-if="citationsExpanded.includes(citationIndex)"
+          class="card mt-1"
+        >
           <div class="card-body">
-            <h5 class="card-title">Citation details</h5>
+            <h5 class="card-title">
+              Citation details
+            </h5>
 
             <!-- Citation type -->
             <div class="form-group row">
-              <label class="col-form-label col-md-2" for="citation-type">Citation type</label>
+              <label
+                class="col-form-label col-md-2"
+                for="citation-type"
+              >
+                Citation type
+              </label>
               <div class="col-md-10">
-                <select id="citation-type" class="form-control"
+                <select
+                  id="citation-type"
                   v-model="citation.type"
+                  class="form-control"
                   @change="updateCitations()"
                 >
-                  <option value="journal">Journal</option>
-                  <option value="book">Book</option>
-                  <option value="book_section">Book section</option>
+                  <option value="journal">
+                    Journal
+                  </option>
+                  <option value="book">
+                    Book
+                  </option>
+                  <option value="book_section">
+                    Book section
+                  </option>
                 </select>
               </div>
             </div>
 
             <!-- Authors (one per line) -->
             <div class="form-group row">
-              <label class="col-form-label col-md-2" for="authors">Authors (one per line)</label>
+              <label
+                class="col-form-label col-md-2"
+                for="authors"
+              >
+                Authors (one per line)
+              </label>
               <div class="col-md-10">
-                <textarea id="authors" rows="3" class="form-control"
+                <textarea
+                  id="authors"
+                  rows="3"
+                  class="form-control"
                   placeholder="Enter authors here"
                   :value="wrappedCitation(citation).authorsAsStrings.join('\n')"
                   @change="wrappedCitation(citation).authorsAsStrings = $event.target.value.split(/\s*\n\s*/); updateCitations();"
-                ></textarea>
+                />
               </div>
             </div>
 
             <!-- Title -->
             <div class="form-group row">
-              <label class="col-form-label col-md-2" for="title">Title</label>
+              <label
+                class="col-form-label col-md-2"
+                for="title"
+              >
+                Title
+              </label>
               <div class="col-md-10">
-                <input id="title" type="text" class="form-control"
-                  placeholder="Enter title here"
+                <input
+                  id="title"
                   v-model="citation.title"
+                  type="text"
+                  class="form-control"
+                  placeholder="Enter title here"
                   @change="updateCitations()"
-                />
+                >
               </div>
             </div>
 
             <!-- Only for journal entries! -->
             <template v-if="citation.type === 'journal'">
-
               <!-- Journal title -->
               <div class="form-group row">
-                <label class="col-form-label col-md-2" for="journal-title">Journal title</label>
+                <label
+                  class="col-form-label col-md-2"
+                  for="journal-title"
+                >
+                  Journal title
+                </label>
                 <div class="col-md-10">
-                  <input id="journal-title" type="text" class="form-control"
-                    placeholder="Enter journal title here"
+                  <input
+                    id="journal-title"
                     v-model="wrappedCitation(citation).journal.name"
+                    type="text"
+                    class="form-control"
+                    placeholder="Enter journal title here"
                     @change="updateCitations()"
-                  />
+                  >
                 </div>
               </div>
 
               <!-- Journal volume -->
               <div class="form-group row">
-                <label class="col-form-label col-md-2" for="journal-volume">Volume</label>
+                <label
+                  class="col-form-label col-md-2"
+                  for="journal-volume"
+                >
+                  Volume
+                </label>
                 <div class="col-md-10">
-                  <input id="journal-volume" type="text" class="form-control"
-                    placeholder="Enter journal volume number here"
+                  <input
+                    id="journal-volume"
                     v-model="wrappedCitation(citation).journal.volume"
+                    type="text"
+                    class="form-control"
+                    placeholder="Enter journal volume number here"
                     @change="updateCitations()"
-                  />
+                  >
                 </div>
               </div>
 
               <!-- Journal pages -->
               <div class="form-group row">
-                <label class="col-form-label col-md-2" for="journal-pages">Pages</label>
+                <label
+                  class="col-form-label col-md-2"
+                  for="journal-pages"
+                >
+                  Pages
+                </label>
                 <div class="col-md-10">
-                  <input id="journal-pages" type="text" class="form-control"
-                    placeholder="Enter journal pages here"
+                  <input
+                    id="journal-pages"
                     v-model="wrappedCitation(citation).journal.pages"
+                    type="text"
+                    class="form-control"
+                    placeholder="Enter journal pages here"
                     @change="updateCitations()"
-                  />
+                  >
                 </div>
               </div>
 
               <!-- ISBNs (one per line) -->
               <div class="form-group row">
-                <label class="col-form-label col-md-2" for="isbns">ISBNs (one per line)</label>
+                <label
+                  class="col-form-label col-md-2"
+                  for="isbns"
+                >
+                  ISBNs (one per line)
+                </label>
                 <div class="col-md-10">
                   <div class="input-group">
-                    <textarea id="isbns" rows="1" class="form-control"
+                    <textarea
+                      id="isbns"
+                      rows="1"
+                      class="form-control"
                       placeholder="Enter ISBNs here"
                       :value="wrappedCitation(wrappedCitation(citation).journal).isbns.join('\n')"
                       @change="wrappedCitation(wrappedCitation(citation).journal).isbns = $event.target.value.split(/\s*\n\s*/); updateCitations()"
-                    ></textarea>
+                    />
                     <div class="input-group-append">
-                      <a class="btn btn-outline-secondary align-middle" target="_blank" style="vertical-align: middle"
+                      <a
+                        class="btn btn-outline-secondary align-middle"
+                        target="_blank"
+                        style="vertical-align: middle"
                         :href="'https://www.worldcat.org/search?q=bn%3A' + wrappedCitation(wrappedCitation(citation).journal).isbns[0]"
                         :class="{disabled: (wrappedCitation(wrappedCitation(citation).journal).isbns || []).length === 0}"
-                        >Open in new window</a>
+                      >
+                        Open in new window
+                      </a>
                     </div>
                   </div>
                 </div>
@@ -119,41 +215,66 @@
 
               <!-- ISBNs (one per line) -->
               <div class="form-group row">
-                <label class="col-form-label col-md-2" for="issns">ISSNs (one per line)</label>
+                <label
+                  class="col-form-label col-md-2"
+                  for="issns"
+                >
+                  ISSNs (one per line)
+                </label>
                 <div class="col-md-10">
                   <div class="input-group">
-                    <textarea id="issns" rows="1" class="form-control"
+                    <textarea
+                      id="issns"
+                      rows="1"
+                      class="form-control"
                       placeholder="Enter ISSNs here"
                       :value="wrappedCitation(wrappedCitation(citation).journal).issns.join('\n')"
                       @change="wrappedCitation(wrappedCitation(citation).journal).issns = $event.target.value.split(/\s*\n\s*/); updateCitations()"
-                    ></textarea>
+                    />
                     <div class="input-group-append">
-                      <a class="btn btn-outline-secondary align-middle" target="_blank" style="vertical-align: middle"
+                      <a
+                        class="btn btn-outline-secondary align-middle"
+                        target="_blank"
+                        style="vertical-align: middle"
                         :href="'https://www.worldcat.org/search?q=n2%3A' + wrappedCitation(wrappedCitation(citation).journal).issns[0]"
                         :class="{disabled: (wrappedCitation(wrappedCitation(citation).journal).issns || []).length === 0}"
-                        >Open in new window</a>
+                      >
+                        Open in new window
+                      </a>
                     </div>
                   </div>
                 </div>
               </div>
-
             </template>
 
             <!-- DOIs (one per line) -->
             <div class="form-group row">
-              <label class="col-form-label col-md-2" for="doi">DOIs (one per line)</label>
+              <label
+                class="col-form-label col-md-2"
+                for="doi"
+              >
+                DOIs (one per line)
+              </label>
               <div class="col-md-10">
                 <div class="input-group">
-                  <textarea id="doi" rows="1" class="form-control"
+                  <textarea
+                    id="doi"
+                    rows="1"
+                    class="form-control"
                     placeholder="Enter DOIs here"
                     :value="wrappedCitation(citation).dois.join('\n')"
                     @change="setDOIs(citation, $event.target.value.split(/\s*\n\s*/))"
-                  ></textarea>
+                  />
                   <div class="input-group-append">
-                    <a class="btn btn-outline-secondary align-middle" target="_blank" style="vertical-align: middle"
+                    <a
+                      class="btn btn-outline-secondary align-middle"
+                      target="_blank"
+                      style="vertical-align: middle"
                       :href="'http://doi.org/' + wrappedCitation(citation).firstDOI"
                       :class="{disabled: !wrappedCitation(citation).firstDOI}"
-                      >Open in new window</a>
+                    >
+                      Open in new window
+                    </a>
                   </div>
                 </div>
               </div>
@@ -171,7 +292,9 @@
  */
 
 import Vue from 'vue';
-import { has, isEmpty, isEqual, cloneDeep } from 'lodash';
+import {
+  has, isEmpty, isEqual, cloneDeep,
+} from 'lodash';
 
 export default {
   name: 'Citation',
@@ -186,8 +309,8 @@ export default {
     },
     citationKey: { /* The key on the object containing the citation to display and edit */
       type: String,
-      required: true
-    }
+      required: true,
+    },
   },
   data() {
     // Set up a citations variable that has to be an array. It may actually be
@@ -196,7 +319,7 @@ export default {
     let citations;
     if (Array.isArray(this.object[this.citationKey])) {
       citations = this.object[this.citationKey];
-    } else if(isEmpty(this.object[this.citationKey])) {
+    } else if (isEmpty(this.object[this.citationKey])) {
       citations = [];
     } else {
       citations = [this.object[this.citationKey]];
@@ -210,7 +333,7 @@ export default {
       citations,
 
       // Items used to store new items.
-      newDOI: "",
+      newDOI: '',
     };
   },
   watch: {
@@ -229,26 +352,24 @@ export default {
         object: this.object,
         citationKey: this.citationKey,
         citations: this.citations,
-      })
+      });
     },
     toggleCitationExpanded(citationIndex) {
       // Given the index of a citation, either expand it or collapse it.
       // (The citation is expanded if its index is in the citationsExpanded list)
-      if (this.citationsExpanded.includes(citationIndex))
-        this.citationsExpanded = this.citationsExpanded.filter(index => index !== citationIndex);
-      else
-        this.citationsExpanded.push(citationIndex);
+      if (this.citationsExpanded.includes(citationIndex)) this.citationsExpanded = this.citationsExpanded.filter(index => index !== citationIndex);
+      else this.citationsExpanded.push(citationIndex);
     },
     wrappedCitation(citation) {
       // Return the citation
       return this.$store.getters.getWrappedCitation(citation);
     },
     setDOIs(citation, dois) {
-      console.log("Setting citation", citation, "to DOIs", dois);
-      Vue.set(citation, 'identifier', dois.map(doi => { return { type: 'doi', id: doi }; }));
+      console.log('Setting citation', citation, 'to DOIs', dois);
+      Vue.set(citation, 'identifier', dois.map(doi => ({ type: 'doi', id: doi })));
       updateCitations();
     },
-  }
+  },
 };
 </script>
 

--- a/src/components/citations/Citation.vue
+++ b/src/components/citations/Citation.vue
@@ -1,0 +1,39 @@
+<template>
+  <div>
+    <div class="input-group" v-for="citation of citations">
+      <input type="text" class="form-control" placeholder="Citation" :value="asText(citation)">
+      <div class="input-group-append">
+        <a class="btn btn-outline-secondary" target="_blank" :href="doiFor(citation)" :disabled="!doiFor(citation)">Open in new window</a>
+      </div>
+    </div>R
+  </div>
+</template>
+
+<script>
+/*
+ * Displays a citation as a textfield/expanded field.
+ */
+
+import { has, isEmpty } from 'lodash';
+
+export default {
+  name: 'Citation',
+  props: {
+    citations: { /* The citations to display and edit */
+      type: Array,
+      required: true,
+    },
+  },
+  methods: {
+    asText(citation) {
+      // console.log(asCite(citation).format('data'));
+      // return asCite(citation).format('citation');
+      return '';
+    },
+    doiFor(citation) {
+      //return citation['bibo:doi'] || undefined;
+      return '';
+    }
+  }
+};
+</script>

--- a/src/components/citations/Citation.vue
+++ b/src/components/citations/Citation.vue
@@ -98,6 +98,46 @@
               </div>
             </div>
 
+            <!-- Editors (one per line) -->
+            <div class="form-group row">
+              <label
+                class="col-form-label col-md-2"
+                for="editors"
+              >
+                Editors (one per line)
+              </label>
+              <div class="col-md-10">
+                <textarea
+                  id="editors"
+                  rows="2"
+                  class="form-control"
+                  placeholder="Enter editors here"
+                  :value="wrappedCitation(citation).editorsAsStrings.join('\n')"
+                  @change="wrappedCitation(citation).editorsAsStrings = $event.target.value.split(/\s*\n\s*/); updateCitations();"
+                />
+              </div>
+            </div>
+
+            <!-- Series editors (one per line) -->
+            <div class="form-group row">
+              <label
+                class="col-form-label col-md-2"
+                for="series-editors"
+              >
+                Series editors (one per line)
+              </label>
+              <div class="col-md-10">
+                <textarea
+                  id="series-editors"
+                  rows="2"
+                  class="form-control"
+                  placeholder="Enter series editors here"
+                  :value="wrappedCitation(citation).seriesEditorsAsStrings.join('\n')"
+                  @change="wrappedCitation(citation).seriesEditorsAsStrings = $event.target.value.split(/\s*\n\s*/); updateCitations();"
+                />
+              </div>
+            </div>
+
             <!-- Title -->
             <div class="form-group row">
               <label

--- a/src/components/citations/Citation.vue
+++ b/src/components/citations/Citation.vue
@@ -5,18 +5,36 @@
     </label>
     <div class="col-md-10">
       <template v-if="citations.length === 0">
-        <a href="javascript:;" @click="citations.push({})">Add citation</a>
+        <a class="form-control-plaintext" href="javascript:;" @click="citations.push({})">Add citation</a>
       </template>
       <template v-for="(citation, citationIndex) of citations">
         <div class="input-group">
-          <input type="text" disabled class="form-control" placeholder="Citation" :value="wrappedCitation(citation).toString()">
+          <input @click="toggleCitationExpanded(citationIndex)" type="text" readonly class="form-control hand-cursor" placeholder="Citation" :value="wrappedCitation(citation).toString()">
           <div class="input-group-append">
+            <a v-if="wrappedCitation(citation).firstURL" class="btn btn-primary" target="_blank" :href="wrappedCitation(citation).firstURL">Open in new window</a>
             <a class="btn btn-secondary" @click="toggleCitationExpanded(citationIndex)" href="javascript:;">Expand</a>
           </div>
         </div>
         <div class="card mt-1" v-if="citationsExpanded.includes(citationIndex)">
           <div class="card-body">
             <h5 class="card-title">Citation details</h5>
+
+            <!-- Citation type -->
+            <div class="form-group row">
+              <label class="col-form-label col-md-2" for="citation-type">Citation type</label>
+              <div class="col-md-10">
+                <select id="citation-type" class="form-control"
+                  v-model="citation.type"
+                  @change="updateCitations()"
+                >
+                  <option value="journal">Journal</option>
+                  <option value="book">Book</option>
+                  <option value="book_section">Book section</option>
+                </select>
+              </div>
+            </div>
+
+            <!-- Authors (one per line) -->
             <div class="form-group row">
               <label class="col-form-label col-md-2" for="authors">Authors (one per line)</label>
               <div class="col-md-10">
@@ -27,6 +45,8 @@
                 ></textarea>
               </div>
             </div>
+
+            <!-- Title -->
             <div class="form-group row">
               <label class="col-form-label col-md-2" for="title">Title</label>
               <div class="col-md-10">
@@ -37,6 +57,89 @@
                 />
               </div>
             </div>
+
+            <!-- Only for journal entries! -->
+            <template v-if="citation.type === 'journal'">
+
+              <!-- Journal title -->
+              <div class="form-group row">
+                <label class="col-form-label col-md-2" for="journal-title">Journal title</label>
+                <div class="col-md-10">
+                  <input id="journal-title" type="text" class="form-control"
+                    placeholder="Enter journal title here"
+                    v-model="wrappedCitation(citation).journal.name"
+                    @change="updateCitations()"
+                  />
+                </div>
+              </div>
+
+              <!-- Journal volume -->
+              <div class="form-group row">
+                <label class="col-form-label col-md-2" for="journal-volume">Volume</label>
+                <div class="col-md-10">
+                  <input id="journal-volume" type="text" class="form-control"
+                    placeholder="Enter journal volume number here"
+                    v-model="wrappedCitation(citation).journal.volume"
+                    @change="updateCitations()"
+                  />
+                </div>
+              </div>
+
+              <!-- Journal pages -->
+              <div class="form-group row">
+                <label class="col-form-label col-md-2" for="journal-pages">Pages</label>
+                <div class="col-md-10">
+                  <input id="journal-pages" type="text" class="form-control"
+                    placeholder="Enter journal pages here"
+                    v-model="wrappedCitation(citation).journal.pages"
+                    @change="updateCitations()"
+                  />
+                </div>
+              </div>
+
+              <!-- ISBNs (one per line) -->
+              <div class="form-group row">
+                <label class="col-form-label col-md-2" for="isbns">ISBNs (one per line)</label>
+                <div class="col-md-10">
+                  <div class="input-group">
+                    <textarea id="isbns" rows="1" class="form-control"
+                      placeholder="Enter ISBNs here"
+                      :value="wrappedCitation(wrappedCitation(citation).journal).isbns.join('\n')"
+                      @change="wrappedCitation(wrappedCitation(citation).journal).isbns = $event.target.value.split(/\s*\n\s*/); updateCitations()"
+                    ></textarea>
+                    <div class="input-group-append">
+                      <a class="btn btn-outline-secondary align-middle" target="_blank" style="vertical-align: middle"
+                        :href="'https://www.worldcat.org/search?q=bn%3A' + wrappedCitation(wrappedCitation(citation).journal).isbns[0]"
+                        :class="{disabled: (wrappedCitation(wrappedCitation(citation).journal).isbns || []).length === 0}"
+                        >Open in new window</a>
+                    </div>
+                  </div>
+                </div>
+              </div>
+
+              <!-- ISBNs (one per line) -->
+              <div class="form-group row">
+                <label class="col-form-label col-md-2" for="issns">ISSNs (one per line)</label>
+                <div class="col-md-10">
+                  <div class="input-group">
+                    <textarea id="issns" rows="1" class="form-control"
+                      placeholder="Enter ISSNs here"
+                      :value="wrappedCitation(wrappedCitation(citation).journal).issns.join('\n')"
+                      @change="wrappedCitation(wrappedCitation(citation).journal).issns = $event.target.value.split(/\s*\n\s*/); updateCitations()"
+                    ></textarea>
+                    <div class="input-group-append">
+                      <a class="btn btn-outline-secondary align-middle" target="_blank" style="vertical-align: middle"
+                        :href="'https://www.worldcat.org/search?q=n2%3A' + wrappedCitation(wrappedCitation(citation).journal).issns[0]"
+                        :class="{disabled: (wrappedCitation(wrappedCitation(citation).journal).issns || []).length === 0}"
+                        >Open in new window</a>
+                    </div>
+                  </div>
+                </div>
+              </div>
+
+            </template>
+
+            <!-- DOIs (one per line) -->
             <div class="form-group row">
               <label class="col-form-label col-md-2" for="doi">DOIs (one per line)</label>
               <div class="col-md-10">
@@ -87,12 +190,24 @@ export default {
     }
   },
   data() {
+    // Set up a citations variable that has to be an array. It may actually be
+    // a single object in the JSON file; in that case, we convert it into an
+    // array.
+    let citations;
+    if (Array.isArray(this.object[this.citationKey])) {
+      citations = this.object[this.citationKey];
+    } else if(isEmpty(this.object[this.citationKey])) {
+      citations = [];
+    } else {
+      citations = [this.object[this.citationKey]];
+    }
+
     return {
       // Which citations have been expanded (by index).
       citationsExpanded: [],
 
       // Copy of the citations provided to this component.
-      citations: cloneDeep(this.object[this.citationKey] || []),
+      citations,
 
       // Items used to store new items.
       newDOI: "",
@@ -136,3 +251,9 @@ export default {
   }
 };
 </script>
+
+<style>
+.hand-cursor {
+  cursor: pointer;
+}
+</style>

--- a/src/components/citations/Citation.vue
+++ b/src/components/citations/Citation.vue
@@ -25,10 +25,10 @@
           >
           <div class="input-group-append">
             <a
-              v-if="wrappedCitation(citation).firstURL"
+              v-if="wrappedCitation(citation).url"
               class="btn btn-primary"
               target="_blank"
-              :href="wrappedCitation(citation).firstURL"
+              :href="wrappedCitation(citation).url"
             >
               Open in new window
             </a>
@@ -452,6 +452,39 @@
                       style="vertical-align: middle"
                       :href="'http://doi.org/' + wrappedCitation(citation).firstDOI"
                       :class="{disabled: !wrappedCitation(citation).firstDOI}"
+                    >
+                      Open in new window
+                    </a>
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            <!-- URLs (one per line) -->
+            <div class="form-group row">
+              <label
+                class="col-form-label col-md-2"
+                for="urls"
+              >
+                URLs (one per line)
+              </label>
+              <div class="col-md-10">
+                <div class="input-group">
+                  <textarea
+                    id="urls"
+                    rows="1"
+                    class="form-control"
+                    placeholder="Enter URLs here"
+                    :value="wrappedCitation(citation).urlsAsStrings.join('\n')"
+                    @change="wrappedCitation(citation).urlsAsStrings = $event.target.value.split(/\s*\n\s*/); updateCitations()"
+                  />
+                  <div class="input-group-append">
+                    <a
+                      class="btn btn-outline-secondary align-middle"
+                      target="_blank"
+                      style="vertical-align: middle"
+                      :href="wrappedCitation(citation).firstURL"
+                      :class="{disabled: !wrappedCitation(citation).firstURL}"
                     >
                       Open in new window
                     </a>

--- a/src/components/citations/Citation.vue
+++ b/src/components/citations/Citation.vue
@@ -159,7 +159,10 @@
             </div>
 
             <!-- Section title -->
-            <div v-if="citation.type === 'book_section'" class="form-group row">
+            <div
+              v-if="citation.type === 'book_section'"
+              class="form-group row"
+            >
               <label
                 class="col-form-label col-md-2"
                 for="section-title"
@@ -528,12 +531,12 @@ export default {
       // Exception: this component will ALWAYS add a 'journal' key to the citation,
       // even if it is empty. We should eliminate that to make the comparison.
       const ourCitations = cloneDeep(this.citations).map(
-        citation => {
+        (citation) => {
           if (has(citation, 'journal') && isEqual(pickBy(citation.journal), {})) {
             delete citation.journal;
           }
           return citation;
-        }
+        },
       );
 
       // Exception: we *always* store citations as an array, but
@@ -542,14 +545,14 @@ export default {
       if (ourCitations.length === 1) {
         if (isEqual(ourCitations[0], this.object[this.citationKey])) return;
 
-        console.log("Updating citations as ", ourCitations[0], " differs from ", this.object[this.citationKey]);
+        console.log('Updating citations as ', ourCitations[0], ' differs from ', this.object[this.citationKey]);
         this.$store.commit('setCitations', {
           object: this.object,
           citationKey: this.citationKey,
           citations: ourCitations[0],
         });
       } else {
-        console.log("Updating citations as ", ourCitations, " differs from ", this.object[this.citationKey]);
+        console.log('Updating citations as ', ourCitations, ' differs from ', this.object[this.citationKey]);
         this.$store.commit('setCitations', {
           object: this.object,
           citationKey: this.citationKey,

--- a/src/components/citations/Citation.vue
+++ b/src/components/citations/Citation.vue
@@ -233,7 +233,7 @@
               <div class="col-md-4">
                 <input
                   id="pages"
-                  v-model="wrappedCitation(citation).journal.pages"
+                  v-model="citation.pages"
                   type="text"
                   class="form-control"
                   placeholder="Enter pages here"

--- a/src/components/citations/Citation.vue
+++ b/src/components/citations/Citation.vue
@@ -442,15 +442,15 @@
                     rows="1"
                     class="form-control"
                     placeholder="Enter DOIs here"
-                    :value="wrappedCitation(citation).dois.join('\n')"
-                    @change="setDOIs(citation, $event.target.value.split(/\s*\n\s*/))"
+                    :value="wrappedCitation(citation).doisAsStrings.join('\n')"
+                    @change="wrappedCitation(citation).doisAsStrings = $event.target.value.split(/\s*\n\s*/); updateCitations()"
                   />
                   <div class="input-group-append">
                     <a
                       class="btn btn-outline-secondary align-middle"
                       target="_blank"
                       style="vertical-align: middle"
-                      :href="'http://doi.org/' + wrappedCitation(citation).firstDOI"
+                      :href="wrappedCitation(citation).firstDOI ? 'http://doi.org/' + wrappedCitation(citation).firstDOI : undefined"
                       :class="{disabled: !wrappedCitation(citation).firstDOI}"
                     >
                       Open in new window
@@ -602,11 +602,6 @@ export default {
     wrappedCitation(citation) {
       // Return the citation
       return this.$store.getters.getWrappedCitation(citation);
-    },
-    setDOIs(citation, dois) {
-      console.log('Setting citation', citation, 'to DOIs', dois);
-      Vue.set(citation, 'identifier', dois.map(doi => ({ type: 'doi', id: doi })));
-      updateCitations();
     },
   },
 };

--- a/src/components/phylogeny/PhylogenyView.vue
+++ b/src/components/phylogeny/PhylogenyView.vue
@@ -49,6 +49,20 @@
             </div>
           </div>
 
+          <!-- Primary reference phylogeny -->
+          <Citation
+            label="Primary reference phylogeny"
+            :object="selectedPhylogeny"
+            citationKey="primaryPhylogenyCitation"
+          />
+
+          <!-- Other reference phylogeny -->
+          <Citation
+            label="Reference phylogeny"
+            :object="selectedPhylogeny"
+            citationKey="phylogenyCitation"
+          />
+
           <div class="form-group row">
             <label
               for="newick"
@@ -112,10 +126,11 @@ import { parse as parseNewick } from 'newick-js';
 
 import ModifiedCard from '../cards/ModifiedCard.vue';
 import Phylotree from './Phylotree.vue';
+import Citation from '../citations/Citation.vue';
 
 export default {
   name: 'PhylogenyView',
-  components: { ModifiedCard, Phylotree },
+  components: { ModifiedCard, Phylotree, Citation },
   computed: {
     /*
      * The following properties allow you to get or set the phylogeny label,

--- a/src/components/phylogeny/PhylogenyView.vue
+++ b/src/components/phylogeny/PhylogenyView.vue
@@ -53,14 +53,14 @@
           <Citation
             label="Primary reference phylogeny"
             :object="selectedPhylogeny"
-            citationKey="primaryPhylogenyCitation"
+            citation-key="primaryPhylogenyCitation"
           />
 
           <!-- Other reference phylogeny -->
           <Citation
             label="Reference phylogeny"
             :object="selectedPhylogeny"
-            citationKey="phylogenyCitation"
+            citation-key="phylogenyCitation"
           />
 
           <div class="form-group row">

--- a/src/components/phyloref/PhylorefView.vue
+++ b/src/components/phyloref/PhylorefView.vue
@@ -56,6 +56,16 @@
             </div>
           </div>
 
+          <!-- Primary reference phylogeny -->
+          <div class="form-group row">
+            <label class="col-form-label col-md-2">
+              Primary reference phylogeny
+            </label>
+            <div class="col-md-10">
+              <Citation :citations="selectedPhyloref.primaryPhylogenyCitation" />
+            </div>
+          </div>
+
           <!-- Phyloreference curator comments -->
           <div class="form-group row">
             <label
@@ -343,12 +353,14 @@ import { PhylogenyWrapper, PhylorefWrapper } from '@phyloref/phyx';
 
 import ModifiedCard from '../cards/ModifiedCard.vue';
 import Phylotree from '../phylogeny/Phylotree.vue';
+import Citation from '../citations/Citation.vue';
 
 export default {
   name: 'PhylorefView',
   components: {
     ModifiedCard,
     Phylotree,
+    Citation,
   },
   computed: {
     /*

--- a/src/components/phyloref/PhylorefView.vue
+++ b/src/components/phyloref/PhylorefView.vue
@@ -43,7 +43,7 @@
           <Citation
             label="Pre-existing name definition"
             :object="selectedPhyloref"
-            citationKey="dwc:namePublishedIn"
+            citation-key="dwc:namePublishedIn"
           />
 
           <!-- Phyloreference clade definition -->
@@ -69,7 +69,7 @@
           <Citation
             label="Definition source"
             :object="selectedPhyloref"
-            citationKey="obo:IAO_0000119"
+            citation-key="obo:IAO_0000119"
           />
 
           <!-- Phyloreference curator comments -->

--- a/src/components/phyloref/PhylorefView.vue
+++ b/src/components/phyloref/PhylorefView.vue
@@ -57,14 +57,11 @@
           </div>
 
           <!-- Primary reference phylogeny -->
-          <div class="form-group row">
-            <label class="col-form-label col-md-2">
-              Primary reference phylogeny
-            </label>
-            <div class="col-md-10">
-              <Citation :citations="selectedPhyloref.primaryPhylogenyCitation" />
-            </div>
-          </div>
+          <Citation
+            label="Primary reference phylogeny"
+            :object="selectedPhyloref"
+            citationKey="primaryPhylogenyCitation"
+          />
 
           <!-- Phyloreference curator comments -->
           <div class="form-group row">

--- a/src/components/phyloref/PhylorefView.vue
+++ b/src/components/phyloref/PhylorefView.vue
@@ -37,6 +37,15 @@
             </div>
           </div>
 
+          <!-- TODO add definition authors here -->
+
+          <!-- Pre-existing definition source -->
+          <Citation
+            label="Pre-existing name definition"
+            :object="selectedPhyloref"
+            citationKey="dwc:namePublishedIn"
+          />
+
           <!-- Phyloreference clade definition -->
           <div class="form-group row">
             <label
@@ -56,11 +65,11 @@
             </div>
           </div>
 
-          <!-- Primary reference phylogeny -->
+          <!-- Phyloref definition source -->
           <Citation
-            label="Primary reference phylogeny"
+            label="Definition source"
             :object="selectedPhyloref"
-            citationKey="primaryPhylogenyCitation"
+            citationKey="obo:IAO_0000119"
           />
 
           <!-- Phyloreference curator comments -->

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -8,6 +8,7 @@ import phyloref from './modules/phyloref';
 import phyx from './modules/phyx';
 import ui from './modules/ui';
 import owlterms from './modules/owlterms';
+import citations from './modules/citations';
 
 Vue.use(Vuex);
 
@@ -18,7 +19,7 @@ export default new Vuex.Store({
     CURATION_TOOL_VERSION: '0.1',
   },
   modules: {
-    phylogeny, phyloref, phyx, ui, owlterms,
+    phylogeny, phyloref, phyx, ui, owlterms, citations,
   },
   strict: debug,
 });

--- a/src/store/modules/citations.js
+++ b/src/store/modules/citations.js
@@ -1,0 +1,78 @@
+/*
+ * Store module for handing citations.
+ *
+ * Note that citations are located as keys on objects (for example, a phyloreference
+ * can have both a primaryPhylogenyCitation as well as a phylogenyCitation). Thus,
+ * citations are referred to by an object (which exists elsewhere in the Vuex store)
+ * and the key for the citation.
+ *
+ * The format for citations we use is based on BibJSON (http://okfnlabs.org/bibjson/),
+ * since that is essentially what Regnum uses. This is surprisingly poorly supported,
+ * except for the Citation.JS library (https://citation.js.org/), but I haven't been
+ * able to get it working on Vue JS yet. Therefore, mostly, I've implemented a
+ * basic CitationWrapper here, we'll replace it with Citations.JS or another proper
+ * library when we can.
+ */
+
+import Vue from 'vue';
+import { has } from 'lodash';
+
+class CitationWrapper {
+  constructor(citation) {
+    // Store the citation we're wrapping.
+    this.citation = citation;
+  }
+
+  toString() {
+    return JSON.stringify(this.citation);
+  }
+
+  get identifiers() {
+    // Returns a list of identifiers for this citation.
+    const citation = this.citation;
+
+    if (has(citation, 'identifier')) {
+      // Are there more than one identifier?
+      if (Array.isArray(citation.identifier)) {
+        return citation.identifier;
+      }
+
+      // If not, make an array out of that one identifier.
+      return [citation.identifier];
+    }
+
+    // No identifiers!
+    return [];
+  }
+
+  get dois() {
+    return this.identifiers.map((identifier) => {
+      if (has(identifier, 'type') && identifier.type === 'doi' && has(identifier, 'id')) {
+        return [identifier.id];
+      }
+
+      return [];
+    }).reduce((acc, val) => acc.concat(val), []);
+  }
+
+  get firstDOI() {
+    const dois = this.dois || [];
+    if (dois.length > 0) return dois[0];
+    return undefined;
+  }
+}
+
+export default {
+  getters: {
+    getWrappedCitation: () => citation => new CitationWrapper(citation),
+  },
+  mutations: {
+    setCitations(state, payload) {
+      Vue.set(
+        payload.object,
+        payload.citationKey,
+        payload.citations,
+      );
+    },
+  },
+};

--- a/src/store/modules/citations.js
+++ b/src/store/modules/citations.js
@@ -27,6 +27,35 @@ class CitationWrapper {
     return JSON.stringify(this.citation);
   }
 
+  get authors() {
+    const citation = this.citation;
+
+    if (has(citation, 'authors')) {
+      // Is there more than one author?
+      if (Array.isArray(citation.authors)) {
+        return citation.authors;
+      }
+
+      // If not, make an array out of that one author.
+      return [citation.authors];
+    }
+
+    return [];
+  }
+
+  set authors(authors) {
+    Vue.set(this.citation, 'authors', authors);
+  }
+
+  get authorsAsStrings() {
+    return this.authors.map(author => author.name);
+  }
+
+  set authorsAsStrings(authorsAsStrings) {
+    // TODO parse names back into first and last name.
+    Vue.set(this.citation, 'authors', authorsAsStrings.map(name => ({ name })));
+  }
+
   get identifiers() {
     // Returns a list of identifiers for this citation.
     const citation = this.citation;

--- a/src/store/modules/citations.js
+++ b/src/store/modules/citations.js
@@ -89,6 +89,26 @@ class CitationWrapper {
     Vue.set(this.citation, 'authors', authorsAsStrings.map(name => ({ name })));
   }
 
+  get editorsAsStrings() {
+    if (!has(this.citation, 'editors')) return [];
+    return this.citation.editors.map(editor => editor.name);
+  }
+
+  set editorsAsStrings(editors) {
+    // TODO parse names back into first and last name.
+    Vue.set(this.citation, 'editors', editors.map(name => ({ name })));
+  }
+
+  get seriesEditorsAsStrings() {
+    if (!has(this.citation, 'series_editors')) return [];
+    return this.citation.series_editors.map(editor => editor.name);
+  }
+
+  set seriesEditorsAsStrings(editors) {
+    // TODO parse names back into first and last name.
+    Vue.set(this.citation, 'series_editors', editors.map(name => ({ name })));
+  }
+
   get identifiers() {
     // Returns a list of identifiers for this citation.
     const citation = this.citation;

--- a/src/store/modules/citations.js
+++ b/src/store/modules/citations.js
@@ -44,7 +44,7 @@ class CitationWrapper {
 
     // Add DOIs and URLs.
     additionalInfo += this.dois.map(doi => ` doi: ${doi}`).join('');
-    additionalInfo += this.urls.map(url => ` URL: ${url}`).join('');
+    additionalInfo += this.urlsAsStrings.map(url => ` URL: ${url}`).join('');
 
     additionalInfo += this.isbns.map(isbn => ` ISBN: ${isbn}`).join('');
 
@@ -179,8 +179,22 @@ class CitationWrapper {
     return undefined;
   }
 
+  get urlsAsStrings() {
+    if (has(this.citation, 'link')) return this.citation.link.map(link => link.url);
+    return [];
+  }
+
+  set urlsAsStrings(urls) {
+    this.citation.link = urls.map(url => ({ url }));
+  }
+
   get firstURL() {
-    if (this.urls.length > 0) return this.urls[0];
+    if (this.urlsAsStrings.length > 0) return this.urlsAsStrings[0];
+    return undefined;
+  }
+
+  get url() {
+    if (this.firstURL) return this.firstURL;
 
     // If we don't have a URL, look for a DOI.
     if (this.firstDOI) return `http://doi.org/${encodeURI(this.firstDOI)}`;
@@ -195,19 +209,6 @@ class CitationWrapper {
     if (has(this.citation, 'journal')) return this.citation.journal;
     Vue.set(this.citation, 'journal', {});
     return this.citation.journal;
-  }
-
-  get urls() {
-    if (has(this.citation, 'link')) {
-      return this.citation.link
-        .filter(link => has(link, 'url'))
-        .map(link => link.url);
-    }
-    return [];
-  }
-
-  set urls(urls) {
-    Vue.set(this.citation, 'link', urls.map(url => ({ url })));
   }
 }
 

--- a/src/store/modules/citations.js
+++ b/src/store/modules/citations.js
@@ -27,9 +27,9 @@ class CitationWrapper {
   }
 
   toString() {
+    // Return this citation in a string representation.
     if (!this.citation || isEmpty(this.citation)) return undefined;
 
-    // Returns a string representation of this citation.
     // TODO add editors
     let authors = this.authorsAsStrings;
     if (authors.length === 0) authors = ['Anonymous'];
@@ -39,6 +39,8 @@ class CitationWrapper {
       authorsAndTitle += ` (section: ${this.citation.section_title})`;
     }
 
+    // Additional info stores details that should be at the end of the figure number,
+    // DOIs, URLs, ISBNs and so on.
     let additionalInfo = ' ';
     if (has(this.citation, 'figure')) additionalInfo += ` fig ${this.citation.figure}`;
 
@@ -48,6 +50,7 @@ class CitationWrapper {
 
     additionalInfo += this.isbns.map(isbn => ` ISBN: ${isbn}`).join('');
 
+    // A citation for a journal article should be different from others.
     if (has(this.citation, 'journal')) {
       const journal = this.citation.journal;
       const journalIssue = (has(journal, 'number')) ? `(${journal.number})` : '';
@@ -56,14 +59,14 @@ class CitationWrapper {
       return `${authorsAndTitle} ${journal.name || 'Unknown journal'} ${journal.volume || 'Unknown volume'}${journalIssue}${pages}${additionalInfo}`;
     }
 
-    // Must be a book or a book_section.
+    // If we are here, this must be a book or a book_section.
     if (has(this.citation, 'pages')) additionalInfo += ` pages: ${this.citation.pages}`;
 
-    // Must be a book or book section.
     return `${authorsAndTitle} ${this.citation.publisher}, ${this.citation.city}${additionalInfo}`;
   }
 
   get authors() {
+    // Return a list of authors (as author objects) for this citation.
     const citation = this.citation;
 
     if (has(citation, 'authors')) {
@@ -80,34 +83,41 @@ class CitationWrapper {
   }
 
   set authors(authors) {
+    // Set the list of authors (as author objects).
     Vue.set(this.citation, 'authors', authors);
   }
 
   get authorsAsStrings() {
+    // Return a list of author names.
     return this.authors.map(author => author.name);
   }
 
   set authorsAsStrings(authorsAsStrings) {
+    // Set a list of author names.
     // TODO parse names back into first and last name.
     Vue.set(this.citation, 'authors', authorsAsStrings.map(name => ({ name })));
   }
 
   get editorsAsStrings() {
+    // Return a list of editor names.
     if (!has(this.citation, 'editors')) return [];
     return this.citation.editors.map(editor => editor.name);
   }
 
   set editorsAsStrings(editors) {
+    // Set a list of editor names.
     // TODO parse names back into first and last name.
     Vue.set(this.citation, 'editors', editors.map(name => ({ name })));
   }
 
   get seriesEditorsAsStrings() {
+    // Return a list of series editor names.
     if (!has(this.citation, 'series_editors')) return [];
     return this.citation.series_editors.map(editor => editor.name);
   }
 
   set seriesEditorsAsStrings(editors) {
+    // Set a list of series editor names.
     // TODO parse names back into first and last name.
     Vue.set(this.citation, 'series_editors', editors.map(name => ({ name })));
   }
@@ -131,10 +141,12 @@ class CitationWrapper {
   }
 
   set identifiers(identifiers) {
+    // Set the list of identifiers for this citation.
     this.citation.identifier = identifiers;
   }
 
   get dois() {
+    // Return a list of DOIs for this citation.
     return this.identifiers.map((identifier) => {
       if (has(identifier, 'type') && identifier.type === 'doi' && has(identifier, 'id') && !isEmpty(identifier.id)) {
         return [identifier.id];
@@ -145,6 +157,7 @@ class CitationWrapper {
   }
 
   get isbns() {
+    // Return a list of ISBNs for this citation.
     return this.identifiers.map((identifier) => {
       if (has(identifier, 'type') && identifier.type === 'isbn' && has(identifier, 'id') && !isEmpty(identifier.id)) {
         return [identifier.id];
@@ -155,12 +168,14 @@ class CitationWrapper {
   }
 
   set isbns(isbns) {
+    // Set a list of ISBNs for this citation.
     this.identifiers = this.identifiers
       .filter(identifier => has(identifier, 'type') && identifier.type !== 'isbn')
       .concat(isbns.map(isbn => ({ type: 'isbn', id: isbn })));
   }
 
   get issns() {
+    // Return a list of ISSNs for this citation.
     return this.identifiers.map((identifier) => {
       if (has(identifier, 'type') && identifier.type === 'issn' && has(identifier, 'id') && !isEmpty(identifier.id)) {
         return [identifier.id];
@@ -171,32 +186,38 @@ class CitationWrapper {
   }
 
   set issns(issns) {
+    // Set a list of ISSNs for this citation.
     this.identifiers = this.identifiers
       .filter(identifier => has(identifier, 'type') && identifier.type !== 'issn')
       .concat(issns.map(issn => ({ type: 'issn', id: issn })));
   }
 
   get firstDOI() {
+    // Return the first DOI of this citation (used to provide a URL to access it).
     const dois = this.dois || [];
     if (dois.length > 0) return dois[0];
     return undefined;
   }
 
   get urlsAsStrings() {
+    // Return a list of URLs in this citation.
     if (has(this.citation, 'link')) return this.citation.link.map(link => link.url);
     return [];
   }
 
   set urlsAsStrings(urls) {
+    // Set the list of URLs in this citation.
     this.citation.link = urls.map(url => ({ url }));
   }
 
   get firstURL() {
+    // Return the first URL in the list of citations (used to provide a URL for buttons).
     if (this.urlsAsStrings.length > 0) return this.urlsAsStrings[0];
     return undefined;
   }
 
   get url() {
+    // Get a URL for this citation, whether from the list of URLs or the list of DOIs.
     if (this.firstURL) return this.firstURL;
 
     // If we don't have a URL, look for a DOI.
@@ -209,6 +230,8 @@ class CitationWrapper {
   }
 
   get journal() {
+    // Return the journal of this citation. If one doesn't exist, create it and
+    // return it.
     if (has(this.citation, 'journal')) return this.citation.journal;
     Vue.set(this.citation, 'journal', {});
     return this.citation.journal;
@@ -217,9 +240,12 @@ class CitationWrapper {
 
 export default {
   getters: {
+    // Get a wrapped citation for a given citation.
     getWrappedCitation: () => citation => new CitationWrapper(citation),
   },
   mutations: {
+    // Update the value of a citation, using object-citationKey so we can change
+    // it anywhere in the Vuex state.
     setCitations(state, payload) {
       Vue.set(
         payload.object,

--- a/src/store/modules/citations.js
+++ b/src/store/modules/citations.js
@@ -11,20 +11,51 @@
  * except for the Citation.JS library (https://citation.js.org/), but I haven't been
  * able to get it working on Vue JS yet. Therefore, mostly, I've implemented a
  * basic CitationWrapper here, we'll replace it with Citations.JS or another proper
- * library when we can.
+ * library when we can. We might switch over to CSL-JSON eventually (see issue
+ * https://github.com/phyloref/clade-ontology/issues/69).
  */
 
 import Vue from 'vue';
-import { has } from 'lodash';
+import { has, isEmpty } from 'lodash';
 
 class CitationWrapper {
+  // Wraps a Citation in a Phyx document. Should be moved to phyx.js.
+
   constructor(citation) {
     // Store the citation we're wrapping.
     this.citation = citation;
   }
 
   toString() {
-    return JSON.stringify(this.citation);
+    if (!this.citation) return '(undefined)';
+
+    // Returns a string representation of this citation.
+    // TODO add editors
+    let authors = this.authorsAsStrings;
+    if (authors.length > 2) authors = [`${authors[0]} et al`];
+    let authorsAndTitle = `${authors.join(' and ')} (${this.citation.year}) ${this.citation.title}`;
+    if (has(this.citation, 'section_title')) {
+      authorsAndTitle += ` (section: ${this.citation.section_title})`;
+    }
+
+    let additionalInfo = ' ';
+    if (has(this.citation, 'figure')) additionalInfo += ` fig ${this.citation.figure}`;
+
+    // Add DOIs and URLs.
+    additionalInfo += this.dois.map(doi => ` doi: ${doi}`).join('');
+    additionalInfo += this.urls.map(url => ` URL: ${url}`).join('');
+
+    additionalInfo += this.isbns.map(isbn => ` ISBN: ${isbn}`).join('');
+
+    if (has(this.citation, 'journal')) {
+      const journal = this.citation.journal;
+      const journalIssue = (has(journal, 'number')) ? `:${journal.number}` : '';
+      additionalInfo += this.issns.map(issn => `ISSN: ${issn} `).join('');
+      return `${authorsAndTitle} ${journal.name} ${journal.volume}${journalIssue} ${journal.pages}${additionalInfo}`;
+    }
+
+    // Must be a book or book section.
+    return `${authorsAndTitle} ${this.citation.publisher}, ${this.citation.city}${additionalInfo}`;
   }
 
   get authors() {
@@ -74,9 +105,13 @@ class CitationWrapper {
     return [];
   }
 
+  set identifiers(identifiers) {
+    this.citation.identifier = identifiers;
+  }
+
   get dois() {
     return this.identifiers.map((identifier) => {
-      if (has(identifier, 'type') && identifier.type === 'doi' && has(identifier, 'id')) {
+      if (has(identifier, 'type') && identifier.type === 'doi' && has(identifier, 'id') && !isEmpty(identifier.id)) {
         return [identifier.id];
       }
 
@@ -84,10 +119,73 @@ class CitationWrapper {
     }).reduce((acc, val) => acc.concat(val), []);
   }
 
+  get isbns() {
+    return this.identifiers.map((identifier) => {
+      if (has(identifier, 'type') && identifier.type === 'isbn' && has(identifier, 'id') && !isEmpty(identifier.id)) {
+        return [identifier.id];
+      }
+
+      return [];
+    }).reduce((acc, val) => acc.concat(val), []);
+  }
+
+  set isbns(isbns) {
+    this.identifiers = this.identifiers
+      .filter(identifier => has(identifier, 'type') && identifier.type !== 'isbn')
+      .concat(isbns.map(isbn => ({ type: 'isbn', id: isbn })));
+  }
+
+  get issns() {
+    return this.identifiers.map((identifier) => {
+      if (has(identifier, 'type') && identifier.type === 'issn' && has(identifier, 'id') && !isEmpty(identifier.id)) {
+        return [identifier.id];
+      }
+
+      return [];
+    }).reduce((acc, val) => acc.concat(val), []);
+  }
+
+  set issns(issns) {
+    this.identifiers = this.identifiers
+      .filter(identifier => has(identifier, 'type') && identifier.type !== 'issn')
+      .concat(issns.map(issn => ({ type: 'issn', id: issn })));
+  }
+
   get firstDOI() {
     const dois = this.dois || [];
     if (dois.length > 0) return dois[0];
     return undefined;
+  }
+
+  get firstURL() {
+    if (this.urls.length > 0) return this.urls[0];
+
+    // If we don't have a URL, look for a DOI.
+    if (this.firstDOI) return `http://doi.org/${encodeURI(this.firstDOI)}`;
+
+    // TODO: Look for ISBN.
+    // TODO: If all else fails, try https://search.crossref.org/?q={title}
+
+    return undefined;
+  }
+
+  get journal() {
+    if (has(this.citation, 'journal')) return this.citation.journal;
+    Vue.set(this.citation, 'journal', {});
+    return this.citation.journal;
+  }
+
+  get urls() {
+    if (has(this.citation, 'link')) {
+      return this.citation.link
+        .filter(link => has(link, 'url'))
+        .map(link => link.url);
+    }
+    return [];
+  }
+
+  set urls(urls) {
+    Vue.set(this.citation, 'link', urls.map(url => ({ url })));
   }
 }
 

--- a/src/store/modules/citations.js
+++ b/src/store/modules/citations.js
@@ -119,7 +119,7 @@ class CitationWrapper {
 
   set authorsAsStrings(authorsAsStrings) {
     // Set a list of author names.
-    // TODO parse names back into first and last name.
+    // TODO parse names back into first and last name (https://github.com/phyloref/curation-tool/issues/145)
     Vue.set(this.citation, 'authors', authorsAsStrings.filter(isNonEmptyString).map(name => ({ name })));
   }
 
@@ -131,7 +131,7 @@ class CitationWrapper {
 
   set editorsAsStrings(editors) {
     // Set a list of editor names.
-    // TODO parse names back into first and last name.
+    // TODO parse names back into first and last name (https://github.com/phyloref/curation-tool/issues/145)
     Vue.set(this.citation, 'editors', editors.filter(isNonEmptyString).map(name => ({ name })));
   }
 
@@ -143,7 +143,7 @@ class CitationWrapper {
 
   set seriesEditorsAsStrings(editors) {
     // Set a list of series editor names.
-    // TODO parse names back into first and last name.
+    // TODO parse names back into first and last name (https://github.com/phyloref/curation-tool/issues/145)
     Vue.set(this.citation, 'series_editors', editors.filter(isNonEmptyString).map(name => ({ name })));
   }
 

--- a/src/store/modules/citations.js
+++ b/src/store/modules/citations.js
@@ -231,8 +231,18 @@ class CitationWrapper {
     // If we don't have a URL, look for a DOI.
     if (this.firstDOI) return `http://doi.org/${encodeURI(this.firstDOI)}`;
 
-    // TODO: Look for ISBN.
-    // TODO: If all else fails, try https://search.crossref.org/?q={title}
+    // If we don't have a DOI, look for an ISBN or ISSN.
+    if (this.isbns.length > 0) return `https://www.worldcat.org/search?q=bn%3A${encodeURI(this.isbns[0])}`;
+    if (this.issns.length > 0) return `https://www.worldcat.org/search?q=n2%3A${encodeURI(this.issns[0])}`;
+
+    // If all else fails, try title searches.
+    if (has(this.citation, 'type') && has(this.citation, 'title')) {
+      // We should check articles against CrossRef.
+      if (this.citation.type === 'article') return `https://search.crossref.org/?q=${encodeURI(this.citation.title)}`;
+
+      // We should search book and book sections against WorldCat.
+      return `https://www.worldcat.org/search?q=${encodeURI(this.citation.title)}`;
+    }
 
     return undefined;
   }

--- a/src/store/modules/citations.js
+++ b/src/store/modules/citations.js
@@ -167,7 +167,7 @@ class CitationWrapper {
 
   set identifiers(identifiers) {
     // Set the list of identifiers for this citation.
-    this.citation.identifier = identifiers;
+    Vue.set(this.citation, 'identifier', identifiers);
   }
 
   get dois() {
@@ -232,7 +232,7 @@ class CitationWrapper {
 
   set urlsAsStrings(urls) {
     // Set the list of URLs in this citation.
-    this.citation.link = urls.filter(isNonEmptyString).map(url => ({ url }));
+    Vue.set(this.citation, 'link', urls.filter(isNonEmptyString).map(url => ({ url })));
   }
 
   get firstURL() {

--- a/src/store/modules/citations.js
+++ b/src/store/modules/citations.js
@@ -1,5 +1,5 @@
 /*
- * Store module for handing citations.
+ * Store module for handling citations.
  *
  * Note that citations are located as keys on objects (for example, a phyloreference
  * can have both a primaryPhylogenyCitation as well as a phylogenyCitation). Thus,

--- a/src/store/modules/citations.js
+++ b/src/store/modules/citations.js
@@ -27,13 +27,14 @@ class CitationWrapper {
   }
 
   toString() {
-    if (!this.citation) return '(undefined)';
+    if (!this.citation || isEmpty(this.citation)) return undefined;
 
     // Returns a string representation of this citation.
     // TODO add editors
     let authors = this.authorsAsStrings;
+    if (authors.length === 0) authors = ['Anonymous'];
     if (authors.length > 2) authors = [`${authors[0]} et al`];
-    let authorsAndTitle = `${authors.join(' and ')} (${this.citation.year}) ${this.citation.title}`;
+    let authorsAndTitle = `${authors.join(' and ')} (${this.citation.year || 'n.d.'}) ${this.citation.title || 'Untitled'}`;
     if (has(this.citation, 'section_title')) {
       authorsAndTitle += ` (section: ${this.citation.section_title})`;
     }
@@ -49,9 +50,10 @@ class CitationWrapper {
 
     if (has(this.citation, 'journal')) {
       const journal = this.citation.journal;
-      const journalIssue = (has(journal, 'number')) ? `:${journal.number}` : '';
+      const journalIssue = (has(journal, 'number')) ? `(${journal.number})` : '';
+      const journalPages = (has(journal, 'pages')) ? `:${journal.pages}` : '';
       additionalInfo += this.issns.map(issn => `ISSN: ${issn} `).join('');
-      return `${authorsAndTitle} ${journal.name} ${journal.volume}${journalIssue} ${journal.pages}${additionalInfo}`;
+      return `${authorsAndTitle} ${journal.name || 'Unknown journal'} ${journal.volume || 'Unknown volume'}${journalIssue}${journalPages}${additionalInfo}`;
     }
 
     // Must be a book or book section.

--- a/src/store/modules/citations.js
+++ b/src/store/modules/citations.js
@@ -51,7 +51,7 @@ class CitationWrapper {
     additionalInfo += this.isbns.map(isbn => ` ISBN: ${isbn}`).join('');
 
     // A citation for a journal article should be different from others.
-    if (has(this.citation, 'journal')) {
+    if (has(this.citation, 'journal') && this.citation.type === 'article') {
       const journal = this.citation.journal;
       const journalIssue = (has(journal, 'number')) ? `(${journal.number})` : '';
       const pages = (has(this.citation, 'pages')) ? `:${this.citation.pages}` : '';
@@ -62,7 +62,15 @@ class CitationWrapper {
     // If we are here, this must be a book or a book_section.
     if (has(this.citation, 'pages')) additionalInfo += ` pages: ${this.citation.pages}`;
 
-    return `${authorsAndTitle} ${this.citation.publisher}, ${this.citation.city}${additionalInfo}`;
+    if (has(this.citation, 'publisher') && has(this.citation, 'city')) {
+      return `${authorsAndTitle} ${this.citation.publisher}, ${this.citation.city}${additionalInfo}`;
+    }
+
+    if (has(this.citation, 'publisher')) {
+      return `${authorsAndTitle} ${this.citation.publisher}${additionalInfo}`;
+    }
+
+    return `${authorsAndTitle}${additionalInfo}`;
   }
 
   get authors() {

--- a/src/store/modules/citations.js
+++ b/src/store/modules/citations.js
@@ -51,10 +51,13 @@ class CitationWrapper {
     if (has(this.citation, 'journal')) {
       const journal = this.citation.journal;
       const journalIssue = (has(journal, 'number')) ? `(${journal.number})` : '';
-      const journalPages = (has(journal, 'pages')) ? `:${journal.pages}` : '';
+      const pages = (has(this.citation, 'pages')) ? `:${this.citation.pages}` : '';
       additionalInfo += this.issns.map(issn => `ISSN: ${issn} `).join('');
-      return `${authorsAndTitle} ${journal.name || 'Unknown journal'} ${journal.volume || 'Unknown volume'}${journalIssue}${journalPages}${additionalInfo}`;
+      return `${authorsAndTitle} ${journal.name || 'Unknown journal'} ${journal.volume || 'Unknown volume'}${journalIssue}${pages}${additionalInfo}`;
     }
+
+    // Must be a book or a book_section.
+    if (has(this.citation, 'pages')) additionalInfo += ` pages: ${this.citation.pages}`;
 
     // Must be a book or book section.
     return `${authorsAndTitle} ${this.citation.publisher}, ${this.citation.city}${additionalInfo}`;


### PR DESCRIPTION
This PR creates a Citation component that can be used anywhere that a citation needs to be edited. In the Curation Tool, this in four places: primary phylogeny and phylogeny citations in phylogenies, and the pre-existing name and phyloref definition source in phyloreferences.

This uses the same model of citations as phyloref/clade-ontology#63, i.e. one based on that currently in Regnum and on [BibJSON](http://okfnlabs.org/bibjson/).