### PR TITLE
Update phyx.js to use model 2.0 ontologies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1230,11 +1230,11 @@
       }
     },
     "@phyloref/phyx": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/@phyloref/phyx/-/phyx-0.1.2.tgz",
-      "integrity": "sha512-/tJi1VzWoWGnm4Sxqc9YnEljLdI77u+xhAc4em/ciVs/ihWAK/h9C7ZcsN2syUMwJ9TDHVol5BB3J+92XaTEUA==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@phyloref/phyx/-/phyx-0.2.0.tgz",
+      "integrity": "sha512-yTCOdJ6RKeR1EsgZLEh5v9YoinqB8xMRJo6kfe5WmmUFt79T+h3NoSDl8R3tXbyRePGur6d4Ba4rdOdQkcoYRA==",
       "requires": {
-        "extend": "^3.0.2",
+        "lodash": "^4.17.11",
         "moment": "^2.23.0",
         "newick-js": "^1.1.0"
       }
@@ -5777,7 +5777,8 @@
     "extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "dev": true
     },
     "extend-shallow": {
       "version": "3.0.2",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@fortawesome/fontawesome-svg-core": "^1.2.19",
     "@fortawesome/free-solid-svg-icons": "^5.9.0",
     "@fortawesome/vue-fontawesome": "^0.1.6",
-    "@phyloref/phyx": "^0.1.2",
+    "@phyloref/phyx": "^0.2.0",
     "bootstrap": "^4.3.1",
     "bootstrap-vue": "^2.0.0-rc.26",
     "filesaver.js-npm": "^1.0.1",

--- a/public/examples/brochu_2003.json
+++ b/public/examples/brochu_2003.json
@@ -1,5 +1,5 @@
 {
-    "@context": "file:///home/vaidyagi/code/phyloref/phyx.js/docs/context/v0.2.0/phyx.json",
+    "@context": "http://www.phyloref.org/phyx.js/context/v0.2.0/phyx.json",
     "doi": "10.1146/annurev.earth.31.100901.141308",
     "url": "https://www.annualreviews.org/doi/10.1146/annurev.earth.31.100901.141308",
     "citation": "Brochu (2003) Annual Review of Earth and Planetary Sciences 31:357-397",

--- a/public/examples/brochu_2003.json
+++ b/public/examples/brochu_2003.json
@@ -59,20 +59,47 @@
             "internalSpecifiers": [
                 {
                     "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
-                    "nameString": "Alligator mississippiensis"
+                    "hasName": {
+                        "@type": "http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName",
+                        "nomenclaturalCode": "http://purl.obolibrary.org/obo/NOMEN_0000107",
+                        "label": "Alligator mississippiensis",
+                        "nameComplete": "Alligator mississippiensis",
+                        "genusPart": "Alligator",
+                        "specificEpithet": "mississippiensis"
+                    }
                 },
                 {
                     "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
-                    "nameString": "Gavialis gangeticus"
+                    "hasName": {
+                        "@type": "http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName",
+                        "nomenclaturalCode": "http://purl.obolibrary.org/obo/NOMEN_0000107",
+                        "label": "Gavialis gangeticus",
+                        "nameComplete": "Gavialis gangeticus",
+                        "genusPart": "Gavialis",
+                        "specificEpithet": "gangeticus"
+                    }
                 },
                 {
                     "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
-                    "nameString": "Crocodylus niloticus"
+                    "hasName": {
+                        "@type": "http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName",
+                        "nomenclaturalCode": "http://purl.obolibrary.org/obo/NOMEN_0000107",
+                        "label": "Crocodylus niloticus",
+                        "nameComplete": "Crocodylus niloticus",
+                        "genusPart": "Crocodylus",
+                        "specificEpithet": "niloticus"
+                    }
                 },
                 {
                     "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
-                    "nameString": "Hylaeochampsa vectiana",
-                    "specifierWillNotMatch": "Not present in figure 1"
+                    "hasName": {
+                        "@type": "http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName",
+                        "nomenclaturalCode": "http://purl.obolibrary.org/obo/NOMEN_0000107",
+                        "label": "Hylaeochampsa vectiana",
+                        "nameComplete": "Hylaeochampsa vectiana",
+                        "genusPart": "Hylaeochampsa",
+                        "specificEpithet": "vectiana"
+                    }
                 }
             ],
             "externalSpecifiers": [],
@@ -94,15 +121,36 @@
             "internalSpecifiers": [
                 {
                     "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
-                    "nameString": "Crocodylus niloticus"
+                    "hasName": {
+                        "@type": "http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName",
+                        "nomenclaturalCode": "http://purl.obolibrary.org/obo/NOMEN_0000107",
+                        "label": "Crocodylus niloticus",
+                        "nameComplete": "Crocodylus niloticus",
+                        "genusPart": "Crocodylus",
+                        "specificEpithet": "niloticus"
+                    }
                 },
                 {
                     "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
-                    "nameString": "Alligator mississippiensis"
+                    "hasName": {
+                        "@type": "http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName",
+                        "nomenclaturalCode": "http://purl.obolibrary.org/obo/NOMEN_0000107",
+                        "label": "Alligator mississippiensis",
+                        "nameComplete": "Alligator mississippiensis",
+                        "genusPart": "Alligator",
+                        "specificEpithet": "mississippiensis"
+                    }
                 },
                 {
                     "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
-                    "nameString": "Gavialis gangeticus"
+                    "hasName": {
+                        "@type": "http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName",
+                        "nomenclaturalCode": "http://purl.obolibrary.org/obo/NOMEN_0000107",
+                        "label": "Gavialis gangeticus",
+                        "nameComplete": "Gavialis gangeticus",
+                        "genusPart": "Gavialis",
+                        "specificEpithet": "gangeticus"
+                    }
                 }
             ],
             "externalSpecifiers": [],
@@ -124,17 +172,38 @@
             "internalSpecifiers": [
                 {
                     "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
-                    "nameString": "Gavialis gangeticus"
+                    "hasName": {
+                        "@type": "http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName",
+                        "nomenclaturalCode": "http://purl.obolibrary.org/obo/NOMEN_0000107",
+                        "label": "Gavialis gangeticus",
+                        "nameComplete": "Gavialis gangeticus",
+                        "genusPart": "Gavialis",
+                        "specificEpithet": "gangeticus"
+                    }
                 }
             ],
             "externalSpecifiers": [
                 {
                     "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
-                    "nameString": "Alligator mississippiensis"
+                    "hasName": {
+                        "@type": "http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName",
+                        "nomenclaturalCode": "http://purl.obolibrary.org/obo/NOMEN_0000107",
+                        "label": "Alligator mississippiensis",
+                        "nameComplete": "Alligator mississippiensis",
+                        "genusPart": "Alligator",
+                        "specificEpithet": "mississippiensis"
+                    }
                 },
                 {
                     "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
-                    "nameString": "Crocodylus niloticus"
+                    "hasName": {
+                        "@type": "http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName",
+                        "nomenclaturalCode": "http://purl.obolibrary.org/obo/NOMEN_0000107",
+                        "label": "Crocodylus niloticus",
+                        "nameComplete": "Crocodylus niloticus",
+                        "genusPart": "Crocodylus",
+                        "specificEpithet": "niloticus"
+                    }
                 }
             ],
             "pso:holdsStatusInTime": [
@@ -155,22 +224,49 @@
             "internalSpecifiers": [
                 {
                     "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
-                    "nameString": "Pristichampsus rollinati",
-                    "specifierWillNotMatch": "Not included in figure 1"
+                    "hasName": {
+                        "@type": "http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName",
+                        "nomenclaturalCode": "http://purl.obolibrary.org/obo/NOMEN_0000107",
+                        "label": "Pristichampsus rollinati",
+                        "nameComplete": "Pristichampsus rollinati",
+                        "genusPart": "Pristichampsus",
+                        "specificEpithet": "rollinati"
+                    }
                 }
             ],
             "externalSpecifiers": [
                 {
                     "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
-                    "nameString": "Gavialis gangeticus"
+                    "hasName": {
+                        "@type": "http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName",
+                        "nomenclaturalCode": "http://purl.obolibrary.org/obo/NOMEN_0000107",
+                        "label": "Gavialis gangeticus",
+                        "nameComplete": "Gavialis gangeticus",
+                        "genusPart": "Gavialis",
+                        "specificEpithet": "gangeticus"
+                    }
                 },
                 {
                     "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
-                    "nameString": "Alligator mississippiensis"
+                    "hasName": {
+                        "@type": "http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName",
+                        "nomenclaturalCode": "http://purl.obolibrary.org/obo/NOMEN_0000107",
+                        "label": "Alligator mississippiensis",
+                        "nameComplete": "Alligator mississippiensis",
+                        "genusPart": "Alligator",
+                        "specificEpithet": "mississippiensis"
+                    }
                 },
                 {
                     "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
-                    "nameString": "Crocodylus niloticus"
+                    "hasName": {
+                        "@type": "http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName",
+                        "nomenclaturalCode": "http://purl.obolibrary.org/obo/NOMEN_0000107",
+                        "label": "Crocodylus niloticus",
+                        "nameComplete": "Crocodylus niloticus",
+                        "genusPart": "Crocodylus",
+                        "specificEpithet": "niloticus"
+                    }
                 }
             ],
             "curatorComments": "Not included in figure 1.",
@@ -192,11 +288,25 @@
             "internalSpecifiers": [
                 {
                     "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
-                    "nameString": "Crocodylus niloticus"
+                    "hasName": {
+                        "@type": "http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName",
+                        "nomenclaturalCode": "http://purl.obolibrary.org/obo/NOMEN_0000107",
+                        "label": "Crocodylus niloticus",
+                        "nameComplete": "Crocodylus niloticus",
+                        "genusPart": "Crocodylus",
+                        "specificEpithet": "niloticus"
+                    }
                 },
                 {
                     "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
-                    "nameString": "Alligator mississippiensis"
+                    "hasName": {
+                        "@type": "http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName",
+                        "nomenclaturalCode": "http://purl.obolibrary.org/obo/NOMEN_0000107",
+                        "label": "Alligator mississippiensis",
+                        "nameComplete": "Alligator mississippiensis",
+                        "genusPart": "Alligator",
+                        "specificEpithet": "mississippiensis"
+                    }
                 }
             ],
             "externalSpecifiers": [],
@@ -257,17 +367,38 @@
             "internalSpecifiers": [
                 {
                     "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
-                    "nameString": "Alligator mississippiensis"
+                    "hasName": {
+                        "@type": "http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName",
+                        "nomenclaturalCode": "http://purl.obolibrary.org/obo/NOMEN_0000107",
+                        "label": "Alligator mississippiensis",
+                        "nameComplete": "Alligator mississippiensis",
+                        "genusPart": "Alligator",
+                        "specificEpithet": "mississippiensis"
+                    }
                 }
             ],
             "externalSpecifiers": [
                 {
                     "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
-                    "nameString": "Crocodylus niloticus"
+                    "hasName": {
+                        "@type": "http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName",
+                        "nomenclaturalCode": "http://purl.obolibrary.org/obo/NOMEN_0000107",
+                        "label": "Crocodylus niloticus",
+                        "nameComplete": "Crocodylus niloticus",
+                        "genusPart": "Crocodylus",
+                        "specificEpithet": "niloticus"
+                    }
                 },
                 {
                     "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
-                    "nameString": "Gavialis gangeticus"
+                    "hasName": {
+                        "@type": "http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName",
+                        "nomenclaturalCode": "http://purl.obolibrary.org/obo/NOMEN_0000107",
+                        "label": "Gavialis gangeticus",
+                        "nameComplete": "Gavialis gangeticus",
+                        "genusPart": "Gavialis",
+                        "specificEpithet": "gangeticus"
+                    }
                 }
             ],
             "pso:holdsStatusInTime": [
@@ -290,15 +421,27 @@
             "internalSpecifiers": [
                 {
                     "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
-                    "nameString": "Diplocynodon ratelii",
-                    "nomenclaturalCode": "http://purl.obolibrary.org/obo/NOMEN_0000107"
+                    "hasName": {
+                        "@type": "http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName",
+                        "nomenclaturalCode": "http://purl.obolibrary.org/obo/NOMEN_0000107",
+                        "label": "Diplocynodon ratelii",
+                        "nameComplete": "Diplocynodon ratelii",
+                        "genusPart": "Diplocynodon",
+                        "specificEpithet": "ratelii"
+                    }
                 }
             ],
             "externalSpecifiers": [
                 {
                     "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
-                    "nameString": "Alligator mississippiensis",
-                    "nomenclaturalCode": "http://purl.obolibrary.org/obo/NOMEN_0000107"
+                    "hasName": {
+                        "@type": "http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName",
+                        "nomenclaturalCode": "http://purl.obolibrary.org/obo/NOMEN_0000107",
+                        "label": "Alligator mississippiensis",
+                        "nameComplete": "Alligator mississippiensis",
+                        "genusPart": "Alligator",
+                        "specificEpithet": "mississippiensis"
+                    }
                 }
             ],
             "pso:holdsStatusInTime": [
@@ -319,13 +462,27 @@
             "internalSpecifiers": [
                 {
                     "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
-                    "nameString": "Alligator mississippiensis"
+                    "hasName": {
+                        "@type": "http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName",
+                        "nomenclaturalCode": "http://purl.obolibrary.org/obo/NOMEN_0000107",
+                        "label": "Alligator mississippiensis",
+                        "nameComplete": "Alligator mississippiensis",
+                        "genusPart": "Alligator",
+                        "specificEpithet": "mississippiensis"
+                    }
                 }
             ],
             "externalSpecifiers": [
                 {
                     "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
-                    "nameString": "Diplocynodon ratelii"
+                    "hasName": {
+                        "@type": "http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName",
+                        "nomenclaturalCode": "http://purl.obolibrary.org/obo/NOMEN_0000107",
+                        "label": "Diplocynodon ratelii",
+                        "nameComplete": "Diplocynodon ratelii",
+                        "genusPart": "Diplocynodon",
+                        "specificEpithet": "ratelii"
+                    }
                 }
             ],
             "pso:holdsStatusInTime": [
@@ -346,11 +503,25 @@
             "internalSpecifiers": [
                 {
                     "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
-                    "nameString": "Caiman crocodilus"
+                    "hasName": {
+                        "@type": "http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName",
+                        "nomenclaturalCode": "http://purl.obolibrary.org/obo/NOMEN_0000107",
+                        "label": "Caiman crocodilus",
+                        "nameComplete": "Caiman crocodilus",
+                        "genusPart": "Caiman",
+                        "specificEpithet": "crocodilus"
+                    }
                 },
                 {
                     "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
-                    "nameString": "Alligator mississippiensis"
+                    "hasName": {
+                        "@type": "http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName",
+                        "nomenclaturalCode": "http://purl.obolibrary.org/obo/NOMEN_0000107",
+                        "label": "Alligator mississippiensis",
+                        "nameComplete": "Alligator mississippiensis",
+                        "genusPart": "Alligator",
+                        "specificEpithet": "mississippiensis"
+                    }
                 }
             ],
             "externalSpecifiers": [],
@@ -372,13 +543,27 @@
             "internalSpecifiers": [
                 {
                     "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
-                    "nameString": "Alligator mississippiensis"
+                    "hasName": {
+                        "@type": "http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName",
+                        "nomenclaturalCode": "http://purl.obolibrary.org/obo/NOMEN_0000107",
+                        "label": "Alligator mississippiensis",
+                        "nameComplete": "Alligator mississippiensis",
+                        "genusPart": "Alligator",
+                        "specificEpithet": "mississippiensis"
+                    }
                 }
             ],
             "externalSpecifiers": [
                 {
                     "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
-                    "nameString": "Caiman crocodilus"
+                    "hasName": {
+                        "@type": "http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName",
+                        "nomenclaturalCode": "http://purl.obolibrary.org/obo/NOMEN_0000107",
+                        "label": "Caiman crocodilus",
+                        "nameComplete": "Caiman crocodilus",
+                        "genusPart": "Caiman",
+                        "specificEpithet": "crocodilus"
+                    }
                 }
             ],
             "pso:holdsStatusInTime": [
@@ -399,13 +584,27 @@
             "internalSpecifiers": [
                 {
                     "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
-                    "nameString": "Caiman crocodilus"
+                    "hasName": {
+                        "@type": "http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName",
+                        "nomenclaturalCode": "http://purl.obolibrary.org/obo/NOMEN_0000107",
+                        "label": "Caiman crocodilus",
+                        "nameComplete": "Caiman crocodilus",
+                        "genusPart": "Caiman",
+                        "specificEpithet": "crocodilus"
+                    }
                 }
             ],
             "externalSpecifiers": [
                 {
                     "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
-                    "nameString": "Alligator mississippiensis"
+                    "hasName": {
+                        "@type": "http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName",
+                        "nomenclaturalCode": "http://purl.obolibrary.org/obo/NOMEN_0000107",
+                        "label": "Alligator mississippiensis",
+                        "nameComplete": "Alligator mississippiensis",
+                        "genusPart": "Alligator",
+                        "specificEpithet": "mississippiensis"
+                    }
                 }
             ],
             "pso:holdsStatusInTime": [
@@ -426,17 +625,38 @@
             "internalSpecifiers": [
                 {
                     "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
-                    "nameString": "Crocodylus niloticus"
+                    "hasName": {
+                        "@type": "http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName",
+                        "nomenclaturalCode": "http://purl.obolibrary.org/obo/NOMEN_0000107",
+                        "label": "Crocodylus niloticus",
+                        "nameComplete": "Crocodylus niloticus",
+                        "genusPart": "Crocodylus",
+                        "specificEpithet": "niloticus"
+                    }
                 }
             ],
             "externalSpecifiers": [
                 {
                     "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
-                    "nameString": "Alligator mississippiensis"
+                    "hasName": {
+                        "@type": "http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName",
+                        "nomenclaturalCode": "http://purl.obolibrary.org/obo/NOMEN_0000107",
+                        "label": "Alligator mississippiensis",
+                        "nameComplete": "Alligator mississippiensis",
+                        "genusPart": "Alligator",
+                        "specificEpithet": "mississippiensis"
+                    }
                 },
                 {
                     "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
-                    "nameString": "Gavialis gangeticus"
+                    "hasName": {
+                        "@type": "http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName",
+                        "nomenclaturalCode": "http://purl.obolibrary.org/obo/NOMEN_0000107",
+                        "label": "Gavialis gangeticus",
+                        "nameComplete": "Gavialis gangeticus",
+                        "genusPart": "Gavialis",
+                        "specificEpithet": "gangeticus"
+                    }
                 }
             ],
             "pso:holdsStatusInTime": [
@@ -457,15 +677,36 @@
             "internalSpecifiers": [
                 {
                     "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
-                    "nameString": "Tomistoma schlegelii"
+                    "hasName": {
+                        "@type": "http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName",
+                        "nomenclaturalCode": "http://purl.obolibrary.org/obo/NOMEN_0000107",
+                        "label": "Tomistoma schlegelii",
+                        "nameComplete": "Tomistoma schlegelii",
+                        "genusPart": "Tomistoma",
+                        "specificEpithet": "schlegelii"
+                    }
                 },
                 {
                     "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
-                    "nameString": "Osteolaemus tetraspis"
+                    "hasName": {
+                        "@type": "http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName",
+                        "nomenclaturalCode": "http://purl.obolibrary.org/obo/NOMEN_0000107",
+                        "label": "Osteolaemus tetraspis",
+                        "nameComplete": "Osteolaemus tetraspis",
+                        "genusPart": "Osteolaemus",
+                        "specificEpithet": "tetraspis"
+                    }
                 },
                 {
                     "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
-                    "nameString": "Crocodylus niloticus"
+                    "hasName": {
+                        "@type": "http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName",
+                        "nomenclaturalCode": "http://purl.obolibrary.org/obo/NOMEN_0000107",
+                        "label": "Crocodylus niloticus",
+                        "nameComplete": "Crocodylus niloticus",
+                        "genusPart": "Crocodylus",
+                        "specificEpithet": "niloticus"
+                    }
                 }
             ],
             "externalSpecifiers": [],
@@ -487,38 +728,80 @@
             "internalSpecifiers": [
                 {
                     "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
-                    "nameString": "Mekosuchus inexpectatus",
-                    "specifierWillNotMatch": "Not illustrated in fig 1"
+                    "hasName": {
+                        "@type": "http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName",
+                        "nomenclaturalCode": "http://purl.obolibrary.org/obo/NOMEN_0000107",
+                        "label": "Mekosuchus inexpectatus",
+                        "nameComplete": "Mekosuchus inexpectatus",
+                        "genusPart": "Mekosuchus",
+                        "specificEpithet": "inexpectatus"
+                    }
                 },
                 {
                     "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
-                    "nameString": "Quinkana fortirostrum",
-                    "specifierWillNotMatch": "Not illustrated in fig 1"
+                    "hasName": {
+                        "@type": "http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName",
+                        "nomenclaturalCode": "http://purl.obolibrary.org/obo/NOMEN_0000107",
+                        "label": "Quinkana fortirostrum",
+                        "nameComplete": "Quinkana fortirostrum",
+                        "genusPart": "Quinkana",
+                        "specificEpithet": "fortirostrum"
+                    }
                 },
                 {
                     "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
-                    "nameString": "Trilophosuchus rackhami",
-                    "specifierWillNotMatch": "Not illustrated in fig 1"
+                    "hasName": {
+                        "@type": "http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName",
+                        "nomenclaturalCode": "http://purl.obolibrary.org/obo/NOMEN_0000107",
+                        "label": "Trilophosuchus rackhami",
+                        "nameComplete": "Trilophosuchus rackhami",
+                        "genusPart": "Trilophosuchus",
+                        "specificEpithet": "rackhami"
+                    }
                 },
                 {
                     "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
-                    "nameString": "Baru darrowi",
-                    "specifierWillNotMatch": "Not illustrated in fig 1"
+                    "hasName": {
+                        "@type": "http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName",
+                        "nomenclaturalCode": "http://purl.obolibrary.org/obo/NOMEN_0000107",
+                        "label": "Baru darrowi",
+                        "nameComplete": "Baru darrowi",
+                        "genusPart": "Baru",
+                        "specificEpithet": "darrowi"
+                    }
                 },
                 {
                     "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
-                    "nameString": "Pallimnarchus pollens",
-                    "specifierWillNotMatch": "Not illustrated in fig 1"
+                    "hasName": {
+                        "@type": "http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName",
+                        "nomenclaturalCode": "http://purl.obolibrary.org/obo/NOMEN_0000107",
+                        "label": "Pallimnarchus pollens",
+                        "nameComplete": "Pallimnarchus pollens",
+                        "genusPart": "Pallimnarchus",
+                        "specificEpithet": "pollens"
+                    }
                 },
                 {
                     "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
-                    "nameString": "Australosuchus clarkae",
-                    "specifierWillNotMatch": "Not illustrated in fig 1"
+                    "hasName": {
+                        "@type": "http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName",
+                        "nomenclaturalCode": "http://purl.obolibrary.org/obo/NOMEN_0000107",
+                        "label": "Australosuchus clarkae",
+                        "nameComplete": "Australosuchus clarkae",
+                        "genusPart": "Australosuchus",
+                        "specificEpithet": "clarkae"
+                    }
                 },
                 {
                     "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
-                    "nameString": "Kambara murgonensis",
-                    "specifierWillNotMatch": "Not illustrated in fig 1"
+                    "hasName": {
+                        "@type": "http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName",
+                        "nomenclaturalCode": "http://purl.obolibrary.org/obo/NOMEN_0000107",
+                        "label": "Kambara murgonensis",
+                        "nameComplete": "Kambara murgonensis",
+                        "genusPart": "Kambara",
+                        "specificEpithet": "murgonensis"
+                    }
                 }
             ],
             "externalSpecifiers": [],
@@ -541,13 +824,27 @@
             "internalSpecifiers": [
                 {
                     "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
-                    "nameString": "Tomistoma schlegelii"
+                    "hasName": {
+                        "@type": "http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName",
+                        "nomenclaturalCode": "http://purl.obolibrary.org/obo/NOMEN_0000107",
+                        "label": "Tomistoma schlegelii",
+                        "nameComplete": "Tomistoma schlegelii",
+                        "genusPart": "Tomistoma",
+                        "specificEpithet": "schlegelii"
+                    }
                 }
             ],
             "externalSpecifiers": [
                 {
                     "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
-                    "nameString": "Crocodylus niloticus"
+                    "hasName": {
+                        "@type": "http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName",
+                        "nomenclaturalCode": "http://purl.obolibrary.org/obo/NOMEN_0000107",
+                        "label": "Crocodylus niloticus",
+                        "nameComplete": "Crocodylus niloticus",
+                        "genusPart": "Crocodylus",
+                        "specificEpithet": "niloticus"
+                    }
                 }
             ],
             "pso:holdsStatusInTime": [
@@ -568,13 +865,27 @@
             "internalSpecifiers": [
                 {
                     "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
-                    "nameString": "Crocodylus niloticus"
+                    "hasName": {
+                        "@type": "http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName",
+                        "nomenclaturalCode": "http://purl.obolibrary.org/obo/NOMEN_0000107",
+                        "label": "Crocodylus niloticus",
+                        "nameComplete": "Crocodylus niloticus",
+                        "genusPart": "Crocodylus",
+                        "specificEpithet": "niloticus"
+                    }
                 }
             ],
             "externalSpecifiers": [
                 {
                     "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
-                    "nameString": "Tomistoma schlegelii"
+                    "hasName": {
+                        "@type": "http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName",
+                        "nomenclaturalCode": "http://purl.obolibrary.org/obo/NOMEN_0000107",
+                        "label": "Tomistoma schlegelii",
+                        "nameComplete": "Tomistoma schlegelii",
+                        "genusPart": "Tomistoma",
+                        "specificEpithet": "schlegelii"
+                    }
                 }
             ],
             "pso:holdsStatusInTime": [
@@ -595,13 +906,27 @@
             "internalSpecifiers": [
                 {
                     "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
-                    "nameString": "Osteolaemus tetraspis"
+                    "hasName": {
+                        "@type": "http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName",
+                        "nomenclaturalCode": "http://purl.obolibrary.org/obo/NOMEN_0000107",
+                        "label": "Osteolaemus tetraspis",
+                        "nameComplete": "Osteolaemus tetraspis",
+                        "genusPart": "Osteolaemus",
+                        "specificEpithet": "tetraspis"
+                    }
                 }
             ],
             "externalSpecifiers": [
                 {
                     "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
-                    "nameString": "Crocodylus niloticus"
+                    "hasName": {
+                        "@type": "http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName",
+                        "nomenclaturalCode": "http://purl.obolibrary.org/obo/NOMEN_0000107",
+                        "label": "Crocodylus niloticus",
+                        "nameComplete": "Crocodylus niloticus",
+                        "genusPart": "Crocodylus",
+                        "specificEpithet": "niloticus"
+                    }
                 }
             ],
             "curatorComments": "Not illustrated in fig 1, but it's resolution is pretty unambiguous, so I'm going to assert that it should resolve to \"Osteolaemus tetraspis\"",
@@ -623,11 +948,25 @@
             "internalSpecifiers": [
                 {
                     "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
-                    "nameString": "Osteolaemus tetraspis"
+                    "hasName": {
+                        "@type": "http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName",
+                        "nomenclaturalCode": "http://purl.obolibrary.org/obo/NOMEN_0000107",
+                        "label": "Osteolaemus tetraspis",
+                        "nameComplete": "Osteolaemus tetraspis",
+                        "genusPart": "Osteolaemus",
+                        "specificEpithet": "tetraspis"
+                    }
                 },
                 {
                     "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
-                    "nameString": "Crocodylus niloticus"
+                    "hasName": {
+                        "@type": "http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName",
+                        "nomenclaturalCode": "http://purl.obolibrary.org/obo/NOMEN_0000107",
+                        "label": "Crocodylus niloticus",
+                        "nameComplete": "Crocodylus niloticus",
+                        "genusPart": "Crocodylus",
+                        "specificEpithet": "niloticus"
+                    }
                 }
             ],
             "externalSpecifiers": [],
@@ -650,13 +989,27 @@
             "internalSpecifiers": [
                 {
                     "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
-                    "nameString": "Crocodylus niloticus"
+                    "hasName": {
+                        "@type": "http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName",
+                        "nomenclaturalCode": "http://purl.obolibrary.org/obo/NOMEN_0000107",
+                        "label": "Crocodylus niloticus",
+                        "nameComplete": "Crocodylus niloticus",
+                        "genusPart": "Crocodylus",
+                        "specificEpithet": "niloticus"
+                    }
                 }
             ],
             "externalSpecifiers": [
                 {
                     "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
-                    "nameString": "Osteolaemus tetraspis"
+                    "hasName": {
+                        "@type": "http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName",
+                        "nomenclaturalCode": "http://purl.obolibrary.org/obo/NOMEN_0000107",
+                        "label": "Osteolaemus tetraspis",
+                        "nameComplete": "Osteolaemus tetraspis",
+                        "genusPart": "Osteolaemus",
+                        "specificEpithet": "tetraspis"
+                    }
                 }
             ],
             "curatorComments": "Not illustrated in fig 1.",
@@ -678,11 +1031,25 @@
             "internalSpecifiers": [
                 {
                     "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
-                    "nameString": "Tomistoma schlegelii"
+                    "hasName": {
+                        "@type": "http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName",
+                        "nomenclaturalCode": "http://purl.obolibrary.org/obo/NOMEN_0000107",
+                        "label": "Tomistoma schlegelii",
+                        "nameComplete": "Tomistoma schlegelii",
+                        "genusPart": "Tomistoma",
+                        "specificEpithet": "schlegelii"
+                    }
                 },
                 {
                     "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
-                    "nameString": "Gavialis gangeticus"
+                    "hasName": {
+                        "@type": "http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName",
+                        "nomenclaturalCode": "http://purl.obolibrary.org/obo/NOMEN_0000107",
+                        "label": "Gavialis gangeticus",
+                        "nameComplete": "Gavialis gangeticus",
+                        "genusPart": "Gavialis",
+                        "specificEpithet": "gangeticus"
+                    }
                 }
             ],
             "externalSpecifiers": [],
@@ -705,13 +1072,27 @@
             "internalSpecifiers": [
                 {
                     "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
-                    "nameString": "Tomistoma schlegelii"
+                    "hasName": {
+                        "@type": "http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName",
+                        "nomenclaturalCode": "http://purl.obolibrary.org/obo/NOMEN_0000107",
+                        "label": "Tomistoma schlegelii",
+                        "nameComplete": "Tomistoma schlegelii",
+                        "genusPart": "Tomistoma",
+                        "specificEpithet": "schlegelii"
+                    }
                 }
             ],
             "externalSpecifiers": [
                 {
                     "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
-                    "nameString": "Gavialis gangeticus"
+                    "hasName": {
+                        "@type": "http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName",
+                        "nomenclaturalCode": "http://purl.obolibrary.org/obo/NOMEN_0000107",
+                        "label": "Gavialis gangeticus",
+                        "nameComplete": "Gavialis gangeticus",
+                        "genusPart": "Gavialis",
+                        "specificEpithet": "gangeticus"
+                    }
                 }
             ],
             "curatorComments": "Not illustrated in fig 1.",
@@ -733,13 +1114,27 @@
             "internalSpecifiers": [
                 {
                     "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
-                    "nameString": "Gavialis gangeticus"
+                    "hasName": {
+                        "@type": "http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName",
+                        "nomenclaturalCode": "http://purl.obolibrary.org/obo/NOMEN_0000107",
+                        "label": "Gavialis gangeticus",
+                        "nameComplete": "Gavialis gangeticus",
+                        "genusPart": "Gavialis",
+                        "specificEpithet": "gangeticus"
+                    }
                 }
             ],
             "externalSpecifiers": [
                 {
                     "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
-                    "nameString": "Tomistoma schlegelii"
+                    "hasName": {
+                        "@type": "http://rs.tdwg.org/ontology/voc/TaxonName#TaxonName",
+                        "nomenclaturalCode": "http://purl.obolibrary.org/obo/NOMEN_0000107",
+                        "label": "Tomistoma schlegelii",
+                        "nameComplete": "Tomistoma schlegelii",
+                        "genusPart": "Tomistoma",
+                        "specificEpithet": "schlegelii"
+                    }
                 }
             ],
             "curatorComments": "Not illustrated in fig 1",
@@ -756,5 +1151,6 @@
             ]
         }
     ],
-    "title": "Phylogenetic Approaches Toward Crocodylian History"
+    "title": "Phylogenetic Approaches Toward Crocodylian History",
+    "defaultNomenclaturalCodeURI": "http://purl.obolibrary.org/obo/NOMEN_0000107"
 }

--- a/public/examples/brochu_2003.json
+++ b/public/examples/brochu_2003.json
@@ -1,4 +1,5 @@
 {
+    "@context": "file:///home/vaidyagi/code/phyloref/phyx.js/docs/context/v0.2.0/phyx.json",
     "doi": "10.1146/annurev.earth.31.100901.141308",
     "url": "https://www.annualreviews.org/doi/10.1146/annurev.earth.31.100901.141308",
     "citation": "Brochu (2003) Annual Review of Earth and Planetary Sciences 31:357-397",
@@ -56,48 +57,20 @@
             "cladeDefinition": "Eusuchia (Huxley 1875). Amended definition.\n\nLast common ancestor of Hylaeochampsa vectiana, Crocodylus niloticus, Gavialis gangeticus, and Alligator mississippiensis\t and all of its descendents.",
             "internalSpecifiers": [
                 {
-                    "referencesTaxonomicUnits": [
-                        {
-                            "scientificNames": [
-                                {
-                                    "scientificName": "Alligator mississippiensis"
-                                }
-                            ]
-                        }
-                    ]
+                    "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
+                    "nameString": "Alligator mississippiensis"
                 },
                 {
-                    "referencesTaxonomicUnits": [
-                        {
-                            "scientificNames": [
-                                {
-                                    "scientificName": "Gavialis gangeticus"
-                                }
-                            ]
-                        }
-                    ]
+                    "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
+                    "nameString": "Gavialis gangeticus"
                 },
                 {
-                    "referencesTaxonomicUnits": [
-                        {
-                            "scientificNames": [
-                                {
-                                    "scientificName": "Crocodylus niloticus"
-                                }
-                            ]
-                        }
-                    ]
+                    "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
+                    "nameString": "Crocodylus niloticus"
                 },
                 {
-                    "referencesTaxonomicUnits": [
-                        {
-                            "scientificNames": [
-                                {
-                                    "scientificName": "Hylaeochampsa vectiana"
-                                }
-                            ]
-                        }
-                    ],
+                    "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
+                    "nameString": "Hylaeochampsa vectiana",
                     "specifierWillNotMatch": "Not present in figure 1"
                 }
             ],
@@ -119,37 +92,16 @@
             "cladeDefinition": "Crocodylia (Gmelin 1789). Amended definition.\n\nLast common ancestor of Gavialis gangeticus, Alligator mississippiensis, and Crocodylus niloticus and all of its\t descendents.",
             "internalSpecifiers": [
                 {
-                    "referencesTaxonomicUnits": [
-                        {
-                            "scientificNames": [
-                                {
-                                    "scientificName": "Crocodylus niloticus"
-                                }
-                            ]
-                        }
-                    ]
+                    "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
+                    "nameString": "Crocodylus niloticus"
                 },
                 {
-                    "referencesTaxonomicUnits": [
-                        {
-                            "scientificNames": [
-                                {
-                                    "scientificName": "Alligator mississippiensis"
-                                }
-                            ]
-                        }
-                    ]
+                    "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
+                    "nameString": "Alligator mississippiensis"
                 },
                 {
-                    "referencesTaxonomicUnits": [
-                        {
-                            "scientificNames": [
-                                {
-                                    "scientificName": "Gavialis gangeticus"
-                                }
-                            ]
-                        }
-                    ]
+                    "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
+                    "nameString": "Gavialis gangeticus"
                 }
             ],
             "externalSpecifiers": [],
@@ -170,39 +122,18 @@
             "cladeDefinition": "Gavialoidea (Case 1930).\n\nGavialis gangeticus and all crocodylians closer to it than to Alligator mississippiensis or Crocodylus niloticus.",
             "internalSpecifiers": [
                 {
-                    "referencesTaxonomicUnits": [
-                        {
-                            "scientificNames": [
-                                {
-                                    "scientificName": "Gavialis gangeticus"
-                                }
-                            ]
-                        }
-                    ]
+                    "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
+                    "nameString": "Gavialis gangeticus"
                 }
             ],
             "externalSpecifiers": [
                 {
-                    "referencesTaxonomicUnits": [
-                        {
-                            "scientificNames": [
-                                {
-                                    "scientificName": "Alligator mississippiensis"
-                                }
-                            ]
-                        }
-                    ]
+                    "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
+                    "nameString": "Alligator mississippiensis"
                 },
                 {
-                    "referencesTaxonomicUnits": [
-                        {
-                            "scientificNames": [
-                                {
-                                    "scientificName": "Crocodylus niloticus"
-                                }
-                            ]
-                        }
-                    ]
+                    "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
+                    "nameString": "Crocodylus niloticus"
                 }
             ],
             "pso:holdsStatusInTime": [
@@ -222,51 +153,23 @@
             "cladeDefinition": "Pristichampsinae (Kuhn 1968)\t. New definition.\n\nPristichampsus rollinati and all crocodylians closer to it than to Gavialis gangeticus, Alligator mississippiensis, or Crocodylus niloticus.",
             "internalSpecifiers": [
                 {
-                    "referencesTaxonomicUnits": [
-                        {
-                            "scientificNames": [
-                                {
-                                    "scientificName": "Pristichampsus rollinati"
-                                }
-                            ]
-                        }
-                    ],
+                    "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
+                    "nameString": "Pristichampsus rollinati",
                     "specifierWillNotMatch": "Not included in figure 1"
                 }
             ],
             "externalSpecifiers": [
                 {
-                    "referencesTaxonomicUnits": [
-                        {
-                            "scientificNames": [
-                                {
-                                    "scientificName": "Gavialis gangeticus"
-                                }
-                            ]
-                        }
-                    ]
+                    "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
+                    "nameString": "Gavialis gangeticus"
                 },
                 {
-                    "referencesTaxonomicUnits": [
-                        {
-                            "scientificNames": [
-                                {
-                                    "scientificName": "Alligator mississippiensis"
-                                }
-                            ]
-                        }
-                    ]
+                    "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
+                    "nameString": "Alligator mississippiensis"
                 },
                 {
-                    "referencesTaxonomicUnits": [
-                        {
-                            "scientificNames": [
-                                {
-                                    "scientificName": "Crocodylus niloticus"
-                                }
-                            ]
-                        }
-                    ]
+                    "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
+                    "nameString": "Crocodylus niloticus"
                 }
             ],
             "curatorComments": "Not included in figure 1.",
@@ -287,26 +190,12 @@
             "cladeDefinition": "Brevirostres (von Zittel 1890). If Gavialis and Tomistoma are sister taxa, Brevirostres is a junior synonym of Crocodylia.\n\nLast common ancestor of Alligator mississippiensis and Crocodylus niloticus and all of its descendents.\n \t \t ",
             "internalSpecifiers": [
                 {
-                    "referencesTaxonomicUnits": [
-                        {
-                            "scientificNames": [
-                                {
-                                    "scientificName": "Crocodylus niloticus"
-                                }
-                            ]
-                        }
-                    ]
+                    "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
+                    "nameString": "Crocodylus niloticus"
                 },
                 {
-                    "referencesTaxonomicUnits": [
-                        {
-                            "scientificNames": [
-                                {
-                                    "scientificName": "Alligator mississippiensis"
-                                }
-                            ]
-                        }
-                    ]
+                    "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
+                    "nameString": "Alligator mississippiensis"
                 }
             ],
             "externalSpecifiers": [],
@@ -327,39 +216,18 @@
             "cladeDefinition": "Alligatoroidea (Gray 1844). \n\nAlligator mississippiensis and all crocodylians closer to it than to Crocodylus niloticus or Gavialis gangeticus.",
             "internalSpecifiers": [
                 {
-                    "referencesTaxonomicUnits": [
-                        {
-                            "scientificNames": [
-                                {
-                                    "scientificName": "Alligator mississippiensis"
-                                }
-                            ]
-                        }
-                    ]
+                    "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
+                    "nameString": "Alligator mississippiensis"
                 }
             ],
             "externalSpecifiers": [
                 {
-                    "referencesTaxonomicUnits": [
-                        {
-                            "scientificNames": [
-                                {
-                                    "scientificName": "Crocodylus niloticus"
-                                }
-                            ]
-                        }
-                    ]
+                    "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
+                    "nameString": "Crocodylus niloticus"
                 },
                 {
-                    "referencesTaxonomicUnits": [
-                        {
-                            "scientificNames": [
-                                {
-                                    "scientificName": "Gavialis gangeticus"
-                                }
-                            ]
-                        }
-                    ]
+                    "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
+                    "nameString": "Gavialis gangeticus"
                 }
             ],
             "pso:holdsStatusInTime": [
@@ -381,28 +249,16 @@
             "cladeDefinition": "Diplocynodontinae (Brochu 1999).\n\nDiplocynodon ratelii and all crocodylians closer to it than to Alligator mississippiensis.",
             "internalSpecifiers": [
                 {
-                    "referencesTaxonomicUnits": [
-                        {
-                            "scientificNames": [
-                                {
-                                    "scientificName": "Diplocynodon ratelii"
-                                }
-                            ]
-                        }
-                    ]
+                    "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
+                    "nameString": "Diplocynodon ratelii",
+                    "nomenclaturalCode": "http://purl.obolibrary.org/obo/NOMEN_0000107"
                 }
             ],
             "externalSpecifiers": [
                 {
-                    "referencesTaxonomicUnits": [
-                        {
-                            "scientificNames": [
-                                {
-                                    "scientificName": "Alligator mississippiensis"
-                                }
-                            ]
-                        }
-                    ]
+                    "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
+                    "nameString": "Alligator mississippiensis",
+                    "nomenclaturalCode": "http://purl.obolibrary.org/obo/NOMEN_0000107"
                 }
             ],
             "pso:holdsStatusInTime": [
@@ -422,28 +278,14 @@
             "cladeDefinition": "Globidonta (Brochu 1999).\n\nAlligator mississippiensis and all crocodylians closer to it than to Diplocynodon ratelii.",
             "internalSpecifiers": [
                 {
-                    "referencesTaxonomicUnits": [
-                        {
-                            "scientificNames": [
-                                {
-                                    "scientificName": "Alligator mississippiensis"
-                                }
-                            ]
-                        }
-                    ]
+                    "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
+                    "nameString": "Alligator mississippiensis"
                 }
             ],
             "externalSpecifiers": [
                 {
-                    "referencesTaxonomicUnits": [
-                        {
-                            "scientificNames": [
-                                {
-                                    "scientificName": "Diplocynodon ratelii"
-                                }
-                            ]
-                        }
-                    ]
+                    "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
+                    "nameString": "Diplocynodon ratelii"
                 }
             ],
             "pso:holdsStatusInTime": [
@@ -463,26 +305,12 @@
             "cladeDefinition": "Alligatoridae (Cuvier 1807).\n\nLast common ancestor of Alligator mississippiensis and Caiman crocodilus and all of its descendents.",
             "internalSpecifiers": [
                 {
-                    "referencesTaxonomicUnits": [
-                        {
-                            "scientificNames": [
-                                {
-                                    "scientificName": "Caiman crocodilus"
-                                }
-                            ]
-                        }
-                    ]
+                    "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
+                    "nameString": "Caiman crocodilus"
                 },
                 {
-                    "referencesTaxonomicUnits": [
-                        {
-                            "scientificNames": [
-                                {
-                                    "scientificName": "Alligator mississippiensis"
-                                }
-                            ]
-                        }
-                    ]
+                    "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
+                    "nameString": "Alligator mississippiensis"
                 }
             ],
             "externalSpecifiers": [],
@@ -503,28 +331,14 @@
             "cladeDefinition": "Alligatorinae (Kälin 1940).\n\nAlligator mississippiensis and all crocodylians closer to it than to Caiman crocodilus.",
             "internalSpecifiers": [
                 {
-                    "referencesTaxonomicUnits": [
-                        {
-                            "scientificNames": [
-                                {
-                                    "scientificName": "Alligator mississippiensis"
-                                }
-                            ]
-                        }
-                    ]
+                    "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
+                    "nameString": "Alligator mississippiensis"
                 }
             ],
             "externalSpecifiers": [
                 {
-                    "referencesTaxonomicUnits": [
-                        {
-                            "scientificNames": [
-                                {
-                                    "scientificName": "Caiman crocodilus"
-                                }
-                            ]
-                        }
-                    ]
+                    "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
+                    "nameString": "Caiman crocodilus"
                 }
             ],
             "pso:holdsStatusInTime": [
@@ -544,28 +358,14 @@
             "cladeDefinition": "Caimaninae (Norell 1988).\n\nCaiman crocodilus and all crocodylians closer to it than to Alligator mississippiensis.",
             "internalSpecifiers": [
                 {
-                    "referencesTaxonomicUnits": [
-                        {
-                            "scientificNames": [
-                                {
-                                    "scientificName": "Caiman crocodilus"
-                                }
-                            ]
-                        }
-                    ]
+                    "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
+                    "nameString": "Caiman crocodilus"
                 }
             ],
             "externalSpecifiers": [
                 {
-                    "referencesTaxonomicUnits": [
-                        {
-                            "scientificNames": [
-                                {
-                                    "scientificName": "Alligator mississippiensis"
-                                }
-                            ]
-                        }
-                    ]
+                    "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
+                    "nameString": "Alligator mississippiensis"
                 }
             ],
             "pso:holdsStatusInTime": [
@@ -585,39 +385,18 @@
             "cladeDefinition": "Crocodyloidea (Fitzinger 1826).\n\nCrocodylus niloticus and all crocodylians closer to it than to Alligator mississippiensis or Gavialis gangeticus.",
             "internalSpecifiers": [
                 {
-                    "referencesTaxonomicUnits": [
-                        {
-                            "scientificNames": [
-                                {
-                                    "scientificName": "Crocodylus niloticus"
-                                }
-                            ]
-                        }
-                    ]
+                    "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
+                    "nameString": "Crocodylus niloticus"
                 }
             ],
             "externalSpecifiers": [
                 {
-                    "referencesTaxonomicUnits": [
-                        {
-                            "scientificNames": [
-                                {
-                                    "scientificName": "Alligator mississippiensis"
-                                }
-                            ]
-                        }
-                    ]
+                    "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
+                    "nameString": "Alligator mississippiensis"
                 },
                 {
-                    "referencesTaxonomicUnits": [
-                        {
-                            "scientificNames": [
-                                {
-                                    "scientificName": "Gavialis gangeticus"
-                                }
-                            ]
-                        }
-                    ]
+                    "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
+                    "nameString": "Gavialis gangeticus"
                 }
             ],
             "pso:holdsStatusInTime": [
@@ -637,37 +416,16 @@
             "cladeDefinition": "Crocodylidae (Cuvier 1807). Definition dependent on phylogenetic context.\n\nLast common ancestor of Crocodylus niloticus, Osteolaemus tetraspis, and Tomistoma schlegelii and all of its descendents.",
             "internalSpecifiers": [
                 {
-                    "referencesTaxonomicUnits": [
-                        {
-                            "scientificNames": [
-                                {
-                                    "scientificName": "Tomistoma schlegelii"
-                                }
-                            ]
-                        }
-                    ]
+                    "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
+                    "nameString": "Tomistoma schlegelii"
                 },
                 {
-                    "referencesTaxonomicUnits": [
-                        {
-                            "scientificNames": [
-                                {
-                                    "scientificName": "Osteolaemus tetraspis"
-                                }
-                            ]
-                        }
-                    ]
+                    "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
+                    "nameString": "Osteolaemus tetraspis"
                 },
                 {
-                    "referencesTaxonomicUnits": [
-                        {
-                            "scientificNames": [
-                                {
-                                    "scientificName": "Crocodylus niloticus"
-                                }
-                            ]
-                        }
-                    ]
+                    "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
+                    "nameString": "Crocodylus niloticus"
                 }
             ],
             "externalSpecifiers": [],
@@ -688,87 +446,38 @@
             "cladeDefinition": "Mekosuchinae (Balouet & Buffetaut 1987). Definition adapted from Salisbury & Willis 1996.\n\nLast common ancestor of Kambara murgonensis, Australosuchus clarkae, Pallimnarchus pollens, Baru darrowi, Trilophosuchus rackhami, Quinkana\t fortirostrum, and Mekosuchus inexpectatus and all of its descendents.",
             "internalSpecifiers": [
                 {
-                    "referencesTaxonomicUnits": [
-                        {
-                            "scientificNames": [
-                                {
-                                    "scientificName": "Mekosuchus inexpectatus"
-                                }
-                            ]
-                        }
-                    ],
+                    "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
+                    "nameString": "Mekosuchus inexpectatus",
                     "specifierWillNotMatch": "Not illustrated in fig 1"
                 },
                 {
-                    "referencesTaxonomicUnits": [
-                        {
-                            "scientificNames": [
-                                {
-                                    "scientificName": "Quinkana fortirostrum"
-                                }
-                            ]
-                        }
-                    ],
+                    "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
+                    "nameString": "Quinkana fortirostrum",
                     "specifierWillNotMatch": "Not illustrated in fig 1"
                 },
                 {
-                    "referencesTaxonomicUnits": [
-                        {
-                            "scientificNames": [
-                                {
-                                    "scientificName": "Trilophosuchus rackhami"
-                                }
-                            ]
-                        }
-                    ],
+                    "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
+                    "nameString": "Trilophosuchus rackhami",
                     "specifierWillNotMatch": "Not illustrated in fig 1"
                 },
                 {
-                    "referencesTaxonomicUnits": [
-                        {
-                            "scientificNames": [
-                                {
-                                    "scientificName": "Baru darrowi"
-                                }
-                            ]
-                        }
-                    ],
+                    "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
+                    "nameString": "Baru darrowi",
                     "specifierWillNotMatch": "Not illustrated in fig 1"
                 },
                 {
-                    "referencesTaxonomicUnits": [
-                        {
-                            "scientificNames": [
-                                {
-                                    "scientificName": "Pallimnarchus pollens"
-                                }
-                            ]
-                        }
-                    ],
+                    "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
+                    "nameString": "Pallimnarchus pollens",
                     "specifierWillNotMatch": "Not illustrated in fig 1"
                 },
                 {
-                    "referencesTaxonomicUnits": [
-                        {
-                            "scientificNames": [
-                                {
-                                    "scientificName": "Australosuchus clarkae"
-                                }
-                            ]
-                        }
-                    ],
+                    "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
+                    "nameString": "Australosuchus clarkae",
                     "specifierWillNotMatch": "Not illustrated in fig 1"
                 },
                 {
-                    "referencesTaxonomicUnits": [
-                        {
-                            "scientificNames": [
-                                {
-                                    "scientificName": "Kambara murgonensis"
-                                }
-                            ]
-                        }
-                    ],
+                    "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
+                    "nameString": "Kambara murgonensis",
                     "specifierWillNotMatch": "Not illustrated in fig 1"
                 }
             ],
@@ -791,28 +500,14 @@
             "cladeDefinition": "Tomistominae (Kälin 1955). Definition dependent on phylogenetic context.\n\nTomistoma schlegelii and all crocodylians closer to it than to Crocodylus niloticus.",
             "internalSpecifiers": [
                 {
-                    "referencesTaxonomicUnits": [
-                        {
-                            "scientificNames": [
-                                {
-                                    "scientificName": "Tomistoma schlegelii"
-                                }
-                            ]
-                        }
-                    ]
+                    "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
+                    "nameString": "Tomistoma schlegelii"
                 }
             ],
             "externalSpecifiers": [
                 {
-                    "referencesTaxonomicUnits": [
-                        {
-                            "scientificNames": [
-                                {
-                                    "scientificName": "Crocodylus niloticus"
-                                }
-                            ]
-                        }
-                    ]
+                    "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
+                    "nameString": "Crocodylus niloticus"
                 }
             ],
             "pso:holdsStatusInTime": [
@@ -832,28 +527,14 @@
             "cladeDefinition": "Crocodylinae (Cuvier 1807). Definition dependent on phylogenetic context.\n\nCrocodylus niloticus and all crocodylians closer to it than to Tomistoma schlegelii.\n \t \t ",
             "internalSpecifiers": [
                 {
-                    "referencesTaxonomicUnits": [
-                        {
-                            "scientificNames": [
-                                {
-                                    "scientificName": "Crocodylus niloticus"
-                                }
-                            ]
-                        }
-                    ]
+                    "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
+                    "nameString": "Crocodylus niloticus"
                 }
             ],
             "externalSpecifiers": [
                 {
-                    "referencesTaxonomicUnits": [
-                        {
-                            "scientificNames": [
-                                {
-                                    "scientificName": "Tomistoma schlegelii"
-                                }
-                            ]
-                        }
-                    ]
+                    "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
+                    "nameString": "Tomistoma schlegelii"
                 }
             ],
             "pso:holdsStatusInTime": [
@@ -873,28 +554,14 @@
             "cladeDefinition": "Osteolaeminae tax. nov. New definition.\n\nOsteolaemus tetraspis and all crocodylians closer to it than to Crocodylus niloticus.",
             "internalSpecifiers": [
                 {
-                    "referencesTaxonomicUnits": [
-                        {
-                            "scientificNames": [
-                                {
-                                    "scientificName": "Osteolaemus tetraspis"
-                                }
-                            ]
-                        }
-                    ]
+                    "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
+                    "nameString": "Osteolaemus tetraspis"
                 }
             ],
             "externalSpecifiers": [
                 {
-                    "referencesTaxonomicUnits": [
-                        {
-                            "scientificNames": [
-                                {
-                                    "scientificName": "Crocodylus niloticus"
-                                }
-                            ]
-                        }
-                    ]
+                    "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
+                    "nameString": "Crocodylus niloticus"
                 }
             ],
             "curatorComments": "Not illustrated in fig 1, but it's resolution is pretty unambiguous, so I'm going to assert that it should resolve to \"Osteolaemus tetraspis\"",
@@ -915,26 +582,12 @@
             "cladeDefinition": "Crocodylidae (Cuvier 1807).\n\nLast common ancestor of Crocodylus niloticus and Osteolaemus tetraspis and all of its descendents.",
             "internalSpecifiers": [
                 {
-                    "referencesTaxonomicUnits": [
-                        {
-                            "scientificNames": [
-                                {
-                                    "scientificName": "Osteolaemus tetraspis"
-                                }
-                            ]
-                        }
-                    ]
+                    "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
+                    "nameString": "Osteolaemus tetraspis"
                 },
                 {
-                    "referencesTaxonomicUnits": [
-                        {
-                            "scientificNames": [
-                                {
-                                    "scientificName": "Crocodylus niloticus"
-                                }
-                            ]
-                        }
-                    ]
+                    "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
+                    "nameString": "Crocodylus niloticus"
                 }
             ],
             "externalSpecifiers": [],
@@ -956,28 +609,14 @@
             "cladeDefinition": "Crocodylinae (Cuvier 1807). At present, this would be redundant with Crocodylus.\n\nCrocodylus niloticus and all crocodylians closer to it than to Osteolaemus tetraspis.",
             "internalSpecifiers": [
                 {
-                    "referencesTaxonomicUnits": [
-                        {
-                            "scientificNames": [
-                                {
-                                    "scientificName": "Crocodylus niloticus"
-                                }
-                            ]
-                        }
-                    ]
+                    "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
+                    "nameString": "Crocodylus niloticus"
                 }
             ],
             "externalSpecifiers": [
                 {
-                    "referencesTaxonomicUnits": [
-                        {
-                            "scientificNames": [
-                                {
-                                    "scientificName": "Osteolaemus tetraspis"
-                                }
-                            ]
-                        }
-                    ]
+                    "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
+                    "nameString": "Osteolaemus tetraspis"
                 }
             ],
             "curatorComments": "Not illustrated in fig 1.",
@@ -998,26 +637,12 @@
             "cladeDefinition": "Gavialidae (Adams 1854). In a morphological context, Gavialidae would be redundant with Gavialis gangeticus.\n\nLast common ancestor of Gavialis gangeticus and Tomistoma schlegelii and all of its descendents.",
             "internalSpecifiers": [
                 {
-                    "referencesTaxonomicUnits": [
-                        {
-                            "scientificNames": [
-                                {
-                                    "scientificName": "Tomistoma schlegelii"
-                                }
-                            ]
-                        }
-                    ]
+                    "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
+                    "nameString": "Tomistoma schlegelii"
                 },
                 {
-                    "referencesTaxonomicUnits": [
-                        {
-                            "scientificNames": [
-                                {
-                                    "scientificName": "Gavialis gangeticus"
-                                }
-                            ]
-                        }
-                    ]
+                    "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
+                    "nameString": "Gavialis gangeticus"
                 }
             ],
             "externalSpecifiers": [],
@@ -1039,28 +664,14 @@
             "cladeDefinition": "Tomistominae (Kälin 1955).\n\nTomistoma schlegelii and all crocodylians closer to it than to Gavialis gangeticus.",
             "internalSpecifiers": [
                 {
-                    "referencesTaxonomicUnits": [
-                        {
-                            "scientificNames": [
-                                {
-                                    "scientificName": "Tomistoma schlegelii"
-                                }
-                            ]
-                        }
-                    ]
+                    "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
+                    "nameString": "Tomistoma schlegelii"
                 }
             ],
             "externalSpecifiers": [
                 {
-                    "referencesTaxonomicUnits": [
-                        {
-                            "scientificNames": [
-                                {
-                                    "scientificName": "Gavialis gangeticus"
-                                }
-                            ]
-                        }
-                    ]
+                    "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
+                    "nameString": "Gavialis gangeticus"
                 }
             ],
             "curatorComments": "Not illustrated in fig 1.",
@@ -1081,28 +692,14 @@
             "cladeDefinition": "Gavialinae (Nopcsa 1923).\n\nGavialis gangeticus and all crocodylians closer to it than to Tomistoma schlegelii.",
             "internalSpecifiers": [
                 {
-                    "referencesTaxonomicUnits": [
-                        {
-                            "scientificNames": [
-                                {
-                                    "scientificName": "Gavialis gangeticus"
-                                }
-                            ]
-                        }
-                    ]
+                    "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
+                    "nameString": "Gavialis gangeticus"
                 }
             ],
             "externalSpecifiers": [
                 {
-                    "referencesTaxonomicUnits": [
-                        {
-                            "scientificNames": [
-                                {
-                                    "scientificName": "Tomistoma schlegelii"
-                                }
-                            ]
-                        }
-                    ]
+                    "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
+                    "nameString": "Tomistoma schlegelii"
                 }
             ],
             "curatorComments": "Not illustrated in fig 1",
@@ -1119,6 +716,5 @@
             ]
         }
     ],
-    "title": "Phylogenetic Approaches Toward Crocodylian History",
-    "@context": "http://phyloref.org/phyx.js/context/v0.1.0/phyx.json"
+    "title": "Phylogenetic Approaches Toward Crocodylian History"
 }

--- a/public/examples/brochu_2003.json
+++ b/public/examples/brochu_2003.json
@@ -5,7 +5,7 @@
     "citation": "Brochu (2003) Annual Review of Earth and Planetary Sciences 31:357-397",
     "phylogenies": [
         {
-            "description": "Fig 1 from the paper",
+            "description": "",
             "newick": "(Parasuchia,(rauisuchians,Aetosauria,(sphenosuchians,(protosuchians,(mesosuchians,(Hylaeochampsa,Aegyptosuchus,Stomatosuchus,(Allodaposuchus,('Gavialis gangeticus',(('Diplocynodon ratelii',('Alligator mississippiensis','Caiman crocodilus')Alligatoridae)Alligatoroidea,('Tomistoma schlegelii',('Osteolaemus tetraspis','Crocodylus niloticus')Crocodylinae)Crocodylidae)Brevirostres)Crocodylia))Eusuchia)Mesoeucrocodylia)Crocodyliformes)Crocodylomorpha))root;",
             "additionalNodeProperties": {
                 "Gavialis gangeticus": {
@@ -48,7 +48,8 @@
                         "Osteolaeminae"
                     ]
                 }
-            }
+            },
+            "label": "Fig 1 from Brochu 2003"
         }
     ],
     "phylorefs": [
@@ -187,7 +188,7 @@
         },
         {
             "label": "Brevirostres",
-            "cladeDefinition": "Brevirostres (von Zittel 1890). If Gavialis and Tomistoma are sister taxa, Brevirostres is a junior synonym of Crocodylia.\n\nLast common ancestor of Alligator mississippiensis and Crocodylus niloticus and all of its descendents.\n \t \t ",
+            "cladeDefinition": "Last common ancestor of Alligator mississippiensis and Crocodylus niloticus and all of its descendents.",
             "internalSpecifiers": [
                 {
                     "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
@@ -209,7 +210,46 @@
                         "timeinterval:hasIntervalStartDate": "2018-06-11T22:49:04.648Z"
                     }
                 }
-            ]
+            ],
+            "dwc:namePublishedIn": {
+                "type": "book_section",
+                "authors": [
+                    {
+                        "name": "Zittel, Karl Alfred von"
+                    }
+                ],
+                "title": "Handbuch der Palaeontologie",
+                "section_title": "III. Band. Vertebrata",
+                "year": "1890",
+                "pages": "674",
+                "link": [
+                    {
+                        "url": "http://biodiversitylibrary.org/page/40393898"
+                    }
+                ]
+            },
+            "curatorComments": "If Gavialis and Tomistoma are sister taxa, Brevirostres is a junior synonym of Crocodylia.",
+            "obo:IAO_0000119": {
+                "journal": {
+                    "name": "Annual Review of Earth and Planetary Sciences",
+                    "volume": "31"
+                },
+                "type": "article",
+                "authors": [
+                    {
+                        "name": "Brooch, Christopher A"
+                    }
+                ],
+                "title": "Phylogenetic Approaches Toward Crocodilian History",
+                "year": "2003",
+                "pages": "357-397",
+                "identifier": [
+                    {
+                        "type": "doi",
+                        "id": "10.1146/annurev.earth.31.100901.141308"
+                    }
+                ]
+            }
         },
         {
             "label": "Alligatoroidea",

--- a/public/examples/fisher_et_al_2007.json
+++ b/public/examples/fisher_et_al_2007.json
@@ -15,18 +15,9 @@
                     ],
                     "representsTaxonomicUnits": [
                         {
-                            "includesSpecimens": [
-                                {
-                                    "occurrenceID": "urn:catalog:::Mishler 7/24/98 (5)"
-                                }
-                            ]
-                        },
-                        {
-                            "scientificNames": [
-                                {
-                                    "scientificName": "Arthrocormus schimperi"
-                                }
-                            ]
+                            "@type": "http://rs.tdwg.org/dwc/terms/Occurrence",
+                            "occurrenceID": "urn:catalog:::Mishler 7/24/98 (5)",
+                            "nameString": "Arthrocormus schimperi"
                         }
                     ]
                 },
@@ -36,19 +27,9 @@
                     ],
                     "representsTaxonomicUnits": [
                         {
-                            "includesSpecimens": [
-                                {
-                                    "occurrenceID": "urn:catalog:::Wall 2527, Fiji (uc)"
-                                }
-                            ],
-                            "scientificNames": []
-                        },
-                        {
-                            "scientificNames": [
-                                {
-                                    "scientificName": "Exodictyon sp"
-                                }
-                            ]
+                            "@type": "http://rs.tdwg.org/dwc/terms/Occurrence",
+                            "occurrenceID": "urn:catalog:::Wall 2527, Fiji (uc)",
+                            "nameString": "Exodictyon sp"
                         }
                     ]
                 },
@@ -56,26 +37,14 @@
                     "comment": "The paper does not tell us which specimen ID goes with which node, so I've assigned both specmen IDs to both nodes. -- GGV",
                     "representsTaxonomicUnits": [
                         {
-                            "includesSpecimens": [
-                                {
-                                    "occurrenceID": "urn:catalog:::Mishler 7/24/98(3)"
-                                }
-                            ],
-                            "scientificNames": []
+                            "@type": "http://rs.tdwg.org/dwc/terms/Occurrence",
+                            "occurrenceID": "urn:catalog:::Mishler 7/26/98(1)",
+                            "nameString": "Exostratum blumii"
                         },
                         {
-                            "includesSpecimens": [
-                                {
-                                    "occurrenceID": "urn:catalog:::Mishler 7/26/98(1)"
-                                }
-                            ]
-                        },
-                        {
-                            "scientificNames": [
-                                {
-                                    "scientificName": "Exostratum blumii"
-                                }
-                            ]
+                            "@type": "http://rs.tdwg.org/dwc/terms/Occurrence",
+                            "occurrenceID": "urn:catalog:::Mishler 7/26/98(3)",
+                            "nameString": "Exostratum blumii"
                         }
                     ]
                 },
@@ -83,26 +52,14 @@
                     "comment": "The paper does not tell us which specimen ID goes with which node, so I've assigned both specmen IDs to both nodes. -- GGV",
                     "representsTaxonomicUnits": [
                         {
-                            "includesSpecimens": [
-                                {
-                                    "occurrenceID": "urn:catalog:::Mishler 7/24/98(3)"
-                                }
-                            ],
-                            "scientificNames": []
+                            "@type": "http://rs.tdwg.org/dwc/terms/Occurrence",
+                            "occurrenceID": "urn:catalog:::Mishler 7/26/98(1)",
+                            "nameString": "Exostratum blumii"
                         },
                         {
-                            "includesSpecimens": [
-                                {
-                                    "occurrenceID": "urn:catalog:::Mishler 7/26/98(1)"
-                                }
-                            ]
-                        },
-                        {
-                            "scientificNames": [
-                                {
-                                    "scientificName": "Exostratum blumii"
-                                }
-                            ]
+                            "@type": "http://rs.tdwg.org/dwc/terms/Occurrence",
+                            "occurrenceID": "urn:catalog:::Mishler 7/26/98(3)",
+                            "nameString": "Exostratum blumii"
                         }
                     ]
                 }
@@ -116,41 +73,20 @@
             "internalSpecifiers": [
                 {
                     "verbatimSpecifier": "Type: Syrrhopodon gardneri (Hook.) Schwägr., Sp. Musc. Frond. Suppl. 2(1): 110, tab. 131, figs. 1–13. (1824)",
-                    "referencesTaxonomicUnits": [
-                        {
-                            "scientificNames": [
-                                {
-                                    "scientificName": "Syrrhopodon gardneri (Hook.) Schwägr., Sp. Musc. Frond. Suppl. 2(1): 110, tab. 131, figs. 1-13 (1824)"
-                                }
-                            ]
-                        }
-                    ]
+                    "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
+                    "nameString": "Syrrhopodon gardneri (Hook.) Schwägr., Sp. Musc. Frond. Suppl. 2(1): 110, tab. 131, figs. 1-13 (1824)"
                 },
                 {
                     "verbatimSpecifier": "Type: Leucophanes octoblepharoides Brid., Bryol. Univ. 1: 763. (1826)",
-                    "referencesTaxonomicUnits": [
-                        {
-                            "scientificNames": [
-                                {
-                                    "scientificName": "Leucophanes octoblepharoides Brid., Bryol. Univ. 1: 763. (1826)"
-                                }
-                            ]
-                        }
-                    ]
+                    "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
+                    "nameString": "Leucophanes octoblepharoides Brid., Bryol. Univ. 1: 763. (1826)"
                 }
             ],
             "externalSpecifiers": [
                 {
                     "verbatimSpecifier": "Type: Octoblepharum albidum Hedw., Sp. Musc. 50. (1801)",
-                    "referencesTaxonomicUnits": [
-                        {
-                            "scientificNames": [
-                                {
-                                    "scientificName": "Octoblepharum albidum Hedw., Sp. Musc. 50. (1801)"
-                                }
-                            ]
-                        }
-                    ]
+                    "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
+                    "nameString": "Octoblepharum albidum Hedw., Sp. Musc. 50. (1801)"
                 }
             ]
         },
@@ -160,41 +96,20 @@
             "internalSpecifiers": [
                 {
                     "verbatimSpecifier": "Type: Calymperes lonchophyllum Schwägr., Tab. Exhib. Calyptr. Opercul. (3). 1814 (1813).",
-                    "referencesTaxonomicUnits": [
-                        {
-                            "scientificNames": [
-                                {
-                                    "scientificName": "Calymperes lonchophyllum Schwägr., Tab. Exhib. Calyptr. Opercul. (3). 1814 (1813)."
-                                }
-                            ]
-                        }
-                    ]
+                    "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
+                    "nameString": "Calymperes lonchophyllum Schwägr., Tab. Exhib. Calyptr. Opercul. (3). 1814 (1813)."
                 },
                 {
                     "verbatimSpecifier": "Type: Syrrhopodon mauritianus Müll. Hal. ex Ångstr., Öfv. Förh. Kongl. Svenska Vet.-Akad. 33(4): 54. (1876)",
-                    "referencesTaxonomicUnits": [
-                        {
-                            "scientificNames": [
-                                {
-                                    "scientificName": "Syrrhopodon mauritianus Müll. Hal. ex Ångstr., Öfv. Förh. Kongl. Svenska Vet.-Akad. 33(4): 54. (1876)"
-                                }
-                            ]
-                        }
-                    ]
+                    "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
+                    "nameString": "Syrrhopodon mauritianus Müll. Hal. ex Ångstr., Öfv. Förh. Kongl. Svenska Vet.-Akad. 33(4): 54. (1876)"
                 }
             ],
             "externalSpecifiers": [
                 {
                     "verbatimSpecifier": "Type: Syrrhopodon croceus Mitt., J. Proc. Linn. Soc., Bot. Suppl. 1: 41. (1859)",
-                    "referencesTaxonomicUnits": [
-                        {
-                            "scientificNames": [
-                                {
-                                    "scientificName": "Syrrhopodon croceus Mitt., J. Proc. Linn. Soc., Bot. Suppl. 1: 41. (1859)"
-                                }
-                            ]
-                        }
-                    ]
+                    "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
+                    "nameString": "Syrrhopodon croceus Mitt., J. Proc. Linn. Soc., Bot. Suppl. 1: 41. (1859)"
                 }
             ]
         },
@@ -204,41 +119,20 @@
             "internalSpecifiers": [
                 {
                     "verbatimSpecifier": "Type: Syrrhopodon croceus Mitt., J. Proc. Linn. Soc., Bot. Suppl. 1: 41. (1859)",
-                    "referencesTaxonomicUnits": [
-                        {
-                            "scientificNames": [
-                                {
-                                    "scientificName": "Syrrhopodon croceus Mitt., J. Proc. Linn. Soc., Bot. Suppl. 1: 41. (1859)"
-                                }
-                            ]
-                        }
-                    ]
+                    "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
+                    "nameString": "Syrrhopodon croceus Mitt., J. Proc. Linn. Soc., Bot. Suppl. 1: 41. (1859)"
                 },
                 {
                     "verbatimSpecifier": "Type: Leucophanes octoblepharoides Brid., Bryol. Univ. 1: 763. (1826)",
-                    "referencesTaxonomicUnits": [
-                        {
-                            "scientificNames": [
-                                {
-                                    "scientificName": "Leucophanes octoblepharoides Brid., Bryol. Univ. 1: 763. (1826)"
-                                }
-                            ]
-                        }
-                    ]
+                    "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
+                    "nameString": "Leucophanes octoblepharoides Brid., Bryol. Univ. 1: 763. (1826)"
                 }
             ],
             "externalSpecifiers": [
                 {
                     "verbatimSpecifier": "Type: Syrrhopodon mauritianus Müll. Hal. ex Ångstr., Öfv. Förh. Kongl. Svenska Vet.-Akad. 33(4): 54. (1876)",
-                    "referencesTaxonomicUnits": [
-                        {
-                            "scientificNames": [
-                                {
-                                    "scientificName": "Syrrhopodon mauritianus Müll. Hal. ex Ångstr., Öfv. Förh. Kongl. Svenska Vet.-Akad. 33(4): 54. (1876)"
-                                }
-                            ]
-                        }
-                    ]
+                    "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
+                    "nameString": "Syrrhopodon mauritianus Müll. Hal. ex Ångstr., Öfv. Förh. Kongl. Svenska Vet.-Akad. 33(4): 54. (1876)"
                 }
             ]
         },
@@ -248,47 +142,20 @@
             "internalSpecifiers": [
                 {
                     "verbatimSpecifier": "Type: Syrrhopodon fasciculatum Hook. & Grev., Edinb. J. Sci. 3: 225. (1825)",
-                    "referencesTaxonomicUnits": [
-                        {
-                            "scientificNames": [
-                                {
-                                    "scientificName": "Syrrhopodon fasciculatum Hook. & Grev., Edinb. J. Sci. 3: 225. (1825)"
-                                },
-                                {
-                                    "scientificName": "Mitthyridium fasciculatum"
-                                }
-                            ]
-                        }
-                    ]
+                    "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
+                    "nameString": "Syrrhopodon fasciculatum Hook. & Grev., Edinb. J. Sci. 3: 225. (1825)"
                 },
                 {
                     "verbatimSpecifier": "Type: Codonoblepharum undulatum Dozy & Molk., Ann. Sci. Nat., Bot., III, 2: 301. (1844)",
-                    "referencesTaxonomicUnits": [
-                        {
-                            "scientificNames": [
-                                {
-                                    "scientificName": "Codonoblepharum undulatum Dozy & Molk., Ann. Sci. Nat., Bot., III, 2: 301. (1844)"
-                                },
-                                {
-                                    "scientificName": "Mitthyridium undulatum"
-                                }
-                            ]
-                        }
-                    ]
+                    "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
+                    "nameString": "Codonoblepharum undulatum Dozy & Molk., Ann. Sci. Nat., Bot., III, 2: 301. (1844)"
                 }
             ],
             "externalSpecifiers": [
                 {
                     "verbatimSpecifier": "Type: Syrrhopodon croceus Mitt., J. Proc. Linn. Soc., Bot. Suppl. 1: 41. (1859)",
-                    "referencesTaxonomicUnits": [
-                        {
-                            "scientificNames": [
-                                {
-                                    "scientificName": "Syrrhopodon croceus Mitt., J. Proc. Linn. Soc., Bot. Suppl. 1: 41. (1859)"
-                                }
-                            ]
-                        }
-                    ]
+                    "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
+                    "nameString": "Syrrhopodon croceus Mitt., J. Proc. Linn. Soc., Bot. Suppl. 1: 41. (1859)"
                 }
             ]
         },
@@ -298,44 +165,20 @@
             "internalSpecifiers": [
                 {
                     "verbatimSpecifier": "Type: Syrrhopodon croceus Mitt., J. Proc. Linn. Soc., Bot. Suppl. 1: 41. (1859)",
-                    "referencesTaxonomicUnits": [
-                        {
-                            "scientificNames": [
-                                {
-                                    "scientificName": "Weissia ciliata Hook., Musci Exot. 2: 7. 171. (1820)"
-                                },
-                                {
-                                    "scientificName": "Syrrhopodon ciliatus"
-                                }
-                            ]
-                        }
-                    ]
+                    "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
+                    "nameString": "Weissia ciliata Hook., Musci Exot. 2: 7. 171. (1820)"
                 },
                 {
                     "verbatimSpecifier": "Type: Syrrhopodon involutus Schwägr., Sp. Musc. Frond. Suppl. 2, 1(2): 117. pl. 132. (1824)",
-                    "referencesTaxonomicUnits": [
-                        {
-                            "scientificNames": [
-                                {
-                                    "scientificName": "Syrrhopodon involutus Schwägr., Sp. Musc. Frond. Suppl. 2, 1(2): 117. pl. 132. (1824)"
-                                }
-                            ]
-                        }
-                    ]
+                    "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
+                    "nameString": "Syrrhopodon involutus Schwägr., Sp. Musc. Frond. Suppl. 2, 1(2): 117. pl. 132. (1824)"
                 }
             ],
             "externalSpecifiers": [
                 {
                     "verbatimSpecifier": "Type: Syrrhopodon perarmatus Broth. & Watts, J. & Proc. Roy. Soc. New South Wales 49: 133. (1915)",
-                    "referencesTaxonomicUnits": [
-                        {
-                            "scientificNames": [
-                                {
-                                    "scientificName": "Syrrhopodon perarmatus Broth. & Watts, J. & Proc. Roy. Soc. New South Wales 49: 133. (1915)"
-                                }
-                            ]
-                        }
-                    ]
+                    "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
+                    "nameString": "Syrrhopodon perarmatus Broth. & Watts, J. & Proc. Roy. Soc. New South Wales 49: 133. (1915)"
                 }
             ]
         },
@@ -345,54 +188,26 @@
             "internalSpecifiers": [
                 {
                     "verbatimSpecifier": "Type: S. banksii Müll. Hal., Bot. Zeitung (Berlin) 16: 162. (1858)",
-                    "referencesTaxonomicUnits": [
-                        {
-                            "scientificNames": [
-                                {
-                                    "scientificName": "Syrrhopodon banksii Müll. Hal., Bot. Zeitung (Berlin) 16: 162. (1858)"
-                                }
-                            ]
-                        }
-                    ]
+                    "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
+                    "nameString": "Syrrhopodon banksii Müll. Hal., Bot. Zeitung (Berlin) 16: 162. (1858)"
                 },
                 {
                     "verbatimSpecifier": "Type: S. banksii Müll. Hal., Bot. Zeitung (Berlin) 16: 162. (1858)",
-                    "referencesTaxonomicUnits": [
-                        {
-                            "scientificNames": [
-                                {
-                                    "scientificName": "Syrrhopodon involutus Schwägr., Sp. Musc. Frond. Suppl. 2, 1(2): 117. pl. 132. (1824)"
-                                }
-                            ]
-                        }
-                    ]
+                    "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
+                    "nameString": "Syrrhopodon involutus Schwägr., Sp. Musc. Frond. Suppl. 2, 1(2): 117. pl. 132. (1824)"
                 },
                 {
                     "verbatimSpecifier": "Type: S. revolutus Dozy & Molk.",
+                    "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
                     "specifierWillNotMatch": "*Syrrhopodon revolutus* not included in phylogeny",
-                    "referencesTaxonomicUnits": [
-                        {
-                            "scientificNames": [
-                                {
-                                    "scientificName": "Syrrhopodon revolutus Dozy & Molk."
-                                }
-                            ]
-                        }
-                    ]
+                    "nameString": "Syrrhopodon revolutus Dozy & Molk."
                 }
             ],
             "externalSpecifiers": [
                 {
                     "verbatimSpecifier": "S. trachyphyllus Mont., Sylloge Gen. Sp. Cryptog. 47. (1856)",
-                    "referencesTaxonomicUnits": [
-                        {
-                            "scientificNames": [
-                                {
-                                    "scientificName": "Syrrhopodon trachyphyllus Mont., Sylloge Gen. Sp. Cryptog. 47. (1856)"
-                                }
-                            ]
-                        }
-                    ]
+                    "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
+                    "nameString": "Syrrhopodon trachyphyllus Mont., Sylloge Gen. Sp. Cryptog. 47. (1856)"
                 }
             ]
         },
@@ -402,41 +217,20 @@
             "internalSpecifiers": [
                 {
                     "verbatimSpecifier": "Type: Arthrocormus schimperi (Dozy & Molk.) Dozy & Molk. (=Mielichhoferia schimperi Dozy & Molk.), Musci Frond. Ined. Archip. Ind. 75. (1846)",
-                    "referencesTaxonomicUnits": [
-                        {
-                            "scientificNames": [
-                                {
-                                    "scientificName": "Arthrocormus schimperi (Dozy & Molk.) Dozy & Molk. (=Mielichhoferia schimperi Dozy & Molk.), Musci Frond. Ined. Archip. Ind. 75. (1846)"
-                                }
-                            ]
-                        }
-                    ]
+                    "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
+                    "nameString": "Arthrocormus schimperi (Dozy & Molk.) Dozy & Molk. (=Mielichhoferia schimperi Dozy & Molk.), Musci Frond. Ined. Archip. Ind. 75. (1846)"
                 },
                 {
                     "verbatimSpecifier": "Type: Leucophanes octoblepharoides Brid., Bryol. Univ. 1: 763. (1826)",
-                    "referencesTaxonomicUnits": [
-                        {
-                            "scientificNames": [
-                                {
-                                    "scientificName": "Leucophanes octoblepharoides Brid., Bryol. Univ. 1: 763. (1826)"
-                                }
-                            ]
-                        }
-                    ]
+                    "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
+                    "nameString": "Leucophanes octoblepharoides Brid., Bryol. Univ. 1: 763. (1826)"
                 }
             ],
             "externalSpecifiers": [
                 {
                     "verbatimSpecifier": "Type: Syrrhopodon muelleri (Dozy & Molk) Sande Lac., Bryol. Jav. 2: 224. (1870)",
-                    "referencesTaxonomicUnits": [
-                        {
-                            "scientificNames": [
-                                {
-                                    "scientificName": "Syrrhopodon muelleri (Dozy & Molk) Sande Lac., Bryol. Jav. 2: 224. (1870)"
-                                }
-                            ]
-                        }
-                    ]
+                    "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
+                    "nameString": "Syrrhopodon muelleri (Dozy & Molk) Sande Lac., Bryol. Jav. 2: 224. (1870)"
                 }
             ]
         },
@@ -446,41 +240,21 @@
             "internalSpecifiers": [
                 {
                     "verbatimSpecifier": "Type: Arthrocormus schimperi (Dozy & Molk.) Dozy & Molk. (= Mielichhoferia schimperi Dozy & Molk.), Musci Frond. Ined. Archip. Ind. 75. (1846)",
-                    "referencesTaxonomicUnits": [
-                        {
-                            "scientificNames": [
-                                {
-                                    "scientificName": "Arthrocormus schimperi (Dozy & Molk.) Dozy & Molk. (= Mielichhoferia schimperi Dozy & Molk.), Musci Frond. Ined. Archip. Ind. 75. (1846)"
-                                }
-                            ]
-                        }
-                    ]
+                    "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
+                    "nameString": "Arthrocormus schimperi (Dozy & Molk.) Dozy & Molk. (= Mielichhoferia schimperi Dozy & Molk.), Musci Frond. Ined. Archip. Ind. 75. (1846)"
                 },
                 {
                     "verbatimSpecifier": "Mishler 7/24/98 (5) Queensland, Australia (UC)",
-                    "referencesTaxonomicUnits": [
-                        {
-                            "includesSpecimens": [
-                                {
-                                    "occurrenceID": "urn:catalog:::Mishler 7/24/98 (5)"
-                                }
-                            ]
-                        }
-                    ]
+                    "@type": "http://rs.tdwg.org/dwc/terms/Occurrence",
+                    "nameString": "Arthrocormus schimperi (Dozy & Molk.) Dozy & Molk. (= Mielichhoferia schimperi Dozy & Molk.), Musci Frond. Ined. Archip. Ind. 75. (1846)",
+                    "occurrenceID": "urn:catalog:::Mishler 7/24/98 (5)"
                 }
             ],
             "externalSpecifiers": [
                 {
                     "verbatimSpecifier": "Type: Exostratum blumii (Nees ex Hampe) L. Ellis, Lindbergia 11: 22. (1985)",
-                    "referencesTaxonomicUnits": [
-                        {
-                            "scientificNames": [
-                                {
-                                    "scientificName": "Exostratum blumii (Nees ex Hampe) L. Ellis, Lindbergia 11: 22. (1985)"
-                                }
-                            ]
-                        }
-                    ]
+                    "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
+                    "nameString": "Exostratum blumii (Nees ex Hampe) L. Ellis, Lindbergia 11: 22. (1985)"
                 }
             ]
         },
@@ -490,41 +264,21 @@
             "internalSpecifiers": [
                 {
                     "verbatimSpecifier": "Type: Exostratum blumii (Nees ex Hampe) L. Ellis, Lindbergia 11: 22. (1985)",
-                    "referencesTaxonomicUnits": [
-                        {
-                            "scientificNames": [
-                                {
-                                    "scientificName": "Exostratum blumii (Nees ex Hampe) L. Ellis, Lindbergia 11: 22. (1985)"
-                                }
-                            ]
-                        }
-                    ]
+                    "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
+                    "nameString": "Exostratum blumii (Nees ex Hampe) L. Ellis, Lindbergia 11: 22. (1985)"
                 },
                 {
                     "verbatimSpecifier": "Mishler 7/24/98(3), Queensland, Australia (uc)",
-                    "referencesTaxonomicUnits": [
-                        {
-                            "includesSpecimens": [
-                                {
-                                    "occurrenceID": "urn:catalog:::Mishler 7/24/98(3)"
-                                }
-                            ]
-                        }
-                    ]
+                    "@type": "http://rs.tdwg.org/dwc/terms/Occurrence",
+                    "occurrenceID": "urn:catalog:::Mishler 7/24/98(3)",
+                    "nameString": "Exostratum blumii (Nees ex Hampe) L. Ellis, Lindbergia 11: 22. (1985)"
                 }
             ],
             "externalSpecifiers": [
                 {
                     "verbatimSpecifier": "Type: Arthrocormus schimperi (Dozy & Molk.) Dozy & Molk. (= Mielichhoferia schimperi Dozy & Molk.), Musci Frond. Ined. Archip. Ind. 75. (1846)",
-                    "referencesTaxonomicUnits": [
-                        {
-                            "scientificNames": [
-                                {
-                                    "scientificName": "Arthrocormus schimperi (Dozy & Molk.) Dozy & Molk. (= Mielichhoferia schimperi Dozy & Molk.), Musci Frond. Ined. Archip. Ind. 75. (1846)"
-                                }
-                            ]
-                        }
-                    ]
+                    "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
+                    "nameString": "Arthrocormus schimperi (Dozy & Molk.) Dozy & Molk. (= Mielichhoferia schimperi Dozy & Molk.), Musci Frond. Ined. Archip. Ind. 75. (1846)"
                 }
             ]
         },
@@ -534,44 +288,21 @@
             "internalSpecifiers": [
                 {
                     "verbatimSpecifier": "Type: Exodictyon Cardot, Rev. Bryol. Lichénol. 26: 6. (1899), excl. parte, emend Ellis in Lindbergia 11: 16 (1985)",
-                    "referencesTaxonomicUnits": [
-                        {
-                            "scientificNames": [
-                                {
-                                    "scientificName": "Exodictyon Cardot, Rev. Bryol. Lichénol. 26: 6. (1899), excl. parte, emend Ellis in Lindbergia 11: 16 (1985)"
-                                },
-                                {
-                                    "scientificName": "Exodictyon sp"
-                                }
-                            ]
-                        }
-                    ]
+                    "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
+                    "nameString": "Exodictyon Cardot, Rev. Bryol. Lichénol. 26: 6. (1899), excl. parte, emend Ellis in Lindbergia 11: 16 (1985)"
                 },
                 {
                     "verbatimSpecifier": "Wall 2527, Fiji (UC)",
-                    "referencesTaxonomicUnits": [
-                        {
-                            "includesSpecimens": [
-                                {
-                                    "occurrenceID": "urn:catalog:::Wall 2527, Fiji (uc)"
-                                }
-                            ]
-                        }
-                    ]
+                    "@type": "http://rs.tdwg.org/dwc/terms/Occurrence",
+                    "occurrenceID": "urn:catalog:::Wall 2527, Fiji (uc)",
+                    "nameString": "Exodictyon Cardot, Rev. Bryol. Lichénol. 26: 6. (1899), excl. parte, emend Ellis in Lindbergia 11: 16 (1985)"
                 }
             ],
             "externalSpecifiers": [
                 {
                     "verbatimSpecifier": "Type: Leucophanes octoblepharoides Brid., Bryol. Univ. 1: 763. (1826)",
-                    "referencesTaxonomicUnits": [
-                        {
-                            "scientificNames": [
-                                {
-                                    "scientificName": "Leucophanes octoblepharoides Brid., Bryol. Univ. 1: 763. (1826)"
-                                }
-                            ]
-                        }
-                    ]
+                    "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
+                    "nameString": "Leucophanes octoblepharoides Brid., Bryol. Univ. 1: 763. (1826)"
                 }
             ]
         },
@@ -581,41 +312,20 @@
             "internalSpecifiers": [
                 {
                     "verbatimSpecifier": "Type: Leucophanes octoblepharoides Brid., Bryol. Univ. 1: 763. (1826)",
-                    "referencesTaxonomicUnits": [
-                        {
-                            "scientificNames": [
-                                {
-                                    "scientificName": "Leucophanes octoblepharoides Brid., Bryol. Univ. 1: 763. (1826)"
-                                }
-                            ]
-                        }
-                    ]
+                    "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
+                    "nameString": "Leucophanes octoblepharoides Brid., Bryol. Univ. 1: 763. (1826)"
                 },
                 {
                     "verbatimSpecifier": "Type: Leucophanes seychellarum Besch., Ann. Sci. Nat., Bot., VI, 9: 337. (1880)",
-                    "referencesTaxonomicUnits": [
-                        {
-                            "scientificNames": [
-                                {
-                                    "scientificName": "Leucophanes seychellarum Besch., Ann. Sci. Nat., Bot., VI, 9: 337. (1880)"
-                                }
-                            ]
-                        }
-                    ]
+                    "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
+                    "nameString": "Leucophanes seychellarum Besch., Ann. Sci. Nat., Bot., VI, 9: 337. (1880)"
                 }
             ],
             "externalSpecifiers": [
                 {
                     "verbatimSpecifier": "Wall 2527, Fiji (uc)",
-                    "referencesTaxonomicUnits": [
-                        {
-                            "includesSpecimens": [
-                                {
-                                    "occurrenceID": "urn:catalog:::Wall 2527, Fiji (uc)"
-                                }
-                            ]
-                        }
-                    ]
+                    "@type": "http://rs.tdwg.org/dwc/terms/Occurrence",
+                    "occurrenceID": "urn:catalog:::Wall 2527, Fiji (uc)"
                 }
             ]
         }

--- a/public/examples/fisher_et_al_2007.json
+++ b/public/examples/fisher_et_al_2007.json
@@ -17,7 +17,8 @@
                         {
                             "@type": "http://rs.tdwg.org/dwc/terms/Occurrence",
                             "occurrenceID": "urn:catalog:::Mishler 7/24/98 (5)",
-                            "nameString": "Arthrocormus schimperi"
+                            "nameString": "Arthrocormus schimperi",
+                            "nomenclaturalCode": "http://purl.obolibrary.org/obo/NOMEN_0000109"
                         }
                     ]
                 },
@@ -72,21 +73,30 @@
             "cladeDefinition": "nomen cladi conversum, Calymperaceae Müll. Hal., Synop. Musc. Frond. 1. (1849)\n\tStem-based definition:\n\tinternal specifier: Type: Syrrhopodon gardneri (Hook.) Schwägr., Sp. Musc. Frond. Suppl. 2(1): 110, tab. 131, figs. 1-13. (1824)\n\tinternal specifier: Type: Leucophanes octoblepharoides Brid., Bryol. Univ. 1: 763. (1826)\n\texternal specifier: Type: Octoblepharum albidum Hedw., Sp. Musc. 50. (1801)\n\tImportant synapomorphies: cancellinae, central strand absent from stem\n\tIncluded terminal clades: gardneri, japonicus",
             "internalSpecifiers": [
                 {
-                    "verbatimSpecifier": "Type: Syrrhopodon gardneri (Hook.) Schwägr., Sp. Musc. Frond. Suppl. 2(1): 110, tab. 131, figs. 1–13. (1824)",
+                    "label": "Type: Syrrhopodon gardneri (Hook.) Schwägr., Sp. Musc. Frond. Suppl. 2(1): 110, tab. 131, figs. 1–13. (1824)",
                     "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
-                    "nameString": "Syrrhopodon gardneri (Hook.) Schwägr., Sp. Musc. Frond. Suppl. 2(1): 110, tab. 131, figs. 1-13 (1824)"
+                    "hasName": {
+                      "nameComplete": "Syrrhopodon gardneri",
+                      "nomenclaturalCode": "http://purl.obolibrary.org/obo/NOMEN_0000109"
+                    }
                 },
                 {
-                    "verbatimSpecifier": "Type: Leucophanes octoblepharoides Brid., Bryol. Univ. 1: 763. (1826)",
+                    "label": "Type: Leucophanes octoblepharoides Brid., Bryol. Univ. 1: 763. (1826)",
                     "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
-                    "nameString": "Leucophanes octoblepharoides Brid., Bryol. Univ. 1: 763. (1826)"
+                    "hasName": {
+                      "nameComplete": "Leucophanes octoblepharoides",
+                      "nomenclaturalCode": "http://purl.obolibrary.org/obo/NOMEN_0000109"
+                    }
                 }
             ],
             "externalSpecifiers": [
                 {
-                    "verbatimSpecifier": "Type: Octoblepharum albidum Hedw., Sp. Musc. 50. (1801)",
+                    "label": "Type: Octoblepharum albidum Hedw., Sp. Musc. 50. (1801)",
                     "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
-                    "nameString": "Octoblepharum albidum Hedw., Sp. Musc. 50. (1801)"
+                    "hasName": {
+                      "nameComplete": "Octoblepharum albidum",
+                      "nomenclaturalCode": "http://purl.obolibrary.org/obo/NOMEN_0000109"
+                    }
                 }
             ]
         },
@@ -95,19 +105,19 @@
             "cladeDefinition": "nomen cladi conversum, Calymperes lonchophyllum Schwägr., Tab. Exhib. Calyptr. Opercul. (3). 1814 (1813).\nStem-based definition:\ninternal specifier: Type: Calymperes lonchophyllum Schwägr., Tab. Exhib. Calyptr. Opercul. (3). 1814 (1813).\ninternal specifier: Type: Syrrhopodon mauritianus Müll. Hal. ex Ångstr., Öfv. Förh. Kongl. Svenska Vet.-Akad. 33(4): 54. (1876)\nexternal specifier: Type: Syrrhopodon croceus Mitt., J. Proc. Linn. Soc., Bot. Suppl. 1: 41. (1859) Important synapomorphies:\nperistome greatly reduced or absent\nsheathed or intramarginal elongate border cells\ncampanulate calyptrae\nspecialized gemmiferous leaves\nIncluded terminal clades: afzelii, dozyanum, erosum, hispidum, incompletum, lonchophyllum, mauritianus, moluccense, motleyi, palisotii, pseudopodianum, robinsonii, subintegrum, tahitense, tenerum, tuamotuense",
             "internalSpecifiers": [
                 {
-                    "verbatimSpecifier": "Type: Calymperes lonchophyllum Schwägr., Tab. Exhib. Calyptr. Opercul. (3). 1814 (1813).",
+                    "label": "Type: Calymperes lonchophyllum Schwägr., Tab. Exhib. Calyptr. Opercul. (3). 1814 (1813).",
                     "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
                     "nameString": "Calymperes lonchophyllum Schwägr., Tab. Exhib. Calyptr. Opercul. (3). 1814 (1813)."
                 },
                 {
-                    "verbatimSpecifier": "Type: Syrrhopodon mauritianus Müll. Hal. ex Ångstr., Öfv. Förh. Kongl. Svenska Vet.-Akad. 33(4): 54. (1876)",
+                    "label": "Type: Syrrhopodon mauritianus Müll. Hal. ex Ångstr., Öfv. Förh. Kongl. Svenska Vet.-Akad. 33(4): 54. (1876)",
                     "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
                     "nameString": "Syrrhopodon mauritianus Müll. Hal. ex Ångstr., Öfv. Förh. Kongl. Svenska Vet.-Akad. 33(4): 54. (1876)"
                 }
             ],
             "externalSpecifiers": [
                 {
-                    "verbatimSpecifier": "Type: Syrrhopodon croceus Mitt., J. Proc. Linn. Soc., Bot. Suppl. 1: 41. (1859)",
+                    "label": "Type: Syrrhopodon croceus Mitt., J. Proc. Linn. Soc., Bot. Suppl. 1: 41. (1859)",
                     "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
                     "nameString": "Syrrhopodon croceus Mitt., J. Proc. Linn. Soc., Bot. Suppl. 1: 41. (1859)"
                 }
@@ -118,19 +128,19 @@
             "cladeDefinition": "nomen cladi conversum, Syrrhopodon gardneri (Hook.) Schwägr., Sp. Musc. Frond. Suppl. 2(1): 110, tab. 131, figs. 1–13. (1824)\nStem-based definition:\n\ninternal specifier: Type: Syrrhopodon croceus Mitt., J. Proc. Linn. Soc., Bot. Suppl. 1: 41. (1859)\ninternal specifier: Type: Leucophanes octoblepharoides Brid., Bryol. Univ. 1: 763. (1826)\nexternal specifier: Type: Syrrhopodon mauritianus Müll. Hal. ex Ångstr., Öfv. Förh. Kongl. Svenska Vet.-Akad. 33(4): 54. (1876)\nImportant synapomorphies:\n\ncucullate calyptrae\nmarginal border of elongate hyaline cells (sterome)\nIncluded terminal clades:\n\napertus, armatus, croceus, fimbriatulus, loreus, tristichus, mahensis, muelleri, perarmatus",
             "internalSpecifiers": [
                 {
-                    "verbatimSpecifier": "Type: Syrrhopodon croceus Mitt., J. Proc. Linn. Soc., Bot. Suppl. 1: 41. (1859)",
+                    "label": "Type: Syrrhopodon croceus Mitt., J. Proc. Linn. Soc., Bot. Suppl. 1: 41. (1859)",
                     "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
                     "nameString": "Syrrhopodon croceus Mitt., J. Proc. Linn. Soc., Bot. Suppl. 1: 41. (1859)"
                 },
                 {
-                    "verbatimSpecifier": "Type: Leucophanes octoblepharoides Brid., Bryol. Univ. 1: 763. (1826)",
+                    "label": "Type: Leucophanes octoblepharoides Brid., Bryol. Univ. 1: 763. (1826)",
                     "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
                     "nameString": "Leucophanes octoblepharoides Brid., Bryol. Univ. 1: 763. (1826)"
                 }
             ],
             "externalSpecifiers": [
                 {
-                    "verbatimSpecifier": "Type: Syrrhopodon mauritianus Müll. Hal. ex Ångstr., Öfv. Förh. Kongl. Svenska Vet.-Akad. 33(4): 54. (1876)",
+                    "label": "Type: Syrrhopodon mauritianus Müll. Hal. ex Ångstr., Öfv. Förh. Kongl. Svenska Vet.-Akad. 33(4): 54. (1876)",
                     "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
                     "nameString": "Syrrhopodon mauritianus Müll. Hal. ex Ångstr., Öfv. Förh. Kongl. Svenska Vet.-Akad. 33(4): 54. (1876)"
                 }
@@ -141,19 +151,19 @@
             "cladeDefinition": "nomen cladi conversum, Mitthyridium fasciculatum (Hook. & Grev.) H. Rob., Phytologia 32: 432. (1975)\nStem-based definition:\n\ninternal specifier: Type: Syrrhopodon fasciculatum Hook. & Grev., Edinb. J. Sci. 3: 225. (1825)\ninternal specifier: Type: Codonoblepharum undulatum Dozy & Molk., Ann. Sci. Nat., Bot., III, 2: 301. (1844)\nexternal specifier: Type: Syrrhopodon croceus Mitt., J. Proc. Linn. Soc., Bot. Suppl. 1: 41. (1859)\nImportant synapomorphies:\n\ncladocarpy\nmany cancellinar columns\nvery wide sterome\ncreeping habit\nIncluded terminal clades:\n\nundulatum, jungquilianum, fasciculatum, constrictum, obtusifolium",
             "internalSpecifiers": [
                 {
-                    "verbatimSpecifier": "Type: Syrrhopodon fasciculatum Hook. & Grev., Edinb. J. Sci. 3: 225. (1825)",
+                    "label": "Type: Syrrhopodon fasciculatum Hook. & Grev., Edinb. J. Sci. 3: 225. (1825)",
                     "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
                     "nameString": "Syrrhopodon fasciculatum Hook. & Grev., Edinb. J. Sci. 3: 225. (1825)"
                 },
                 {
-                    "verbatimSpecifier": "Type: Codonoblepharum undulatum Dozy & Molk., Ann. Sci. Nat., Bot., III, 2: 301. (1844)",
+                    "label": "Type: Codonoblepharum undulatum Dozy & Molk., Ann. Sci. Nat., Bot., III, 2: 301. (1844)",
                     "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
                     "nameString": "Codonoblepharum undulatum Dozy & Molk., Ann. Sci. Nat., Bot., III, 2: 301. (1844)"
                 }
             ],
             "externalSpecifiers": [
                 {
-                    "verbatimSpecifier": "Type: Syrrhopodon croceus Mitt., J. Proc. Linn. Soc., Bot. Suppl. 1: 41. (1859)",
+                    "label": "Type: Syrrhopodon croceus Mitt., J. Proc. Linn. Soc., Bot. Suppl. 1: 41. (1859)",
                     "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
                     "nameString": "Syrrhopodon croceus Mitt., J. Proc. Linn. Soc., Bot. Suppl. 1: 41. (1859)"
                 }
@@ -164,19 +174,19 @@
             "cladeDefinition": "nomen cladi conversum, T. ciliatum (Hook.) Brid. (= Weissia ciliata Hook.), Bryol. Univ. 1: 159. (1826)\nStem-based definition:\n\ninternal specifier: Type: Weissia ciliata Hook., Musci Exot. 2: 7. 171. (1820)\ninternal specifier: Type: Syrrhopodon involutus Schwägr., Sp. Musc. Frond. Suppl. 2, 1(2): 117. pl. 132. (1824)\nexternal specifier: Type: Syrrhopodon perarmatus Broth. & Watts, J. & Proc. Roy. Soc. New South Wales 49: 133. (1915)\nIncluded terminal clades:\n\nalbovaginatus, ciliatus, leprieurii, parasiticus, prolifer, tortilis, trachyphyllus",
             "internalSpecifiers": [
                 {
-                    "verbatimSpecifier": "Type: Syrrhopodon croceus Mitt., J. Proc. Linn. Soc., Bot. Suppl. 1: 41. (1859)",
+                    "label": "Type: Syrrhopodon croceus Mitt., J. Proc. Linn. Soc., Bot. Suppl. 1: 41. (1859)",
                     "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
                     "nameString": "Weissia ciliata Hook., Musci Exot. 2: 7. 171. (1820)"
                 },
                 {
-                    "verbatimSpecifier": "Type: Syrrhopodon involutus Schwägr., Sp. Musc. Frond. Suppl. 2, 1(2): 117. pl. 132. (1824)",
+                    "label": "Type: Syrrhopodon involutus Schwägr., Sp. Musc. Frond. Suppl. 2, 1(2): 117. pl. 132. (1824)",
                     "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
                     "nameString": "Syrrhopodon involutus Schwägr., Sp. Musc. Frond. Suppl. 2, 1(2): 117. pl. 132. (1824)"
                 }
             ],
             "externalSpecifiers": [
                 {
-                    "verbatimSpecifier": "Type: Syrrhopodon perarmatus Broth. & Watts, J. & Proc. Roy. Soc. New South Wales 49: 133. (1915)",
+                    "label": "Type: Syrrhopodon perarmatus Broth. & Watts, J. & Proc. Roy. Soc. New South Wales 49: 133. (1915)",
                     "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
                     "nameString": "Syrrhopodon perarmatus Broth. & Watts, J. & Proc. Roy. Soc. New South Wales 49: 133. (1915)"
                 }
@@ -187,17 +197,17 @@
             "cladeDefinition": "nomen cladi conversum, Syrrhopodon sect. Leucophanella Besch., Bull. Soc. Bot. France 45: 60. (1898)\nStem-based definition:\n\ninternal Specifier: Type: S. banksii Müll. Hal., Bot. Zeitung (Berlin) 16: 162. (1858)\ninternal Specifier: Type: S. involutus Schwägr., Sp. Musc. Frond. Suppl. 2, 1(2): 117. pl. 132. (1824)\ninternal Specifier: Type: S. revolutus Dozy & Molk.\nexternal Specifier: S. trachyphyllus Mont., Sylloge Gen. Sp. Cryptog. 47. (1856)\nImportant synapomorphies:\n\nCancellinae comprising 60–>90% of leaf area\nIncluded terminal clades:\n\ninvolutus, banksii",
             "internalSpecifiers": [
                 {
-                    "verbatimSpecifier": "Type: S. banksii Müll. Hal., Bot. Zeitung (Berlin) 16: 162. (1858)",
+                    "label": "Type: S. banksii Müll. Hal., Bot. Zeitung (Berlin) 16: 162. (1858)",
                     "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
                     "nameString": "Syrrhopodon banksii Müll. Hal., Bot. Zeitung (Berlin) 16: 162. (1858)"
                 },
                 {
-                    "verbatimSpecifier": "Type: S. banksii Müll. Hal., Bot. Zeitung (Berlin) 16: 162. (1858)",
+                    "label": "Type: S. banksii Müll. Hal., Bot. Zeitung (Berlin) 16: 162. (1858)",
                     "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
                     "nameString": "Syrrhopodon involutus Schwägr., Sp. Musc. Frond. Suppl. 2, 1(2): 117. pl. 132. (1824)"
                 },
                 {
-                    "verbatimSpecifier": "Type: S. revolutus Dozy & Molk.",
+                    "label": "Type: S. revolutus Dozy & Molk.",
                     "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
                     "specifierWillNotMatch": "*Syrrhopodon revolutus* not included in phylogeny",
                     "nameString": "Syrrhopodon revolutus Dozy & Molk."
@@ -205,7 +215,7 @@
             ],
             "externalSpecifiers": [
                 {
-                    "verbatimSpecifier": "S. trachyphyllus Mont., Sylloge Gen. Sp. Cryptog. 47. (1856)",
+                    "label": "S. trachyphyllus Mont., Sylloge Gen. Sp. Cryptog. 47. (1856)",
                     "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
                     "nameString": "Syrrhopodon trachyphyllus Mont., Sylloge Gen. Sp. Cryptog. 47. (1856)"
                 }
@@ -216,19 +226,19 @@
             "cladeDefinition": "nomen cladi novum\n\nStem-based definition:\n\ninternal specifier: Type: Arthrocormus schimperi (Dozy & Molk.) Dozy & Molk. (=Mielichhoferia schimperi Dozy & Molk.), Musci Frond. Ined. Archip. Ind. 75. (1846)\ninternal specifier: Type: Leucophanes octoblepharoides Brid., Bryol. Univ. 1: 763. (1826)\nexternal specifier: Type: Syrrhopodon muelleri (Dozy & Molk) Sande Lac., Bryol. Jav. 2: 224. (1870)\nImportant synapomorphies:\n\nLeaf architecture / chlorocysts and hyalocysts\ncircular depressions on peristome\nIncluded clades:\n\nArthrocormus, Exodictyon, Exostratum, Leucophanes",
             "internalSpecifiers": [
                 {
-                    "verbatimSpecifier": "Type: Arthrocormus schimperi (Dozy & Molk.) Dozy & Molk. (=Mielichhoferia schimperi Dozy & Molk.), Musci Frond. Ined. Archip. Ind. 75. (1846)",
+                    "label": "Type: Arthrocormus schimperi (Dozy & Molk.) Dozy & Molk. (=Mielichhoferia schimperi Dozy & Molk.), Musci Frond. Ined. Archip. Ind. 75. (1846)",
                     "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
                     "nameString": "Arthrocormus schimperi (Dozy & Molk.) Dozy & Molk. (=Mielichhoferia schimperi Dozy & Molk.), Musci Frond. Ined. Archip. Ind. 75. (1846)"
                 },
                 {
-                    "verbatimSpecifier": "Type: Leucophanes octoblepharoides Brid., Bryol. Univ. 1: 763. (1826)",
+                    "label": "Type: Leucophanes octoblepharoides Brid., Bryol. Univ. 1: 763. (1826)",
                     "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
                     "nameString": "Leucophanes octoblepharoides Brid., Bryol. Univ. 1: 763. (1826)"
                 }
             ],
             "externalSpecifiers": [
                 {
-                    "verbatimSpecifier": "Type: Syrrhopodon muelleri (Dozy & Molk) Sande Lac., Bryol. Jav. 2: 224. (1870)",
+                    "label": "Type: Syrrhopodon muelleri (Dozy & Molk) Sande Lac., Bryol. Jav. 2: 224. (1870)",
                     "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
                     "nameString": "Syrrhopodon muelleri (Dozy & Molk) Sande Lac., Bryol. Jav. 2: 224. (1870)"
                 }
@@ -239,12 +249,12 @@
             "cladeDefinition": "nomen cladi conversum, Arthrocormus schimperi (Dozy & Molk.) Dozy & Molk. (= Mielichhoferia schimperi Dozy & Molk.), Musci Frond. Ined. Archip. Ind. 75. (1846)\nStem-based definition:\n\ninternal specifier: Type: Arthrocormus schimperi (Dozy & Molk.) Dozy & Molk. (= Mielichhoferia schimperi Dozy & Molk.), Musci Frond. Ined. Archip. Ind. 75. (1846)\ninternal specifier: Mishler 7/24/98 (5) Queensland, Australia (UC)\nexternal specifier: Type: Exostratum blumii (Nees ex Hampe) L. Ellis, Lindbergia 11: 22. (1985)\nIncluded terminal clade:\n\nschimperi",
             "internalSpecifiers": [
                 {
-                    "verbatimSpecifier": "Type: Arthrocormus schimperi (Dozy & Molk.) Dozy & Molk. (= Mielichhoferia schimperi Dozy & Molk.), Musci Frond. Ined. Archip. Ind. 75. (1846)",
+                    "label": "Type: Arthrocormus schimperi (Dozy & Molk.) Dozy & Molk. (= Mielichhoferia schimperi Dozy & Molk.), Musci Frond. Ined. Archip. Ind. 75. (1846)",
                     "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
                     "nameString": "Arthrocormus schimperi (Dozy & Molk.) Dozy & Molk. (= Mielichhoferia schimperi Dozy & Molk.), Musci Frond. Ined. Archip. Ind. 75. (1846)"
                 },
                 {
-                    "verbatimSpecifier": "Mishler 7/24/98 (5) Queensland, Australia (UC)",
+                    "label": "Mishler 7/24/98 (5) Queensland, Australia (UC)",
                     "@type": "http://rs.tdwg.org/dwc/terms/Occurrence",
                     "nameString": "Arthrocormus schimperi (Dozy & Molk.) Dozy & Molk. (= Mielichhoferia schimperi Dozy & Molk.), Musci Frond. Ined. Archip. Ind. 75. (1846)",
                     "occurrenceID": "urn:catalog:::Mishler 7/24/98 (5)"
@@ -252,7 +262,7 @@
             ],
             "externalSpecifiers": [
                 {
-                    "verbatimSpecifier": "Type: Exostratum blumii (Nees ex Hampe) L. Ellis, Lindbergia 11: 22. (1985)",
+                    "label": "Type: Exostratum blumii (Nees ex Hampe) L. Ellis, Lindbergia 11: 22. (1985)",
                     "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
                     "nameString": "Exostratum blumii (Nees ex Hampe) L. Ellis, Lindbergia 11: 22. (1985)"
                 }
@@ -263,12 +273,12 @@
             "cladeDefinition": "nomen cladi conversum, Exostratum blumii (Nees ex Hampe) L. Ellis, Lindbergia 11: 22. (1985)\nStem-based definition:\n\ninternal specifier: Type: Exostratum blumii (Nees ex Hampe) L. Ellis, Lindbergia 11: 22. (1985)\ninternal specifier: Mishler 7/24/98(3), Queensland, Australia (uc)\nexternal specifier: Type: Arthrocormus schimperi (Dozy & Molk.) Dozy & Molk. (= Mielichhoferia schimperi Dozy & Molk.), Musci Frond. Ined. Archip. Ind. 75. (1846)\nIncluded terminal clade:\n\nblumii",
             "internalSpecifiers": [
                 {
-                    "verbatimSpecifier": "Type: Exostratum blumii (Nees ex Hampe) L. Ellis, Lindbergia 11: 22. (1985)",
+                    "label": "Type: Exostratum blumii (Nees ex Hampe) L. Ellis, Lindbergia 11: 22. (1985)",
                     "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
                     "nameString": "Exostratum blumii (Nees ex Hampe) L. Ellis, Lindbergia 11: 22. (1985)"
                 },
                 {
-                    "verbatimSpecifier": "Mishler 7/24/98(3), Queensland, Australia (uc)",
+                    "label": "Mishler 7/24/98(3), Queensland, Australia (uc)",
                     "@type": "http://rs.tdwg.org/dwc/terms/Occurrence",
                     "occurrenceID": "urn:catalog:::Mishler 7/24/98(3)",
                     "nameString": "Exostratum blumii (Nees ex Hampe) L. Ellis, Lindbergia 11: 22. (1985)"
@@ -276,7 +286,7 @@
             ],
             "externalSpecifiers": [
                 {
-                    "verbatimSpecifier": "Type: Arthrocormus schimperi (Dozy & Molk.) Dozy & Molk. (= Mielichhoferia schimperi Dozy & Molk.), Musci Frond. Ined. Archip. Ind. 75. (1846)",
+                    "label": "Type: Arthrocormus schimperi (Dozy & Molk.) Dozy & Molk. (= Mielichhoferia schimperi Dozy & Molk.), Musci Frond. Ined. Archip. Ind. 75. (1846)",
                     "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
                     "nameString": "Arthrocormus schimperi (Dozy & Molk.) Dozy & Molk. (= Mielichhoferia schimperi Dozy & Molk.), Musci Frond. Ined. Archip. Ind. 75. (1846)"
                 }
@@ -287,12 +297,12 @@
             "cladeDefinition": "nomen cladi conversum, Exodictyon Cardot, Rev. Bryol. Lichénol. 26: 6. (1899), excl. parte, emend Ellis in Lindbergia 11: 16 (1985)\n\nStem-based definition:\n\ninternal specifier: Type: Exodictyon Cardot, Rev. Bryol. Lichénol. 26: 6. (1899), excl. parte, emend Ellis in Lindbergia 11: 16 (1985)\ninternal specifier: Wall 2527, Fiji (uc)\nexternal specifier: Type: Leucophanes octoblepharoides Brid., Bryol. Univ. 1: 763. (1826)\nIncluded terminal clade:\n\nincrassatum",
             "internalSpecifiers": [
                 {
-                    "verbatimSpecifier": "Type: Exodictyon Cardot, Rev. Bryol. Lichénol. 26: 6. (1899), excl. parte, emend Ellis in Lindbergia 11: 16 (1985)",
+                    "label": "Type: Exodictyon Cardot, Rev. Bryol. Lichénol. 26: 6. (1899), excl. parte, emend Ellis in Lindbergia 11: 16 (1985)",
                     "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
                     "nameString": "Exodictyon Cardot, Rev. Bryol. Lichénol. 26: 6. (1899), excl. parte, emend Ellis in Lindbergia 11: 16 (1985)"
                 },
                 {
-                    "verbatimSpecifier": "Wall 2527, Fiji (UC)",
+                    "label": "Wall 2527, Fiji (UC)",
                     "@type": "http://rs.tdwg.org/dwc/terms/Occurrence",
                     "occurrenceID": "urn:catalog:::Wall 2527, Fiji (uc)",
                     "nameString": "Exodictyon Cardot, Rev. Bryol. Lichénol. 26: 6. (1899), excl. parte, emend Ellis in Lindbergia 11: 16 (1985)"
@@ -300,7 +310,7 @@
             ],
             "externalSpecifiers": [
                 {
-                    "verbatimSpecifier": "Type: Leucophanes octoblepharoides Brid., Bryol. Univ. 1: 763. (1826)",
+                    "label": "Type: Leucophanes octoblepharoides Brid., Bryol. Univ. 1: 763. (1826)",
                     "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
                     "nameString": "Leucophanes octoblepharoides Brid., Bryol. Univ. 1: 763. (1826)"
                 }
@@ -311,19 +321,19 @@
             "cladeDefinition": "nomen cladi conversum, Leucophanes octoblepharoides Brid., Bryol. Univ. 1: 763. (1826)\n\nStem-based definition:\n\ninternal specifier: Type: Leucophanes octoblepharoides Brid., Bryol. Univ. 1: 763. (1826)\ninternal specifier: Type: Leucophanes seychellarum Besch., Ann. Sci. Nat., Bot., VI, 9: 337. (1880)\nexternal specifier: Wall 2527, Fiji (uc)\nIncluded terminal clades:\n\nconfertus, glaucum, octoblepharoides, seychellarum",
             "internalSpecifiers": [
                 {
-                    "verbatimSpecifier": "Type: Leucophanes octoblepharoides Brid., Bryol. Univ. 1: 763. (1826)",
+                    "label": "Type: Leucophanes octoblepharoides Brid., Bryol. Univ. 1: 763. (1826)",
                     "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
                     "nameString": "Leucophanes octoblepharoides Brid., Bryol. Univ. 1: 763. (1826)"
                 },
                 {
-                    "verbatimSpecifier": "Type: Leucophanes seychellarum Besch., Ann. Sci. Nat., Bot., VI, 9: 337. (1880)",
+                    "label": "Type: Leucophanes seychellarum Besch., Ann. Sci. Nat., Bot., VI, 9: 337. (1880)",
                     "@type": "http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept",
                     "nameString": "Leucophanes seychellarum Besch., Ann. Sci. Nat., Bot., VI, 9: 337. (1880)"
                 }
             ],
             "externalSpecifiers": [
                 {
-                    "verbatimSpecifier": "Wall 2527, Fiji (uc)",
+                    "label": "Wall 2527, Fiji (uc)",
                     "@type": "http://rs.tdwg.org/dwc/terms/Occurrence",
                     "occurrenceID": "urn:catalog:::Wall 2527, Fiji (uc)"
                 }

--- a/public/examples/fisher_et_al_2007.json
+++ b/public/examples/fisher_et_al_2007.json
@@ -1,5 +1,5 @@
 {
-    "@context": "http://www.phyloref.org/phyx.js/context/v0.1.0/phyx.json",
+    "@context": "http://www.phyloref.org/phyx.js/context/v0.2.0/phyx.json",
     "title": "Phylogeny of the Calymperaceae with a rank-free systematic treatment",
     "citation": "Fisher KM, Wall DP, Yip KL, Mishler BD (2007) The Bryologist 110(1):46-73.",
     "url": "https://doi.org/10.1639/0007-2745%282007%29110%5B46%3APOTCWA%5D2.0.CO%3B2",

--- a/public/examples/hillis_and_wilcox_2005.json
+++ b/public/examples/hillis_and_wilcox_2005.json
@@ -1,5 +1,5 @@
 {
-    "@context": "http://www.phyloref.org/phyx.js/context/v0.1.0/phyx.json",
+    "@context": "http://www.phyloref.org/phyx.js/context/v0.2.0/phyx.json",
     "title": "Phylogeny of the New World true frogs (Rana)",
     "citation": "Hillis DM and Wilcox TP (2005) Molecular Phylogenetics and Evolution 34(2):299-314",
     "url": "https://doi.org/10.1016/j.ympev.2004.10.007",

--- a/src/App.vue
+++ b/src/App.vue
@@ -73,6 +73,14 @@ export default {
     currentPhyx: state => state.phyx.currentPhyx,
     loadedPhyx: state => state.phyx.loadedPhyx,
   }),
+  watch: {
+    currentPhyx: function() {
+      // If currentPhyx changes, reasoning results can no longer be trusted.
+      // So reset them!
+      console.log("currentPhyx changed; resetting resolution results.");
+      this.$store.commit('setReasoningResults', undefined);
+    }
+  },
   created() {
     // If someone tries to navigate away from the window while the
     // PHYX has been modified, ask users to confirm before leaving.

--- a/src/components/TopNavigationBar.vue
+++ b/src/components/TopNavigationBar.vue
@@ -22,6 +22,7 @@
           <li class="nav-item">
             <a
               class="nav-link"
+              target="_blank"
               href="https://www.phyloref.org/"
             >
               Phyloreferencing website
@@ -30,6 +31,7 @@
           <li class="nav-item">
             <a
               class="nav-link"
+              target="_blank"
               href="https://github.com/phyloref/curation-tool"
             >
               Github repository
@@ -38,6 +40,7 @@
           <li class="nav-item">
             <a
               class="nav-link"
+              target="_blank"
               href="https://github.com/phyloref/curation-tool/issues"
             >
               Report bug

--- a/src/components/modals/AdvancedOptionsModal.vue
+++ b/src/components/modals/AdvancedOptionsModal.vue
@@ -80,7 +80,7 @@
  *  - A download button that allows the JSON-LD file to be downloaded for debugging.
  */
 
-import { PHYXWrapper } from '@phyloref/phyx';
+import { PhyxWrapper } from '@phyloref/phyx';
 import { saveAs } from 'filesaver.js-npm';
 
 export default {
@@ -114,7 +114,7 @@ export default {
     downloadAsJSONLD() {
       // Exports the PHYX file as an OWL/JSON-LD file, which can be opened in
       // Protege or converted into OWL/XML or other formats.
-      const wrapped = new PHYXWrapper(this.$store.state.phyx.currentPhyx);
+      const wrapped = new PhyxWrapper(this.$store.state.phyx.currentPhyx);
       const content = [JSON.stringify([wrapped.asJSONLD()], undefined, 4)];
 
       // Save to local hard drive.

--- a/src/components/phylogeny/Phylotree.vue
+++ b/src/components/phylogeny/Phylotree.vue
@@ -66,7 +66,7 @@ export default {
   computed: {
     reasoningResults() {
       // Included so we can watch this for changes, see `watch` below.
-      return this.$store.state.phyx.reasoningResults;
+      return this.$store.state.resolution.reasoningResults;
     },
     newickAsString() {
       // Returns the Newick string of this phylogeny.

--- a/src/components/phyloref/PhylorefView.vue
+++ b/src/components/phyloref/PhylorefView.vue
@@ -109,6 +109,7 @@
           <Specifier
             :phyloref="selectedPhyloref"
             :remote-specifier="specifier"
+            :remote-specifier-id="'internal' + index"
           />
         </div>
         <div
@@ -118,6 +119,7 @@
           <Specifier
             :phyloref="selectedPhyloref"
             :remote-specifier="specifier"
+            :remote-specifier-id="'external' + index"
           />
         </div>
       </div>

--- a/src/components/phyloref/PhylorefView.vue
+++ b/src/components/phyloref/PhylorefView.vue
@@ -99,7 +99,7 @@
         Specifiers
       </h5>
       <div class="card-body">
-        <template v-if="!selectedPhyloref.internalSpecifiers && !selectedPhyloref.externalSpecifiers">
+        <template v-if="noSpecifiers">
           <p><em>No specifiers in this phyloreference.</em></p>
         </template>
         <div
@@ -378,6 +378,14 @@ export default {
       }
       return undefined;
     },
+    noSpecifiers() {
+      // Return true if no specifiers are present.
+      return (
+        (this.selectedPhyloref.internalSpecifiers || []).length === 0 &&
+        (this.selectedPhyloref.externalSpecifiers || []).length === 0
+      );
+    },
+
     ...mapState({
       currentPhyx: state => state.phyx.currentPhyx,
       loadedPhyx: state => state.phyx.loadedPhyx,

--- a/src/components/phyloref/PhylorefView.vue
+++ b/src/components/phyloref/PhylorefView.vue
@@ -122,7 +122,11 @@
         </div>
       </div>
       <div class="card-footer">
-        <div class="btn-group" role="group" area-label="Specifier management">
+        <div
+          class="btn-group"
+          role="group"
+          area-label="Specifier management"
+        >
           <button
             class="btn btn-primary"
             href="javascript:;"
@@ -381,8 +385,8 @@ export default {
     noSpecifiers() {
       // Return true if no specifiers are present.
       return (
-        (this.selectedPhyloref.internalSpecifiers || []).length === 0 &&
-        (this.selectedPhyloref.externalSpecifiers || []).length === 0
+        (this.selectedPhyloref.internalSpecifiers || []).length === 0
+        && (this.selectedPhyloref.externalSpecifiers || []).length === 0
       );
     },
 

--- a/src/components/phyloref/PhylorefView.vue
+++ b/src/components/phyloref/PhylorefView.vue
@@ -107,6 +107,7 @@
           class="form-row input-group"
         >
           <Specifier
+            v-bind:key="'internal' + index"
             :phyloref="selectedPhyloref"
             :remote-specifier="specifier"
             :remote-specifier-id="'internal' + index"
@@ -117,6 +118,7 @@
           class="form-row input-group"
         >
           <Specifier
+            v-bind:key="'external' + index"
             :phyloref="selectedPhyloref"
             :remote-specifier="specifier"
             :remote-specifier-id="'external' + index"

--- a/src/components/phyloref/PhylorefView.vue
+++ b/src/components/phyloref/PhylorefView.vue
@@ -274,7 +274,7 @@
                 </div>
 
                 <!-- Display the matching node(s) -->
-                <template v-if="!nodesResolved">
+                <template v-if="!$store.state.resolution.reasoningResults">
                   <input
                     readonly
                     type="text"
@@ -373,14 +373,6 @@ export default {
     phylorefURI() {
       // Get the base URI of this phyloreference.
       return this.$store.getters.getBaseURIForPhyloref(this.selectedPhyloref);
-    },
-    nodesResolved() {
-      // Get a list of nodes resolved by this phyloreference.
-      if (!has(this.$store.state.phyx.reasoningResults, 'phylorefs')) return undefined;
-      if (has(this.$store.state.phyx.reasoningResults.phylorefs, this.phylorefURI)) {
-        return this.$store.state.phyx.reasoningResults.phylorefs[this.phylorefURI];
-      }
-      return undefined;
     },
     noSpecifiers() {
       // Return true if no specifiers are present.

--- a/src/components/phyloref/PhylorefView.vue
+++ b/src/components/phyloref/PhylorefView.vue
@@ -99,57 +99,37 @@
         Specifiers
       </h5>
       <div class="card-body">
+        <template v-if="!selectedPhyloref.internalSpecifiers && !selectedPhyloref.externalSpecifiers">
+          <p><em>No specifiers in this phyloreference.</em></p>
+        </template>
         <div
           v-for="(specifier, index) of selectedPhyloref.internalSpecifiers"
           class="form-row input-group"
         >
-          <div class="input-group-prepend">
-            <a
-              class="btn btn-outline-secondary"
-            >
-              Internal
-            </a>
-          </div>
-          <input
-            readonly
-            type="text"
-            class="form-control"
-            :value="getSpecifierLabel(specifier)"
-          >
-          <div class="input-group-append">
-            <button
-              class="btn btn-outline-secondary"
-              @click="$store.commit('changeDisplay', {phyloref: selectedPhyloref, specifier: specifier})"
-            >
-              Edit
-            </button>
-          </div>
+          <Specifier
+            :phyloref="selectedPhyloref"
+            :remote-specifier="specifier"
+          />
         </div>
         <div
           v-for="(specifier, index) of selectedPhyloref.externalSpecifiers"
           class="form-row input-group"
         >
-          <div class="input-group-prepend">
-            <a
-              class="btn btn-outline-secondary"
-            >
-              External
-            </a>
-          </div>
-          <input
-            readonly
-            type="text"
-            class="form-control"
-            :value="getSpecifierLabel(specifier)"
+          <Specifier
+            :phyloref="selectedPhyloref"
+            :remote-specifier="specifier"
+          />
+        </div>
+      </div>
+      <div class="card-footer">
+        <div class="btn-group" role="group" area-label="Specifier management">
+          <button
+            class="btn btn-primary"
+            href="javascript:;"
+            @click="$store.commit('addSpecifier', { phyloref: selectedPhyloref })"
           >
-          <div class="input-group-append">
-            <button
-              class="btn btn-outline-secondary"
-              @click="$store.commit('changeDisplay', {phyloref: selectedPhyloref, specifier: specifier})"
-            >
-              Edit
-            </button>
-          </div>
+            Add specifier
+          </button>
         </div>
       </div>
     </div>
@@ -360,6 +340,7 @@ import { PhylogenyWrapper, PhylorefWrapper } from '@phyloref/phyx';
 import ModifiedCard from '../cards/ModifiedCard.vue';
 import Phylotree from '../phylogeny/Phylotree.vue';
 import Citation from '../citations/Citation.vue';
+import Specifier from '../specifiers/Specifier.vue';
 
 export default {
   name: 'PhylorefView',
@@ -367,6 +348,7 @@ export default {
     ModifiedCard,
     Phylotree,
     Citation,
+    Specifier,
   },
   computed: {
     /*

--- a/src/components/phyloref/PhylorefView.vue
+++ b/src/components/phyloref/PhylorefView.vue
@@ -99,7 +99,7 @@
         Specifiers
       </h5>
       <div class="card-body">
-        <template v-if="noSpecifiers">
+        <template v-if="!selectedPhyloref.internalSpecifiers && !selectedPhyloref.externalSpecifiers">
           <p><em>No specifiers in this phyloreference.</em></p>
         </template>
         <div
@@ -122,11 +122,7 @@
         </div>
       </div>
       <div class="card-footer">
-        <div
-          class="btn-group"
-          role="group"
-          area-label="Specifier management"
-        >
+        <div class="btn-group" role="group" area-label="Specifier management">
           <button
             class="btn btn-primary"
             href="javascript:;"

--- a/src/components/phyloref/SpecifierView.vue
+++ b/src/components/phyloref/SpecifierView.vue
@@ -285,7 +285,7 @@ export default {
     selectedVerbatimSpecifier: {
       // Allow the verbatim specifier to be retrieved or changed.
       get() { return this.selectedSpecifier.verbatimSpecifier; },
-      set(verbatimSpecifier) { this.$store.commit('setSpecifierProps', { specifier: this.selectedSpecifier, verbatimSpecifier }); },
+      set(verbatimSpecifier) { this.$store.commit('setSpecifierProps', { specifier: this.selectedSpecifier, props: { verbatimSpecifier } }); },
     },
     selectedSpecifierFirstTUnit: {
       // This is a temporary hack to reconcile the new single-tunit-to-specifier model

--- a/src/components/phyx/PhyxView.vue
+++ b/src/components/phyx/PhyxView.vue
@@ -92,10 +92,10 @@ export default {
   }),
   methods: {
     hasReasoningResults(phyloref) {
-      if (!has(this.$store.state.phyx.reasoningResults, 'phylorefs')) return false;
+      if (!has(this.$store.state.resolution.reasoningResults, 'phylorefs')) return false;
 
       const phylorefURI = this.$store.getters.getBaseURIForPhyloref(phyloref);
-      return has(this.$store.state.phyx.reasoningResults.phylorefs, phylorefURI);
+      return has(this.$store.state.resolution.reasoningResults.phylorefs, phylorefURI);
     },
     getPhylorefExpectedNodeLabels(phyloref, phylogeny) {
       // Return a list of nodes that a phyloreference is expected to resolve to.

--- a/src/components/phyx/PhyxView.vue
+++ b/src/components/phyx/PhyxView.vue
@@ -81,15 +81,18 @@
  */
 import { mapState } from 'vuex';
 import { has } from 'lodash';
-import { PhylorefWrapper, PhylogenyWrapper } from '@phyloref/phyx';
+import { PhylorefWrapper, PhylogenyWrapper, TaxonNameWrapper } from '@phyloref/phyx';
 
 export default {
   name: 'PhyxView',
-  computed: mapState({
-    phyx: state => state.phyx,
-    phylorefs: state => state.phyx.currentPhyx.phylorefs,
-    phylogenies: state => state.phyx.currentPhyx.phylogenies,
-  }),
+  computed: {
+    nomenCodes: () => TaxonNameWrapper.getNomenclaturalCodes(),
+    ...mapState({
+      phyx: state => state.phyx.currentPhyx,
+      phylorefs: state => state.phyx.currentPhyx.phylorefs,
+      phylogenies: state => state.phyx.currentPhyx.phylogenies,
+    })
+  },
   methods: {
     hasReasoningResults(phyloref) {
       if (!has(this.$store.state.resolution.reasoningResults, 'phylorefs')) return false;

--- a/src/components/sidebar/Sidebar.vue
+++ b/src/components/sidebar/Sidebar.vue
@@ -258,7 +258,7 @@ export default {
       // Get the label for a particular specifier.
       // TODO: We need to include verbatimSpecifier first because of
       // https://github.com/phyloref/phyx.js/issues/14
-      return specifier.verbatimSpecifier || PhylorefWrapper.getSpecifierLabel(specifier) || 'Undefined specifier';
+      return specifier.verbatimSpecifier || new TaxonomicUnitWrapper(specifier).label || 'Undefined specifier';
     },
 
     promptAndSetDict(message, dict, key) {
@@ -365,14 +365,14 @@ export default {
 
       // Disable "Reason" buttons so they can't be reused.
       this.reasoningInProgress = true;
-      $.post('http://localhost:12345/reason', {
+      $.post('http://localhost:34214/reason', {
         // This will convert the JSON-LD file into an application/x-www-form-urlencoded
         // string (see https://api.jquery.com/jquery.ajax/#jQuery-ajax-settings under
         // processData for details). The POST data sent to the server will look like:
         //  jsonld=%7B%5B%7B%22title%22%3A...
         // which translates to:
         //  jsonld={[{"title":...
-        jsonld: JSON.stringify([new PHYXWrapper(
+        jsonld: JSON.stringify([new PhyxWrapper(
           this.$store.state.phyx.currentPhyx,
           d3.layout.newick_parser,
         )

--- a/src/components/sidebar/Sidebar.vue
+++ b/src/components/sidebar/Sidebar.vue
@@ -363,6 +363,9 @@ export default {
       // Are we already reasoning? If so, ignore.
       if (this.reasoningInProgress) return;
 
+      // Reset the existing reasoning information.
+      this.$store.commit('setReasoningResults', undefined);
+
       // Disable "Reason" buttons so they can't be reused.
       this.reasoningInProgress = true;
       $.post('http://localhost:34214/reason', {

--- a/src/components/sidebar/Sidebar.vue
+++ b/src/components/sidebar/Sidebar.vue
@@ -376,7 +376,7 @@ export default {
           this.$store.state.phyx.currentPhyx,
           d3.layout.newick_parser,
         )
-          .asJSONLD()], undefined, 4),
+          .asJSONLD()]),
       }).done((data) => {
         this.$store.commit('setReasoningResults', data);
         // console.log('Data retrieved: ', data);

--- a/src/components/sidebar/Sidebar.vue
+++ b/src/components/sidebar/Sidebar.vue
@@ -365,7 +365,7 @@ export default {
 
       // Disable "Reason" buttons so they can't be reused.
       this.reasoningInProgress = true;
-      $.post('http://localhost:34214/reason', {
+      $.post('http://localhost:12345/reason', {
         // This will convert the JSON-LD file into an application/x-www-form-urlencoded
         // string (see https://api.jquery.com/jquery.ajax/#jQuery-ajax-settings under
         // processData for details). The POST data sent to the server will look like:

--- a/src/components/sidebar/Sidebar.vue
+++ b/src/components/sidebar/Sidebar.vue
@@ -207,7 +207,7 @@ import { has } from 'lodash';
 import { mapState, mapGetters } from 'vuex';
 import { saveAs } from 'filesaver.js-npm';
 
-import { PHYXWrapper, PhylorefWrapper } from '@phyloref/phyx';
+import { PhyxWrapper, PhylorefWrapper, TaxonomicUnitWrapper } from '@phyloref/phyx';
 
 import ModifiedIcon from '../icons/ModifiedIcon.vue';
 

--- a/src/components/sidebar/Sidebar.vue
+++ b/src/components/sidebar/Sidebar.vue
@@ -256,7 +256,9 @@ export default {
   methods: {
     getSpecifierLabel(specifier) {
       // Get the label for a particular specifier.
-      return PhylorefWrapper.getSpecifierLabel(specifier);
+      // TODO: We need to include verbatimSpecifier first because of
+      // https://github.com/phyloref/phyx.js/issues/14
+      return specifier.verbatimSpecifier || PhylorefWrapper.getSpecifierLabel(specifier) || 'Undefined specifier';
     },
 
     promptAndSetDict(message, dict, key) {

--- a/src/components/specifiers/Specifier.vue
+++ b/src/components/specifiers/Specifier.vue
@@ -22,6 +22,28 @@
           <a class="dropdown-item" :class="{active: specifierClassComputed === 'Apomorphy'}"  href="javascript:;" @click="specifierClass = 'Apomorphy'">Apomorphy</a>
         </div>
       </div>
+      <div class="input-group-prepend">
+        <button
+          class="btn btn-outline-secondary dropdown-toggle"
+          type="button"
+          data-toggle="dropdown"
+          aria-haspopup="true"
+          aria-expanded="false"
+        >
+          {{ nomenclaturalCode }}
+        </button>
+        <div class="dropdown-menu">
+          <a
+            class="dropdown-item"
+            v-for="(nomenCode, nomenCodeIndex) of nomenCodes"
+            :class="{active: nomenclaturalCode === nomenCode.uri }"
+            href="javascript:;"
+            @click="nomenclaturalCode = nomenCode.uri"
+          >
+            {{ nomenCode.label }}
+          </a>
+        </div>
+      </div>
       <input
         readonly
         type="text"
@@ -120,7 +142,7 @@
             <div class="col-md-10">
               <select
                 id="nomen-code"
-                v-model="taxonNameWrapped.nomenclaturalCode"
+                v-model="nomenclaturalCode"
                 class="form-control"
               >
                 <option

--- a/src/components/specifiers/Specifier.vue
+++ b/src/components/specifiers/Specifier.vue
@@ -22,7 +22,7 @@
           <a class="dropdown-item" :class="{active: specifierClassComputed === 'Apomorphy'}"  href="javascript:;" @click="specifierClass = 'Apomorphy'">Apomorphy</a>
         </div>
       </div>
-      <div class="input-group-prepend">
+      <div class="input-group-prepend" v-if="specifierClassComputed === 'Taxon'">
         <button
           class="btn btn-outline-secondary dropdown-toggle"
           type="button"

--- a/src/components/specifiers/Specifier.vue
+++ b/src/components/specifiers/Specifier.vue
@@ -407,6 +407,18 @@ export default {
         case 'Specimen':
           result = SpecimenWrapper.fromOccurrenceID(this.enteredOccurrenceID);
           break;
+
+        case 'Apomorphy':
+          result = {
+            '@type': TaxonomicUnitWrapper.TYPE_APOMORPHY,
+          };
+          break;
+
+        case 'External reference':
+          result = {
+            '@type': TaxonomicUnitWrapper.TYPE_EXTERNAL_REFERENCE,
+          };
+          break;
       }
 
       // Make sure we have a result, even if it's just a blank object.
@@ -447,21 +459,16 @@ export default {
           case 'Taxon':
             this.enteredScientificName = label;
             this.enteredOccurrenceID = "";
-            this.enteredExternalReference = "";
             break;
 
           case 'Specimen':
             this.enteredOccurrenceID = label;
             this.enteredScientificName = "";
-            this.enteredExternalReference = "";
-            break;
-
-          case 'External reference':
-            this.enteredExternalReference = label;
-            this.enteredScientificName = "";
-            this.enteredOccurrenceID = "";
             break;
         }
+
+        // TODO: For now, we just write external references and apormorphies
+        // into the verbatim label. We should fix that!
 
         // console.log('Specifier now at', this.specifier);
         this.updateSpecifier();
@@ -539,6 +546,24 @@ export default {
       // Recalculate the entered values.
       const tunit = new TaxonomicUnitWrapper(cloneDeep(this.remoteSpecifier || {}));
       this.enteredVerbatimLabel = tunit.label;
+      if (tunit.types.length > 0) {
+        switch (tunit.types[0]) {
+          case TaxonomicUnitWrapper.TYPE_TAXON_CONCEPT:
+            this.specifierClass = 'Taxon';
+            break;
+
+          case TaxonomicUnitWrapper.TYPE_SPECIMEN:
+            this.specifierClass = 'Specimen';
+            break;
+
+          case TaxonomicUnitWrapper.TYPE_APOMORPHY:
+            this.specifierClass = 'Apomorphy';
+            break;
+
+          case TaxonomicUnitWrapper.TYPE_EXTERNAL_REFERENCE:
+            this.specifierClass = 'External reference';
+        }
+      }
 
       const taxonConceptWrapped = new TaxonConceptWrapper(tunit.taxonConcept)
       if (taxonConceptWrapped && taxonConceptWrapped.taxonName) {

--- a/src/components/specifiers/Specifier.vue
+++ b/src/components/specifiers/Specifier.vue
@@ -442,9 +442,9 @@ export default {
     },
     specifierLabel: {
       get() {
-        return this.enteredVerbatimLabel ||
-          this.taxonNameWrapped.label ||
-          this.specimenWrapped.label;
+        if (this.specimenWrapped) return this.specimenWrapped.label;
+        if (this.taxonNameWrapped) return this.taxonNameWrapped.label;
+        return this.enteredVerbatimLabel;
       },
       set(label) {
         // 1. Set the verbatim label to this.

--- a/src/components/specifiers/Specifier.vue
+++ b/src/components/specifiers/Specifier.vue
@@ -119,7 +119,7 @@
           <div class="col-md-10 input-group">
             <input
               id="verbatim-specifier"
-              v-model="specifier.verbatimSpecifier"
+              v-model="specifierLabel"
               class="form-control"
             >
           </div>
@@ -163,16 +163,16 @@
           <div class="form-group row">
             <label
               class="col-form-label col-md-2"
-              for="scientific-name"
+              for="taxon-name"
             >
-              Scientific name
+              Taxon name
             </label>
             <div class="col-md-10 input-group">
               <input
-                id="scientific-name"
-                v-model="scientificName"
+                id="taxon-name"
+                v-model="taxonNameWrapped.label"
                 class="form-control"
-                placeholder="Enter the scientific name"
+                placeholder="Enter the taxon name"
               >
             </div>
           </div>
@@ -180,16 +180,15 @@
           <div class="form-group row">
             <label
               class="col-form-label col-md-2"
-              for="binomial-name"
+              for="name-complete"
             >
-              Binomial name
+              Binomial/trinomial name
             </label>
             <div class="col-md-10 input-group">
               <input
-                id="binomial-name"
-                readonly
+                id="name-complete"
                 class="form-control"
-                :value="taxonNameWrapped.binomialName"
+                :value="taxonNameWrapped.nameComplete"
               >
             </div>
           </div>
@@ -224,6 +223,23 @@
                 readonly
                 class="form-control"
                 :value="taxonNameWrapped.specificEpithet"
+              >
+            </div>
+          </div>
+
+          <div class="form-group row" v-if="taxonNameWrapped.infraspecificEpithet">
+            <label
+              class="col-form-label col-md-2"
+              for="infraspecific-epithet"
+            >
+              Infraspecific epithet
+            </label>
+            <div class="col-md-10 input-group">
+              <input
+                id="infraspecific-epithet"
+                readonly
+                class="form-control"
+                :value="taxonNameWrapped.infraspecificEpithet"
               >
             </div>
           </div>
@@ -431,7 +447,7 @@ export default {
             break;
         }
 
-        console.log('Specifier now at', this.specifier);
+        // console.log('Specifier now at', this.specifier);
         this.updateSpecifier();
       },
     },
@@ -547,7 +563,7 @@ export default {
       // If our local specifier differs from the remoteSpecifier, update it.
       if (isEqual(result, this.remoteSpecifier)) return;
 
-      console.log('Updating specifier as ', result, ' differs from ', this.remoteSpecifier);
+      // console.log('Updating specifier as ', result, ' differs from ', this.remoteSpecifier);
       this.$store.commit('setSpecifierProps', {
         specifier: this.remoteSpecifier,
         props: result,

--- a/src/components/specifiers/Specifier.vue
+++ b/src/components/specifiers/Specifier.vue
@@ -2,84 +2,30 @@
   <div class="col-md-12">
     <div class="input-group mb-1">
       <div class="input-group-prepend">
-        <button
-          class="btn btn-outline-secondary dropdown-toggle"
-          type="button"
-          data-toggle="dropdown"
-          aria-haspopup="true"
-          aria-expanded="false"
-        >
+        <button class="btn btn-outline-secondary dropdown-toggle" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
           {{ specifierType }}
         </button>
         <div class="dropdown-menu">
-          <a
-            class="dropdown-item"
-            :class="{active: specifierType === 'Internal'}"
-            href="javascript:;"
-            @click="specifierType = 'Internal'"
-          >
-            Internal
-          </a>
-          <a
-            class="dropdown-item"
-            :class="{active: specifierType === 'External'}"
-            href="javascript:;"
-            @click="specifierType = 'External'"
-          >
-            External
-          </a>
+          <a class="dropdown-item" :class="{active: specifierType === 'Internal'}" href="javascript:;" @click="specifierType = 'Internal'">Internal</a>
+          <a class="dropdown-item" :class="{active: specifierType === 'External'}" href="javascript:;" @click="specifierType = 'External'">External</a>
         </div>
       </div>
       <div class="input-group-prepend">
-        <button
-          class="btn btn-outline-secondary dropdown-toggle"
-          type="button"
-          data-toggle="dropdown"
-          aria-haspopup="true"
-          aria-expanded="false"
-        >
+        <button class="btn btn-outline-secondary dropdown-toggle" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
           {{ specifierClassComputed }}
         </button>
         <div class="dropdown-menu">
-          <!-- TODO: remove external reference as a type and add it in as a separate property. -->
-          <a
-            class="dropdown-item"
-            :class="{active: specifierClassComputed === 'Taxon'}"
-            href="javascript:;"
-            @click="specifierClass = 'Taxon'"
-          >
-            Taxon
-          </a>
-          <a
-            class="dropdown-item"
-            :class="{active: specifierClassComputed === 'Specimen'}"
-            href="javascript:;"
-            @click="specifierClass = 'Specimen'"
-          >
-            Specimen
-          </a>
-          <a
-            class="dropdown-item"
-            :class="{active: specifierClassComputed === 'External reference'}"
-            href="javascript:;"
-            @click="specifierClass = 'External reference'"
-          >
-            External reference
-          </a>
-          <a
-            class="dropdown-item"
-            :class="{active: specifierClassComputed === 'Apomorphy'}"
-            href="javascript:;"
-            @click="specifierClass = 'Apomorphy'"
-          >
-            Apomorphy
-          </a>
+          <a class="dropdown-item" :class="{active: specifierClassComputed === 'Taxon'}" href="javascript:;" @click="specifierClass = 'Taxon'">Taxon</a>
+          <a class="dropdown-item" :class="{active: specifierClassComputed === 'Specimen'}"  href="javascript:;" @click="specifierClass = 'Specimen'">Specimen</a>
+          <a class="dropdown-item" :class="{active: specifierClassComputed === 'External reference'}"  href="javascript:;" @click="specifierClass = 'External reference'">External reference</a>
+          <a class="dropdown-item" :class="{active: specifierClassComputed === 'Apomorphy'}"  href="javascript:;" @click="specifierClass = 'Apomorphy'">Apomorphy</a>
         </div>
       </div>
       <input
-        v-model="specifierLabel"
+        readonly
         type="text"
         class="form-control"
+        :value="specifierLabel"
       >
       <div class="input-group-append">
         <button
@@ -116,12 +62,13 @@
           >
             Verbatim specifier
           </label>
-          <div class="col-md-10 input-group">
+          <div class="col-md-10">
             <input
               id="verbatim-specifier"
-              v-model="specifierLabel"
+              v-model="specifier.verbatimSpecifier"
               class="form-control"
-            >
+              @change="updateSpecifier()"
+            />
           </div>
         </div>
 
@@ -138,6 +85,7 @@
               id="specifier-class"
               v-model="specifierClassComputed"
               class="form-control"
+              @change="updateSpecifier()"
             >
               <option value="Taxon">
                 Taxon

--- a/src/components/specifiers/Specifier.vue
+++ b/src/components/specifiers/Specifier.vue
@@ -15,6 +15,7 @@
           {{ specifierClassComputed }}
         </button>
         <div class="dropdown-menu">
+          <!-- TODO: remove external reference as a type and add it in as a separate property. -->
           <a class="dropdown-item" :class="{active: specifierClassComputed === 'Taxon'}" href="javascript:;" @click="specifierClass = 'Taxon'">Taxon</a>
           <a class="dropdown-item" :class="{active: specifierClassComputed === 'Specimen'}"  href="javascript:;" @click="specifierClass = 'Specimen'">Specimen</a>
           <a class="dropdown-item" :class="{active: specifierClassComputed === 'External reference'}"  href="javascript:;" @click="specifierClass = 'External reference'">External reference</a>
@@ -473,13 +474,16 @@ export default {
         return this.taxonNameWrapped.nameComplete;
       },
       set(scname) {
-        // Don't do anything if a scname is not actually set.
-        if (!scname) return;
-
-        // TODO: Add nomen code here.
-        this.taxonNameWrapped = new TaxonNameWrapper(TaxonNameWrapper.fromVerbatimName(scname) || {});
+        Vue.set(this, 'specifier', TaxonConceptWrapper.fromLabel(scname));
         this.updateSpecifier();
-      },
+        this.enteredScientificName = scname;
+      }
+    },
+    scientificNameWrapper() {
+      return new TaxonNameWrapper(TaxonNameWrapper.fromVerbatimName(this.enteredScientificName));
+    },
+    specimenWrapper() {
+      return new SpecimenWrapper(SpecimenWrapper.createFromOccurrenceID(this.enteredOccurrenceID));
     },
     enteredOccurrenceID: {
       get() {

--- a/src/components/specifiers/Specifier.vue
+++ b/src/components/specifiers/Specifier.vue
@@ -428,7 +428,7 @@ export default {
         result.label = this.enteredVerbatimLabel;
       }
 
-      return new TaxonomicUnitWrapper(result);
+      return result;
     },
     specifierType: {
       get() {
@@ -603,7 +603,7 @@ export default {
       console.log('Updating specifier as ', result, ' differs from ', this.remoteSpecifier);
       this.$store.commit('setSpecifierProps', {
         specifier: this.remoteSpecifier,
-        props: result.asJSON,
+        props: result,
       });
     },
   },

--- a/src/components/specifiers/Specifier.vue
+++ b/src/components/specifiers/Specifier.vue
@@ -160,20 +160,36 @@
           types here
         -->
         <template v-if="specifierClassComputed === 'Taxon'">
+          <!-- Specifier class -->
           <div class="form-group row">
             <label
               class="col-form-label col-md-2"
-              for="taxon-name"
+              for="nomen-code"
             >
-              Taxon name
+              Nomenclatural code
             </label>
-            <div class="col-md-10 input-group">
-              <input
-                id="taxon-name"
-                v-model="taxonNameWrapped.label"
+            <div class="col-md-10">
+              <select
+                id="nomen-code"
+                v-model="taxonNameWrapped.nomenclaturalCode"
                 class="form-control"
-                placeholder="Enter the taxon name"
               >
+                <option :value="getNomenCodeAsURI('unknown')">
+                  Unknown
+                </option>
+                <option :value="getNomenCodeAsURI('iczn')">
+                  ICZN
+                </option>
+                <option :value="getNomenCodeAsURI('icn')">
+                  ICNafp
+                </option>
+                <option :value="getNomenCodeAsURI('ictv')">
+                  ICTV
+                </option>
+                <option :value="getNomenCodeAsURI('icnp')">
+                  ICNP
+                </option>
+              </select>
             </div>
           </div>
 
@@ -188,7 +204,7 @@
               <input
                 id="name-complete"
                 class="form-control"
-                :value="taxonNameWrapped.nameComplete"
+                v-model="taxonNameWrapped.nameComplete"
               >
             </div>
           </div>
@@ -203,9 +219,8 @@
             <div class="col-md-10 input-group">
               <input
                 id="genus"
-                readonly
                 class="form-control"
-                :value="taxonNameWrapped.genusPart"
+                v-model="taxonNameWrapped.genusPart"
               >
             </div>
           </div>
@@ -220,9 +235,8 @@
             <div class="col-md-10 input-group">
               <input
                 id="specific-epithet"
-                readonly
                 class="form-control"
-                :value="taxonNameWrapped.specificEpithet"
+                v-model="taxonNameWrapped.specificEpithet"
               >
             </div>
           </div>
@@ -237,9 +251,8 @@
             <div class="col-md-10 input-group">
               <input
                 id="infraspecific-epithet"
-                readonly
                 class="form-control"
-                :value="taxonNameWrapped.infraspecificEpithet"
+                v-model="taxonNameWrapped.infraspecificEpithet"
               >
             </div>
           </div>
@@ -544,7 +557,7 @@ export default {
       let result;
       switch (this.specifierClassComputed) {
         case 'Taxon':
-          result = TaxonConceptWrapper.fromLabel(this.enteredScientificName);
+          result = TaxonConceptWrapper.wrapTaxonName(this.taxonNameWrapped.asJSONLD);
           break;
 
         case 'Specimen':
@@ -556,8 +569,8 @@ export default {
       if(!result) result = {};
 
       // Add verbatimSpecifier.
-      if (has(this.specifier, 'verbatimSpecifier')) {
-        result.verbatimSpecifier = this.specifier.verbatimSpecifier;
+      if (has(this.specifier, 'label')) {
+        result.label = this.specifier.label;
       }
 
       // If our local specifier differs from the remoteSpecifier, update it.
@@ -569,6 +582,9 @@ export default {
         props: result,
       });
     },
+    getNomenCodeAsURI(nomenCode) {
+      return TaxonNameWrapper.getNomenCodeAsURI(nomenCode);
+    }
   },
 };
 </script>

--- a/src/components/specifiers/Specifier.vue
+++ b/src/components/specifiers/Specifier.vue
@@ -443,8 +443,9 @@ export default {
     },
     specifierLabel: {
       get() {
-        // TODO: get labels from taxonNameWrapped or specimenWrapped as appropriate.
-        return this.enteredVerbatimLabel;
+        return this.enteredVerbatimLabel ||
+          this.taxonNameWrapped.label ||
+          this.specimenWrapped.label;
       },
       set(label) {
         // 1. Set the verbatim label to this.

--- a/src/components/specifiers/Specifier.vue
+++ b/src/components/specifiers/Specifier.vue
@@ -513,12 +513,6 @@ export default {
         this.enteredScientificName = scname;
       }
     },
-    scientificNameWrapper() {
-      return new TaxonNameWrapper(TaxonNameWrapper.fromVerbatimName(this.enteredScientificName));
-    },
-    specimenWrapper() {
-      return new SpecimenWrapper(SpecimenWrapper.createFromOccurrenceID(this.enteredOccurrenceID));
-    },
     enteredOccurrenceID: {
       get() {
         return this.specimenWrapped.occurrenceID;

--- a/src/components/specifiers/Specifier.vue
+++ b/src/components/specifiers/Specifier.vue
@@ -384,8 +384,7 @@ export default {
   computed: {
     nomenCodes: () => TaxonNameWrapper.getNomenclaturalCodes(),
     nomenclaturalCodeObj() {
-      return TaxonNameWrapper.getNomenCodeAsObject(this.enteredNomenclaturalCode) ||
-        TaxonNameWrapper.getNomenCodeAsObject(TaxonNameWrapper.NAME_IN_UNKNOWN_CODE);
+      return TaxonNameWrapper.getNomenCodeAsObject(this.enteredNomenclaturalCode || TaxonNameWrapper.NAME_IN_UNKNOWN_CODE);
     },
     specifier() {
       // Check the specifierClass before we figure out how to construct the

--- a/src/components/specifiers/Specifier.vue
+++ b/src/components/specifiers/Specifier.vue
@@ -1,0 +1,197 @@
+<template>
+  <div class="col-md-12">
+    <div class="input-group mb-1">
+      <div class="input-group-prepend">
+        <button class="btn btn-outline-secondary dropdown-toggle" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+          {{ specifierType }}
+        </button>
+        <div class="dropdown-menu">
+          <a class="dropdown-item" :class="{active: specifierType === 'Internal'}" href="javascript:;" @click="specifierType = 'Internal'">Internal</a>
+          <a class="dropdown-item" :class="{active: specifierType === 'External'}" href="javascript:;" @click="specifierType = 'External'">External</a>
+        </div>
+      </div>
+      <div class="input-group-prepend">
+        <button class="btn btn-outline-secondary dropdown-toggle" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+          {{ specifierClassComputed }}
+        </button>
+        <div class="dropdown-menu">
+          <a class="dropdown-item" :class="{active: specifierClassComputed === 'Taxon'}" href="javascript:;" @click="specifierClass = 'Taxon'">Taxon</a>
+          <a class="dropdown-item" :class="{active: specifierClassComputed === 'Specimen'}"  href="javascript:;" @click="specifierClass = 'Specimen'">Specimen</a>
+          <a class="dropdown-item" :class="{active: specifierClassComputed === 'External reference'}"  href="javascript:;" @click="specifierClass = 'External reference'">External reference</a>
+          <a class="dropdown-item" :class="{active: specifierClassComputed === 'Apomorphy'}"  href="javascript:;" @click="specifierClass = 'Apomorphy'">Apomorphy</a>
+        </div>
+      </div>
+      <input
+        readonly
+        type="text"
+        class="form-control"
+        :value="specifierLabel"
+      >
+      <div class="input-group-append">
+        <button
+          class="btn btn-outline-secondary"
+          :class="{active: expand}"
+          @click="expand = !expand"
+        >
+          {{ (expand) ? 'Collapse' : 'Expand' }}
+        </button>
+      </div>
+    </div>
+    <div
+      v-if="expand"
+      class="card mt-1 mb-3"
+    >
+      <div class="card-body">
+        <h5 class="card-title">
+          Specifier details
+        </h5>
+
+        <!-- Verbatim specifier -->
+        <div class="form-group row">
+          <label
+            class="col-form-label col-md-2"
+            for="verbatim-specifier"
+          >
+            Verbatim specifier
+          </label>
+          <div class="col-md-10">
+            <input
+              id="verbatim-specifier"
+              v-model="specifier.verbatimSpecifier"
+              class="form-control"
+              @change="updateSpecifier()"
+            />
+          </div>
+        </div>
+
+        <!-- Specifier class -->
+        <div class="form-group row">
+          <label
+            class="col-form-label col-md-2"
+            for="specifier-class"
+          >
+            Specifier class
+          </label>
+          <div class="col-md-10">
+            <select
+              id="specifier-class"
+              v-model="specifierClassComputed"
+              class="form-control"
+              @change="updateSpecifier()"
+            >
+              <option value="Taxon">
+                Taxon
+              </option>
+              <option value="Specimen">
+                Specimen
+              </option>
+              <option value="External reference">
+                External reference
+              </option>
+              <option value="Apomorphy">
+                Apomorphy
+              </option>
+            </select>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+/*
+ * Displays a specifier as a textfield/expanded field.
+ * Both the textfield and the expanded fields are editable, and will overwrite each other as we go.
+ */
+
+import Vue from 'vue';
+import { PhylorefWrapper, TaxonomicUnitWrapper } from '@phyloref/phyx';
+import {
+  has, isEmpty, isEqual, cloneDeep, pickBy,
+} from 'lodash';
+
+export default {
+  name: 'Specifier',
+  props: {
+    remoteSpecifier: { /* The specifier to display and edit */
+      type: Object,
+      required: true,
+    },
+    phyloref: { /* The phyloreference containing this specifier */
+      type: Object,
+      required: true,
+    },
+  },
+  data() {
+    return {
+      specifier: cloneDeep(this.remoteSpecifier),
+      expand: false,
+      specifierClass: undefined,
+    };
+  },
+  computed: {
+    specifierType: {
+      get() {
+        return new PhylorefWrapper(this.phyloref).getSpecifierType(this.remoteSpecifier);
+      },
+      set(type) {
+        this.$store.commit(
+          'setSpecifierType',
+          {
+            phyloref: this.phyloref,
+            specifier: this.remoteSpecifier,
+            specifierType: type
+          }
+        );
+      },
+    },
+    specifierLabel() { return PhylorefWrapper.getSpecifierLabel(this.specifier); },
+    specifierClassComputed: {
+      get() {
+        // Usually, this will be straightforward. However, an input JSON object might
+        // be confused by having multiple kinds of specifier data. In that case, we
+        // will pick the type in the following order:
+        //  1. external reference (if external reference is filled in)
+        //  2. specimen (if a specimen identifier is filled in)
+        //  3. taxon (if scientificName is filled in)
+
+        if(this.specifierClass) return this.specifierClass;
+
+        // TODO: remove hack once we move to Model 2.0.
+        const tunit = new TaxonomicUnitWrapper(this.specifier.referencesTaxonomicUnits || []);
+
+        if((tunit.externalReferences || []).length > 0) return "External reference";
+        if((tunit.includesSpecimens || []).length > 0) return "Specimen";
+        if((tunit.scientificNames || []).length > 0) return "Taxon";
+
+        // If all else fails, be a taxon.
+        return "Taxon";
+      },
+      set(type) {
+        this.specifierClass = type;
+      }
+    },
+  },
+  watch: {
+  },
+  methods: {
+    updateSpecifier() {
+      // If our local specifier differs from the remoteSpecifier, update it.
+      if (isEqual(this.specifier, this.remoteSpecifier)) return;
+
+      console.log('Updating specifier as ', this.specifier, ' differs from ', this.remoteSpecifier);
+      this.$store.commit('setSpecifierProps', {
+        specifier: this.remoteSpecifier,
+        props: this.specifier,
+      });
+    },
+  },
+};
+</script>
+
+<style>
+.hand-cursor {
+  cursor: pointer;
+}
+</style>

--- a/src/components/specifiers/Specifier.vue
+++ b/src/components/specifiers/Specifier.vue
@@ -409,6 +409,9 @@ export default {
     this.recalculateEntered();
   },
   watch: {
+    phyloref() {
+      this.recalculateEntered();
+    },
     remoteSpecifier() {
       this.recalculateEntered();
     },

--- a/src/components/specifiers/Specifier.vue
+++ b/src/components/specifiers/Specifier.vue
@@ -543,14 +543,12 @@ export default {
       const taxonConceptWrapped = new TaxonConceptWrapper(tunit.taxonConcept)
       if (taxonConceptWrapped && taxonConceptWrapped.taxonName) {
         this.taxonNameWrapped = new TaxonNameWrapper(taxonConceptWrapped.taxonName);
-        this.enteredScientificName = this.taxonNameWrapped.nameComplete;
         this.enteredNomenclaturalCode = this.taxonNameWrapped.nomenclaturalCode ||
           this.$store.getters.getDefaultNomenCodeURI;
       }
 
       if (tunit.specimen) {
         this.specimenWrapped = new SpecimenWrapper(tunit.specimen);
-        this.enteredOccurrenceID = this.specimenWrapped.occurrenceID;
       }
 
       // TODO: handle external references correctly.

--- a/src/components/specifiers/Specifier.vue
+++ b/src/components/specifiers/Specifier.vue
@@ -64,7 +64,7 @@
           <div class="col-md-10 input-group">
             <input
               id="verbatim-specifier"
-              v-model:lazy="specifier.verbatimSpecifier"
+              v-model="specifier.verbatimSpecifier"
               class="form-control"
             />
           </div>
@@ -259,7 +259,7 @@
                 class="form-control"
                 id="external-reference"
                 placeholder="Enter URI of external reference here"
-                v-model:lazy="externalReference"
+                v-model="externalReference"
               />
               <div class="input-group-append">
                 <a class="btn btn-outline-secondary" target="_blank" :href="externalReference">Open in new window</a>

--- a/src/components/specifiers/Specifier.vue
+++ b/src/components/specifiers/Specifier.vue
@@ -386,6 +386,33 @@ export default {
       return TaxonNameWrapper.getNomenCodeAsObject(this.enteredNomenclaturalCode) ||
         TaxonNameWrapper.getNomenCodeAsObject(TaxonNameWrapper.NAME_IN_UNKNOWN_CODE);
     },
+    specifier() {
+      // Check the specifierClass before we figure out how to construct the
+      // specifier we might want to overwrite.
+      let result;
+      switch (this.specifierClassComputed) {
+        case 'Taxon':
+          result = TaxonConceptWrapper.fromLabel(
+            this.enteredScientificName,
+            this.enteredNomenclaturalCode
+          );
+          break;
+
+        case 'Specimen':
+          result = SpecimenWrapper.fromOccurrenceID(this.enteredOccurrenceID);
+          break;
+      }
+
+      // Make sure we have a result, even if it's just a blank object.
+      if(!result) result = {};
+
+      // Add verbatimSpecifier.
+      if (this.enteredVerbatimLabel) {
+        result.label = this.enteredVerbatimLabel;
+      }
+
+      return new TaxonomicUnitWrapper(result);
+    },
     specifierType: {
       get() {
         return new PhylorefWrapper(this.phyloref).getSpecifierType(this.remoteSpecifier);
@@ -535,29 +562,7 @@ export default {
       }
     },
     updateSpecifier() {
-      // Check the specifierClass before we figure out how to construct the
-      // specifier we might want to overwrite.
-      let result;
-      switch (this.specifierClassComputed) {
-        case 'Taxon':
-          result = TaxonConceptWrapper.fromLabel(
-            this.enteredScientificName,
-            this.enteredNomenclaturalCode
-          );
-          break;
-
-        case 'Specimen':
-          result = SpecimenWrapper.fromOccurrenceID(this.enteredOccurrenceID);
-          break;
-      }
-
-      // Make sure we have a result, even if it's just a blank object.
-      if(!result) result = {};
-
-      // Add verbatimSpecifier.
-      if (has(this.specifier, 'label')) {
-        result.label = this.specifier.label;
-      }
+      const result = this.specifier;
 
       // If our local specifier differs from the remoteSpecifier, update it.
       if (isEqual(result, this.remoteSpecifier)) return;

--- a/src/components/specifiers/Specifier.vue
+++ b/src/components/specifiers/Specifier.vue
@@ -2,31 +2,85 @@
   <div class="col-md-12">
     <div class="input-group mb-1">
       <div class="input-group-prepend">
-        <button class="btn btn-outline-secondary dropdown-toggle" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+        <button
+          class="btn btn-outline-secondary dropdown-toggle"
+          type="button"
+          data-toggle="dropdown"
+          aria-haspopup="true"
+          aria-expanded="false"
+        >
           {{ specifierType }}
         </button>
         <div class="dropdown-menu">
-          <a class="dropdown-item" :class="{active: specifierType === 'Internal'}" href="javascript:;" @click="specifierType = 'Internal'">Internal</a>
-          <a class="dropdown-item" :class="{active: specifierType === 'External'}" href="javascript:;" @click="specifierType = 'External'">External</a>
+          <a
+            class="dropdown-item"
+            :class="{active: specifierType === 'Internal'}"
+            href="javascript:;"
+            @click="specifierType = 'Internal'"
+          >
+            Internal
+          </a>
+          <a
+            class="dropdown-item"
+            :class="{active: specifierType === 'External'}"
+            href="javascript:;"
+            @click="specifierType = 'External'"
+          >
+            External
+          </a>
         </div>
       </div>
       <div class="input-group-prepend">
-        <button class="btn btn-outline-secondary dropdown-toggle" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+        <button
+          class="btn btn-outline-secondary dropdown-toggle"
+          type="button"
+          data-toggle="dropdown"
+          aria-haspopup="true"
+          aria-expanded="false"
+        >
           {{ specifierClassComputed }}
         </button>
         <div class="dropdown-menu">
           <!-- TODO: remove external reference as a type and add it in as a separate property. -->
-          <a class="dropdown-item" :class="{active: specifierClassComputed === 'Taxon'}" href="javascript:;" @click="specifierClass = 'Taxon'">Taxon</a>
-          <a class="dropdown-item" :class="{active: specifierClassComputed === 'Specimen'}"  href="javascript:;" @click="specifierClass = 'Specimen'">Specimen</a>
-          <a class="dropdown-item" :class="{active: specifierClassComputed === 'External reference'}"  href="javascript:;" @click="specifierClass = 'External reference'">External reference</a>
-          <a class="dropdown-item" :class="{active: specifierClassComputed === 'Apomorphy'}"  href="javascript:;" @click="specifierClass = 'Apomorphy'">Apomorphy</a>
+          <a
+            class="dropdown-item"
+            :class="{active: specifierClassComputed === 'Taxon'}"
+            href="javascript:;"
+            @click="specifierClass = 'Taxon'"
+          >
+            Taxon
+          </a>
+          <a
+            class="dropdown-item"
+            :class="{active: specifierClassComputed === 'Specimen'}"
+            href="javascript:;"
+            @click="specifierClass = 'Specimen'"
+          >
+            Specimen
+          </a>
+          <a
+            class="dropdown-item"
+            :class="{active: specifierClassComputed === 'External reference'}"
+            href="javascript:;"
+            @click="specifierClass = 'External reference'"
+          >
+            External reference
+          </a>
+          <a
+            class="dropdown-item"
+            :class="{active: specifierClassComputed === 'Apomorphy'}"
+            href="javascript:;"
+            @click="specifierClass = 'Apomorphy'"
+          >
+            Apomorphy
+          </a>
         </div>
       </div>
       <input
+        v-model="specifierLabel"
         type="text"
         class="form-control"
-        v-model="specifierLabel"
-      />
+      >
       <div class="input-group-append">
         <button
           class="btn btn-outline-secondary"
@@ -67,9 +121,8 @@
               id="verbatim-specifier"
               v-model="specifier.verbatimSpecifier"
               class="form-control"
-            />
+            >
           </div>
-
         </div>
 
         <!-- Specifier class -->
@@ -116,11 +169,11 @@
             </label>
             <div class="col-md-10 input-group">
               <input
-                class="form-control"
                 id="scientific-name"
-                placeholder="Enter the scientific name"
                 v-model="scientificName"
-              />
+                class="form-control"
+                placeholder="Enter the scientific name"
+              >
             </div>
           </div>
 
@@ -133,11 +186,11 @@
             </label>
             <div class="col-md-10 input-group">
               <input
+                id="binomial-name"
                 readonly
                 class="form-control"
-                id="binomial-name"
                 :value="scientificNameWrapper.binomialName"
-              />
+              >
             </div>
           </div>
 
@@ -150,11 +203,11 @@
             </label>
             <div class="col-md-10 input-group">
               <input
+                id="genus"
                 readonly
                 class="form-control"
-                id="genus"
                 :value="scientificNameWrapper.genus"
-              />
+              >
             </div>
           </div>
 
@@ -167,11 +220,11 @@
             </label>
             <div class="col-md-10 input-group">
               <input
+                id="specific-epithet"
                 readonly
                 class="form-control"
-                id="specific-epithet"
                 :value="scientificNameWrapper.specificEpithet"
-              />
+              >
             </div>
           </div>
         </template>
@@ -186,12 +239,12 @@
             </label>
             <div class="col-md-10 input-group">
               <input
+                id="occurrence-id"
+                v-model="enteredOccurrenceID"
                 readonly
                 class="form-control"
-                id="occurrence-id"
                 placeholder="Enter the occurrence ID of the specimen here"
-                v-model="enteredOccurrenceID"
-              />
+              >
             </div>
           </div>
 
@@ -204,11 +257,11 @@
             </label>
             <div class="col-md-10 input-group">
               <input
+                id="collection-code"
                 readonly
                 class="form-control"
-                id="collection-code"
                 :value="specimenWrapper.institutionCode"
-              />
+              >
             </div>
           </div>
 
@@ -221,11 +274,11 @@
             </label>
             <div class="col-md-10 input-group">
               <input
+                id="collection-code"
                 readonly
                 class="form-control"
-                id="collection-code"
                 :value="specimenWrapper.collectionCode"
-              />
+              >
             </div>
           </div>
 
@@ -238,11 +291,11 @@
             </label>
             <div class="col-md-10 input-group">
               <input
+                id="catalog-number"
                 readonly
                 class="form-control"
-                id="catalog-number"
                 :value="specimenWrapper.catalogNumber"
-              />
+              >
             </div>
           </div>
         </template>
@@ -257,21 +310,29 @@
             </label>
             <div class="col-md-10 input-group">
               <input
-                class="form-control"
                 id="external-reference"
-                placeholder="Enter URI of external reference here"
                 v-model="externalReference"
-              />
+                class="form-control"
+                placeholder="Enter URI of external reference here"
+              >
               <div class="input-group-append">
-                <a class="btn btn-outline-secondary" target="_blank" :href="externalReference">Open in new window</a>
+                <a
+                  class="btn btn-outline-secondary"
+                  target="_blank"
+                  :href="externalReference"
+                >
+                  Open in new window
+                </a>
               </div>
             </div>
           </div>
         </template>
 
         <template v-if="specifierClassComputed === 'Apomorphy'">
-          <p>Apomorphy-based specifiers are not currently supported. Please enter
-          them into the verbatim label field for now.</p>
+          <p>
+            Apomorphy-based specifiers are not currently supported. Please enter
+            them into the verbatim label field for now.
+          </p>
         </template>
       </div>
     </div>
@@ -313,9 +374,9 @@ export default {
       specifier: cloneDeep(this.remoteSpecifier),
       expand: false,
       specifierClass: undefined,
-      enteredOccurrenceID: "",
-      enteredScientificName: "",
-      enteredExternalReference: "",
+      enteredOccurrenceID: '',
+      enteredScientificName: '',
+      enteredExternalReference: '',
     };
   },
   computed: {
@@ -329,8 +390,8 @@ export default {
           {
             phyloref: this.phyloref,
             specifier: this.remoteSpecifier,
-            specifierType: type
-          }
+            specifierType: type,
+          },
         );
       },
     },
@@ -358,7 +419,7 @@ export default {
             break;
         }
 
-        console.log("Specifier now at", this.specifier);
+        console.log('Specifier now at', this.specifier);
         this.updateSpecifier();
       },
     },
@@ -371,22 +432,22 @@ export default {
         //  2. specimen (if a specimen identifier is filled in)
         //  3. taxon (if scientificName is filled in)
 
-        if(this.specifierClass) return this.specifierClass;
+        if (this.specifierClass) return this.specifierClass;
 
         // TODO: remove hack once we move to Model 2.0.
         const tunit = new TaxonomicUnitWrapper(this.specifier || {});
 
-        if((tunit.externalReferences || []).length > 0) return "External reference";
-        if((tunit.includesSpecimens || []).length > 0) return "Specimen";
-        if((tunit.scientificNames || []).length > 0) return "Taxon";
+        if ((tunit.externalReferences || []).length > 0) return 'External reference';
+        if ((tunit.includesSpecimens || []).length > 0) return 'Specimen';
+        if ((tunit.scientificNames || []).length > 0) return 'Taxon';
 
         // If all else fails, be a taxon.
-        return "Taxon";
+        return 'Taxon';
       },
       set(type) {
         this.specifierClass = type;
         this.updateSpecifier();
-      }
+      },
     },
     scientificName: {
       get() {
@@ -396,7 +457,7 @@ export default {
         Vue.set(this, 'specifier', TaxonConceptWrapper.fromLabel(scname));
         this.updateSpecifier();
         this.enteredScientificName = scname;
-      }
+      },
     },
     scientificNameWrapper() {
       return new TaxonNameWrapper(TaxonNameWrapper.fromVerbatimName(this.enteredScientificName));
@@ -404,9 +465,6 @@ export default {
     specimenWrapper() {
       return new SpecimenWrapper(SpecimenWrapper.createFromOccurrenceID(this.enteredOccurrenceID));
     },
-  },
-  mounted() {
-    this.recalculateEntered();
   },
   watch: {
     phyloref() {
@@ -419,6 +477,9 @@ export default {
       this.updateSpecifier();
     },
   },
+  mounted() {
+    this.recalculateEntered();
+  },
   methods: {
     recalculateEntered() {
       // Recalculate the entered values.
@@ -426,7 +487,7 @@ export default {
 
       if (tunit.types.includes(TaxonomicUnitWrapper.TYPE_SPECIMEN)) {
         this.enteredOccurrenceID = tunit.label;
-      } else  if (tunit.types.includes(TaxonomicUnitWrapper.TYPE_TAXON_CONCEPT)) {
+      } else if (tunit.types.includes(TaxonomicUnitWrapper.TYPE_TAXON_CONCEPT)) {
         this.enteredScientificName = tunit.label;
       } else {
         // No idea what this is! Let's assume it's a scientific name.
@@ -434,11 +495,11 @@ export default {
       }
     },
     deleteSpecifier() {
-      const confirmed = confirm("Are you sure you want to delete this specifier?");
+      const confirmed = confirm('Are you sure you want to delete this specifier?');
       if (confirmed) {
         this.$store.commit('deleteSpecifier', {
           phyloref: this.phyloref,
-          specifier: this.remoteSpecifier
+          specifier: this.remoteSpecifier,
         });
       }
     },
@@ -446,7 +507,7 @@ export default {
       // Check the specifierClass before we figure out how to construct the
       // specifier we might want to overwrite.
       let result;
-      switch(this.specifierClassComputed) {
+      switch (this.specifierClassComputed) {
         case 'Taxon':
           result = TaxonConceptWrapper.fromLabel(this.enteredScientificName);
           break;

--- a/src/components/specifiers/Specifier.vue
+++ b/src/components/specifiers/Specifier.vue
@@ -368,7 +368,13 @@ export default {
     },
   },
   data() {
-    const taxonNameWrapped = new TaxonNameWrapper(cloneDeep(this.remoteSpecifier));
+    const taxonConceptWrapped = new TaxonConceptWrapper(cloneDeep(this.remoteSpecifier));
+    let taxonNameWrapped;
+    if (taxonConceptWrapped.taxonName) {
+      taxonNameWrapped = new TaxonNameWrapper(taxonConceptWrapped.taxonName);
+    } else {
+      taxonNameWrapped = new TaxonNameWrapper({});
+    }
 
     return {
       expand: false,
@@ -570,7 +576,7 @@ export default {
       console.log('Updating specifier as ', result, ' differs from ', this.remoteSpecifier);
       this.$store.commit('setSpecifierProps', {
         specifier: this.remoteSpecifier,
-        props: result,
+        props: result.asJSON,
       });
     },
   },

--- a/src/components/specifiers/Specifier.vue
+++ b/src/components/specifiers/Specifier.vue
@@ -232,7 +232,6 @@
               <input
                 id="occurrence-id"
                 v-model="enteredOccurrenceID"
-                readonly
                 class="form-control"
                 placeholder="Enter the occurrence ID of the specimen here"
               >

--- a/src/components/specifiers/Specifier.vue
+++ b/src/components/specifiers/Specifier.vue
@@ -24,7 +24,7 @@
       <input
         type="text"
         class="form-control"
-        v-model:lazy="specifierLabel"
+        v-model="specifierLabel"
       />
       <div class="input-group-append">
         <button

--- a/src/components/specifiers/Specifier.vue
+++ b/src/components/specifiers/Specifier.vue
@@ -407,12 +407,33 @@ export default {
       return new SpecimenWrapper(SpecimenWrapper.createFromOccurrenceID(this.enteredOccurrenceID));
     },
   },
+  mounted() {
+    this.recalculateEntered();
+  },
   watch: {
+    remoteSpecifier() {
+      this.recalculateEntered();
+    },
     specifier() {
       this.updateSpecifier();
     },
   },
   methods: {
+    recalculateEntered() {
+      // Recalculate the entered values.
+      // TODO: remove hack once we move to Model 2.0.
+      const tunit = new TaxonomicUnitWrapper(this.specifier.referencesTaxonomicUnits[0] || {});
+
+      if((tunit.externalReferences || []).length > 0) {
+        this.enteredExternalReference = tunit.externalReferences[0];
+      }
+      if((tunit.includesSpecimens || []).length > 0) {
+        this.enteredOccurrenceID = new SpecimenWrapper(tunit.includesSpecimens[0]).occurrenceID;
+      }
+      if((tunit.scientificNames || []).length > 0) {
+        this.enteredScientificName = new ScientificNameWrapper(tunit.scientificNames[0]).scientificName;
+      }
+    },
     deleteSpecifier() {
       const confirmed = confirm("Are you sure you want to delete this specifier?");
       if (confirmed) {

--- a/src/components/specifiers/Specifier.vue
+++ b/src/components/specifiers/Specifier.vue
@@ -371,22 +371,14 @@ export default {
     },
   },
   data() {
-    const taxonConceptWrapped = new TaxonConceptWrapper(cloneDeep(this.remoteSpecifier));
-    let taxonNameWrapped;
-    if (taxonConceptWrapped.taxonName) {
-      taxonNameWrapped = new TaxonNameWrapper(taxonConceptWrapped.taxonName);
-    } else {
-      taxonNameWrapped = new TaxonNameWrapper({});
-    }
-
+    // All of this will be filled in by mounted().
     return {
       expand: false,
       specifierClass: undefined,
-      enteredVerbatimLabel: "",
-      specimenWrapped: new SpecimenWrapper(cloneDeep(this.remoteSpecifier)),
-      taxonNameWrapped,
-      enteredNomenclaturalCode: taxonNameWrapped.nomenclaturalCode ||
-        this.$store.getters.getDefaultNomenCodeURI,
+      specimenWrapped: undefined,
+      taxonNameWrapped: undefined,
+      enteredNomenclaturalCode: undefined,
+      enteredVerbatimLabel: undefined,
     };
   },
   computed: {

--- a/src/components/specifiers/Specifier.vue
+++ b/src/components/specifiers/Specifier.vue
@@ -45,10 +45,9 @@
         </div>
       </div>
       <input
-        readonly
         type="text"
         class="form-control"
-        :value="specifierLabel"
+        v-model="specifierLabel"
       >
       <div class="input-group-append">
         <button
@@ -88,7 +87,7 @@
           <div class="col-md-10">
             <input
               id="verbatim-specifier"
-              v-model="specifier.verbatimSpecifier"
+              v-model="enteredVerbatimLabel"
               class="form-control"
               @change="updateSpecifier()"
             />
@@ -447,22 +446,29 @@ export default {
     },
     specifierLabel: {
       get() {
-        return this.specifier.label;
+        // TODO: get labels from taxonNameWrapped or specimenWrapped as appropriate.
+        return this.enteredVerbatimLabel;
       },
       set(label) {
-        // 1. Set the verbatim specifier to this.
+        // 1. Set the verbatim label to this.
         this.enteredVerbatimLabel = label;
 
         // 2. Attempt to extract the specifier information from there.
         switch (this.specifierClass) {
           case 'Taxon':
-            this.enteredScientificName = label;
-            this.enteredOccurrenceID = "";
+            // Try to extract a taxon name from this.
+            const taxonNameWrapped = TaxonNameWrapper.fromVerbatimName(
+              label,
+              this.enteredNomenclaturalCode
+            );
+            if (taxonNameWrapped) this.taxonNameWrapped = taxonNameWrapped;
             break;
 
           case 'Specimen':
-            this.enteredOccurrenceID = label;
-            this.enteredScientificName = "";
+            const specimenWrapped = SpecimenWrapper.fromOccurrenceID(
+              label
+            );
+            if (specimenWrapped) this.specimenWrapped = specimenWrapped;
             break;
         }
 

--- a/src/components/specifiers/Specifier.vue
+++ b/src/components/specifiers/Specifier.vue
@@ -557,10 +557,14 @@ export default {
   methods: {
     recalculateEntered() {
       // Recalculate the entered values.
-      const tunit = new TaxonomicUnitWrapper(cloneDeep(this.specifier || {}));
+      const tunit = new TaxonomicUnitWrapper(cloneDeep(this.remoteSpecifier || {}));
+      this.enteredVerbatimLabel = tunit.label;
 
-      if (tunit.taxonConcept && new TaxonConceptWrapper(tunit.taxonConcept).taxonName) {
-        this.taxonNameWrapped = new TaxonConceptWrapper(tunit.taxonConcept).taxonName;
+      const taxonConceptWrapped = new TaxonConceptWrapper(tunit.taxonConcept)
+      if (taxonConceptWrapped && taxonConceptWrapped.taxonName) {
+        this.taxonNameWrapped = new TaxonNameWrapper(taxonConceptWrapped.taxonName);
+        this.enteredNomenclaturalCode = this.taxonNameWrapped.nomenclaturalCode ||
+          this.$store.getters.getDefaultNomenCodeURI;
       }
 
       if (tunit.specimen) {
@@ -571,8 +575,10 @@ export default {
       // TODO: what if all fail?
     },
     deleteSpecifier() {
+      // Update remoteSpecifier to what we've got currently entered.
       const confirmed = confirm('Are you sure you want to delete this specifier?');
       if (confirmed) {
+        console.log("Deleting specifier: ", this.phyloref, this.remoteSpecifier);
         this.$store.commit('deleteSpecifier', {
           phyloref: this.phyloref,
           specifier: this.remoteSpecifier,

--- a/src/components/specifiers/Specifier.vue
+++ b/src/components/specifiers/Specifier.vue
@@ -199,14 +199,14 @@
               class="col-form-label col-md-2"
               for="collection-code"
             >
-              Collection code
+              Institution code
             </label>
             <div class="col-md-10 input-group">
               <input
                 readonly
                 class="form-control"
                 id="collection-code"
-                :value="specimenWrapper.collectionCode"
+                :value="specimenWrapper.institutionCode"
               />
             </div>
           </div>
@@ -216,14 +216,14 @@
               class="col-form-label col-md-2"
               for="collection-code"
             >
-              Institution code
+              Collection code
             </label>
             <div class="col-md-10 input-group">
               <input
                 readonly
                 class="form-control"
                 id="collection-code"
-                :value="specimenWrapper.institutionCode"
+                :value="specimenWrapper.collectionCode"
               />
             </div>
           </div>

--- a/src/components/specifiers/Specifier.vue
+++ b/src/components/specifiers/Specifier.vue
@@ -472,32 +472,6 @@ export default {
         // TODO: For now, we just write external references and apormorphies
         // into the verbatim label. We should fix that!
 
-        // console.log('Specifier now at', this.specifier);
-        this.updateSpecifier();
-      },
-    },
-    specifierClassComputed: {
-      get() {
-        // Usually, this will be straightforward. However, an input JSON object might
-        // be confused by having multiple kinds of specifier data. In that case, we
-        // will pick the type in the following order:
-        //  1. external reference (if external reference is filled in)
-        //  2. specimen (if a specimen identifier is filled in)
-        //  3. taxon (if scientificName is filled in)
-
-        if (this.specifierClass) return this.specifierClass;
-
-        const tunit = new TaxonomicUnitWrapper(this.remoteSpecifier);
-
-        if ((tunit.externalReferences || []).length > 0) return 'External reference';
-        if ((tunit.includesSpecimens || []).length > 0) return 'Specimen';
-        if ((tunit.scientificNames || []).length > 0) return 'Taxon';
-
-        // If all else fails, be a taxon.
-        return 'Taxon';
-      },
-      set(type) {
-        this.specifierClass = type;
         this.updateSpecifier();
       },
     },

--- a/src/components/specifiers/Specifier.vue
+++ b/src/components/specifiers/Specifier.vue
@@ -123,20 +123,11 @@
                 v-model="taxonNameWrapped.nomenclaturalCode"
                 class="form-control"
               >
-                <option :value="getNomenCodeAsURI('unknown')">
-                  Unknown
-                </option>
-                <option :value="getNomenCodeAsURI('iczn')">
-                  ICZN
-                </option>
-                <option :value="getNomenCodeAsURI('icn')">
-                  ICNafp
-                </option>
-                <option :value="getNomenCodeAsURI('ictv')">
-                  ICTV
-                </option>
-                <option :value="getNomenCodeAsURI('icnp')">
-                  ICNP
+                <option
+                  v-for="(nomenCode, nomenCodeIndex) of nomenCodes"
+                  :value="nomenCode.uri"
+                >
+                  {{ nomenCode.label }}
                 </option>
               </select>
             </div>

--- a/src/components/specifiers/Specifier.vue
+++ b/src/components/specifiers/Specifier.vue
@@ -479,7 +479,8 @@ export default {
       // TODO: We should want the user if we couldn't parse this; at the moment,
       // we silently ignore this and no specifier gets written.
       get() {
-        return this.taxonNameWrapped.nameComplete;
+        if(this.taxonNameWrapped) return this.taxonNameWrapped.nameComplete;
+        return "";
       },
       set(scname) {
         // Don't do anything if a scname is not actually set.
@@ -492,7 +493,8 @@ export default {
     },
     enteredOccurrenceID: {
       get() {
-        return this.specimenWrapped.occurrenceID;
+        if(this.specimenWrapped) return this.specimenWrapped.occurrenceID;
+        return "";
       },
       set(occurID) {
         this.specimenWrapped = new SpecimenWrapper(SpecimenWrapper.fromOccurrenceID(occurID));

--- a/src/components/specifiers/Specifier.vue
+++ b/src/components/specifiers/Specifier.vue
@@ -350,7 +350,7 @@ import {
   SpecimenWrapper,
 } from '@phyloref/phyx';
 import {
-  has, isEmpty, isEqual, cloneDeep, pickBy,
+  has, isEmpty, isEqual, cloneDeep, pickBy, uniqueId,
 } from 'lodash';
 
 export default {
@@ -359,6 +359,11 @@ export default {
     remoteSpecifier: { /* The specifier to display and edit */
       type: Object,
       required: true,
+    },
+    remoteSpecifierId: { /* An ID for this specifier. We recalculate if this ID changes. */
+      type: String,
+      required: false,
+      default: () => uniqueId('remoteSpecifierId'),
     },
     phyloref: { /* The phyloreference containing this specifier */
       type: Object,
@@ -536,6 +541,9 @@ export default {
     remoteSpecifier() {
       this.recalculateEntered();
     },
+    remoteSpecifierId() {
+      this.recalculateEntered();
+    }
   },
   mounted() {
     this.recalculateEntered();

--- a/src/components/specifiers/Specifier.vue
+++ b/src/components/specifiers/Specifier.vue
@@ -30,7 +30,7 @@
           aria-haspopup="true"
           aria-expanded="false"
         >
-          {{ nomenclaturalCode }}
+          {{ nomenclaturalCodeObj.shortName }}
         </button>
         <div class="dropdown-menu">
           <a
@@ -378,36 +378,30 @@ export default {
   },
   computed: {
     nomenCodes: () => TaxonNameWrapper.getNomenclaturalCodes(),
-    nomenclaturalCodeObj() {
-      return TaxonNameWrapper.getNomenCodeAsObject(this.enteredNomenclaturalCode) ||
-        TaxonNameWrapper.getNomenCodeAsObject(TaxonNameWrapper.NAME_IN_UNKNOWN_CODE);
+    nomenclaturalCode: {
+      get() {
+        const nomenCode = this.taxonNameWrapped.nomenclaturalCode;
+        if (nomenCode) return nomenCode;
+
+        // Return the default for this file.
+        this.taxonNameWrapped.nomenclaturalCode = this.$store.getters.getDefaultNomenCodeURI;
+        // console.log(`Setting default nomenCode to ${this.taxonNameWrapped.nomenclaturalCode}.`);
+        return this.taxonNameWrapped.nomenclaturalCode;
+      },
+      set(nomenCode) {
+        // console.log(`Setting nomenclatural code to ${nomenCode}.`);
+        this.taxonNameWrapped.nomenclaturalCode = nomenCode;
+      },
     },
-    specifier() {
-      // Check the specifierClass before we figure out how to construct the
-      // specifier we might want to overwrite.
-      let result;
-      switch (this.specifierClassComputed) {
-        case 'Taxon':
-          result = TaxonConceptWrapper.fromLabel(
-            this.enteredScientificName,
-            this.enteredNomenclaturalCode
-          );
-          break;
+    nomenclaturalCodeObj() {
+      const nomenCode = this.taxonNameWrapped.nomenclaturalCode;
+      if (nomenCode) return this.taxonNameWrapped.nomenclaturalCodeAsObject;
 
-        case 'Specimen':
-          result = SpecimenWrapper.fromOccurrenceID(this.enteredOccurrenceID);
-          break;
-      }
+      // Set the default for this file.
+      this.taxonNameWrapped.nomenclaturalCode = this.$store.getters.getDefaultNomenCodeURI;
 
-      // Make sure we have a result, even if it's just a blank object.
-      if(!result) result = {};
-
-      // Add verbatimSpecifier.
-      if (this.enteredVerbatimLabel) {
-        result.label = this.enteredVerbatimLabel;
-      }
-
-      return new TaxonomicUnitWrapper(result);
+      // console.log(`Setting default nomenCode to ${this.taxonNameWrapped.nomenclaturalCode}.`);
+      return this.taxonNameWrapped.nomenclaturalCodeAsObject;
     },
     specifierType: {
       get() {
@@ -483,11 +477,16 @@ export default {
       },
     },
     enteredScientificName: {
+      // TODO: We should want the user if we couldn't parse this; at the moment,
+      // we silently ignore this and no specifier gets written.
       get() {
         return this.taxonNameWrapped.nameComplete;
       },
       set(scname) {
-        Vue.set(this, 'specifier', TaxonConceptWrapper.fromLabel(scname));
+        // Don't do anything if a scname is not actually set.
+        if (!scname) return;
+
+        this.taxonNameWrapped = new TaxonNameWrapper(TaxonNameWrapper.fromVerbatimName(scname, this.nomenclaturalCode) || {});
         this.updateSpecifier();
         this.enteredScientificName = scname;
       }
@@ -575,15 +574,12 @@ export default {
       // If our local specifier differs from the remoteSpecifier, update it.
       if (isEqual(result, this.remoteSpecifier)) return;
 
-      // console.log('Updating specifier as ', result, ' differs from ', this.remoteSpecifier);
+      console.log('Updating specifier as ', result, ' differs from ', this.remoteSpecifier);
       this.$store.commit('setSpecifierProps', {
         specifier: this.remoteSpecifier,
         props: result,
       });
     },
-    getNomenCodeAsURI(nomenCode) {
-      return TaxonNameWrapper.getNomenCodeAsURI(nomenCode);
-    }
   },
 };
 </script>

--- a/src/components/specifiers/Specifier.vue
+++ b/src/components/specifiers/Specifier.vue
@@ -36,9 +36,9 @@
           <a
             class="dropdown-item"
             v-for="(nomenCode, nomenCodeIndex) of nomenCodes"
-            :class="{active: nomenclaturalCode === nomenCode.uri }"
+            :class="{active: enteredNomenclaturalCode === nomenCode.uri }"
             href="javascript:;"
-            @click="nomenclaturalCode = nomenCode.uri"
+            @click="enteredNomenclaturalCode = nomenCode.uri"
           >
             {{ nomenCode.label }}
           </a>
@@ -142,7 +142,7 @@
             <div class="col-md-10">
               <select
                 id="nomen-code"
-                v-model="nomenclaturalCode"
+                v-model="enteredNomenclaturalCode"
                 class="form-control"
               >
                 <option
@@ -368,40 +368,23 @@ export default {
     },
   },
   data() {
+    const taxonNameWrapped = new TaxonNameWrapper(cloneDeep(this.remoteSpecifier));
+
     return {
       expand: false,
       specifierClass: undefined,
       enteredVerbatimLabel: "",
       specimenWrapped: new SpecimenWrapper(cloneDeep(this.remoteSpecifier)),
-      taxonNameWrapped: new TaxonNameWrapper(cloneDeep(this.remoteSpecifier)),
+      taxonNameWrapped,
+      enteredNomenclaturalCode: taxonNameWrapped.nomenclaturalCode ||
+        this.$store.getters.getDefaultNomenCodeURI,
     };
   },
   computed: {
     nomenCodes: () => TaxonNameWrapper.getNomenclaturalCodes(),
-    nomenclaturalCode: {
-      get() {
-        const nomenCode = this.taxonNameWrapped.nomenclaturalCode;
-        if (nomenCode) return nomenCode;
-
-        // Return the default for this file.
-        this.taxonNameWrapped.nomenclaturalCode = this.$store.getters.getDefaultNomenCodeURI;
-        // console.log(`Setting default nomenCode to ${this.taxonNameWrapped.nomenclaturalCode}.`);
-        return this.taxonNameWrapped.nomenclaturalCode;
-      },
-      set(nomenCode) {
-        // console.log(`Setting nomenclatural code to ${nomenCode}.`);
-        this.taxonNameWrapped.nomenclaturalCode = nomenCode;
-      },
-    },
     nomenclaturalCodeObj() {
-      const nomenCode = this.taxonNameWrapped.nomenclaturalCode;
-      if (nomenCode) return this.taxonNameWrapped.nomenclaturalCodeAsObject;
-
-      // Set the default for this file.
-      this.taxonNameWrapped.nomenclaturalCode = this.$store.getters.getDefaultNomenCodeURI;
-
-      // console.log(`Setting default nomenCode to ${this.taxonNameWrapped.nomenclaturalCode}.`);
-      return this.taxonNameWrapped.nomenclaturalCodeAsObject;
+      return TaxonNameWrapper.getNomenCodeAsObject(this.enteredNomenclaturalCode) ||
+        TaxonNameWrapper.getNomenCodeAsObject(TaxonNameWrapper.NAME_IN_UNKNOWN_CODE);
     },
     specifierType: {
       get() {
@@ -486,7 +469,7 @@ export default {
         // Don't do anything if a scname is not actually set.
         if (!scname) return;
 
-        this.taxonNameWrapped = new TaxonNameWrapper(TaxonNameWrapper.fromVerbatimName(scname, this.nomenclaturalCode) || {});
+        this.taxonNameWrapped = new TaxonNameWrapper(TaxonNameWrapper.fromVerbatimName(scname, this.enteredNomenclaturalCode) || {});
         this.updateSpecifier();
         this.enteredScientificName = scname;
       }
@@ -527,12 +510,14 @@ export default {
       const taxonConceptWrapped = new TaxonConceptWrapper(tunit.taxonConcept)
       if (taxonConceptWrapped && taxonConceptWrapped.taxonName) {
         this.taxonNameWrapped = new TaxonNameWrapper(taxonConceptWrapped.taxonName);
+        this.enteredScientificName = this.taxonNameWrapped.nameComplete;
         this.enteredNomenclaturalCode = this.taxonNameWrapped.nomenclaturalCode ||
           this.$store.getters.getDefaultNomenCodeURI;
       }
 
       if (tunit.specimen) {
         this.specimenWrapped = new SpecimenWrapper(tunit.specimen);
+        this.enteredOccurrenceID = this.specimenWrapped.occurrenceID;
       }
 
       // TODO: handle external references correctly.
@@ -555,7 +540,10 @@ export default {
       let result;
       switch (this.specifierClassComputed) {
         case 'Taxon':
-          result = TaxonConceptWrapper.wrapTaxonName(this.taxonNameWrapped.asJSONLD);
+          result = TaxonConceptWrapper.fromLabel(
+            this.enteredScientificName,
+            this.enteredNomenclaturalCode
+          );
           break;
 
         case 'Specimen':

--- a/src/store/modules/phyloref.js
+++ b/src/store/modules/phyloref.js
@@ -3,7 +3,7 @@
  */
 
 import Vue from 'vue';
-import { has, keys } from 'lodash';
+import { has, keys, cloneDeep } from 'lodash';
 
 export default {
   mutations: {
@@ -82,7 +82,7 @@ export default {
       keys(specifier).forEach(key => Vue.delete(specifier, key));
 
       // Add all new keys from the payload.
-      keys(props).forEach(key => Vue.set(specifier, key, props[key]));
+      keys(props).forEach(key => Vue.set(specifier, key, cloneDeep(props[key])));
     },
 
     setSpecifierType(state, payload) {

--- a/src/store/modules/phyloref.js
+++ b/src/store/modules/phyloref.js
@@ -35,8 +35,7 @@ export default {
         Vue.set(payload.phyloref, 'externalSpecifiers', []);
       }
 
-      // TODO: remove when the model changes.
-      payload.phyloref.externalSpecifiers.push({ referencesTaxonomicUnits: [{}] });
+      payload.phyloref.externalSpecifiers.push({});
     },
 
     deleteSpecifier(state, payload) {

--- a/src/store/modules/phyloref.js
+++ b/src/store/modules/phyloref.js
@@ -82,7 +82,7 @@ export default {
       keys(specifier).forEach(key => Vue.delete(specifier, key));
 
       // Add all new keys from the payload.
-      keys(props).forEach(key => Vue.set(specifier, key, payload[key]));
+      keys(props).forEach(key => Vue.set(specifier, key, props[key]));
     },
 
     setSpecifierType(state, payload) {

--- a/src/store/modules/phyloref.js
+++ b/src/store/modules/phyloref.js
@@ -3,7 +3,7 @@
  */
 
 import Vue from 'vue';
-import { has } from 'lodash';
+import { has, keys } from 'lodash';
 
 export default {
   mutations: {
@@ -70,9 +70,19 @@ export default {
       if (!has(payload, 'specifier')) {
         throw new Error('setSpecifierProps needs a specifier to modify using the "specifier" argument');
       }
-      if (has(payload, 'verbatimSpecifier')) {
-        Vue.set(payload.specifier, 'verbatimSpecifier', payload.verbatimSpecifier);
+
+      if (!has(payload, 'props')) {
+        throw new Error('setSpecifierProps needs properties to set this specifier to using the "props" argument');
       }
+
+      const specifier = payload.specifier;
+      const props = payload.props;
+
+      // Delete all existing keys in this specifier.
+      keys(specifier).forEach(key => Vue.delete(specifier, key));
+
+      // Add all new keys from the payload.
+      keys(props).forEach(key => Vue.set(specifier, key, payload[key]));
     },
 
     setSpecifierType(state, payload) {
@@ -105,13 +115,13 @@ export default {
       }
 
       // Reinsert it into the correct place.
-      if (payload.specifierType === 'internal') {
+      if (payload.specifierType === 'Internal') {
         if (has(payload.phyloref, 'internalSpecifiers')) {
           payload.phyloref.internalSpecifiers.push(payload.specifier);
         } else {
           Vue.set(payload.phyloref, 'internalSpecifiers', [payload.specifier]);
         }
-      } else if (payload.specifierType === 'external') {
+      } else if (payload.specifierType === 'External') {
         if (has(payload.phyloref, 'externalSpecifiers')) {
           payload.phyloref.externalSpecifiers.push(payload.specifier);
         } else {

--- a/src/store/modules/phyloref.js
+++ b/src/store/modules/phyloref.js
@@ -3,6 +3,7 @@
  */
 
 import Vue from 'vue';
+import { PhylorefWrapper } from '@phyloref/phyx';
 import { has, keys, cloneDeep } from 'lodash';
 
 export default {
@@ -48,19 +49,7 @@ export default {
         throw new Error('deleteSpecifier needs a specifier to delete using the "specifier" argument');
       }
 
-      if (has(payload.phyloref, 'internalSpecifiers') && payload.phyloref.internalSpecifiers.includes(payload.specifier)) {
-        payload.phyloref.internalSpecifiers.splice(
-          payload.phyloref.internalSpecifiers.indexOf(payload.specifier),
-          1,
-        );
-      }
-
-      if (has(payload.phyloref, 'externalSpecifiers') && payload.phyloref.externalSpecifiers.includes(payload.specifier)) {
-        payload.phyloref.externalSpecifiers.splice(
-          payload.phyloref.externalSpecifiers.indexOf(payload.specifier),
-          1,
-        );
-      }
+      new PhylorefWrapper(payload.phyloref).deleteSpecifier(payload.specifier);
     },
 
     setSpecifierProps(state, payload) {

--- a/src/store/modules/phyx.js
+++ b/src/store/modules/phyx.js
@@ -28,10 +28,6 @@ export default {
       // update the loaded Phyx file, so these changes are treated as changes
       // made since the file was last loaded.
       Vue.set(state, 'currentPhyx', phyx);
-
-      // When the current phyx is changed, reasoning results are invalidated,
-      // so let's clear those.
-      Vue.set(state, 'reasoningResults', undefined);
     },
     setLoadedPhyx(state, phyx) {
       // Replace the current loaded Phyx file using an object. This also updates

--- a/src/store/modules/phyx.js
+++ b/src/store/modules/phyx.js
@@ -6,6 +6,8 @@
  */
 
 import Vue from 'vue';
+import { has } from 'lodash';
+import { TaxonNameWrapper } from '@phyloref/phyx';
 
 export default {
   state: {
@@ -51,6 +53,35 @@ export default {
     createEmptyPhylogeny(state) {
       // Create a new, empty phylogeny.
       state.currentPhyx.phylogenies.push({});
+    },
+    deletePhyloref(state, payload) {
+      // Delete a phyloreference.
+      if (!has(payload, 'phyloref')) {
+        throw new Error('deletePhyloref needs a phyloref to modify using the "phyloref" argument');
+      }
+
+      const indexOf = (state.currentPhyx.phylorefs || []).indexOf(payload.phyloref);
+      if (indexOf < 0) throw new Error(`Could not delete unknown phyloref: ${JSON.stringify(payload.phyloref)}`);
+
+      state.currentPhyx.phylorefs.splice(indexOf, 1);
+    },
+    deletePhylogeny(state, payload) {
+      // Delete a phylogeny.
+      if (!has(payload, 'phylogeny')) {
+        throw new Error('deletePhylogeny needs a phylogeny to modify using the "phylogeny" argument');
+      }
+
+      const indexOf = (state.currentPhyx.phylogenies || []).indexOf(payload.phylogeny);
+      if (indexOf < 0) throw new Error(`Could not delete unknown phylogeny: ${JSON.stringify(payload.phylogeny)}`);
+
+      state.currentPhyx.phylogenies.splice(indexOf, 1);
+    },
+    setDefaultNomenCodeURI(state, payload) {
+      if (!has(payload, 'defaultNomenclaturalCodeURI')) {
+        throw new Error('No default nomenclatural code URI provided to setDefaultNomenCodeURI');
+      }
+
+      Vue.set(state.currentPhyx, 'defaultNomenclaturalCodeURI', payload.defaultNomenclaturalCodeURI);
     },
   },
 };


### PR DESCRIPTION
This PR updates the version of phyx.js being used by the Curation Tool so it produces model 2.0 ontologies that can be executed on JPhyloRef using Elk as per phyloref/jphyloref#47. It updates all three example files so they use the new Phyx format (v0.2.0).

Since mode 2.0 ontologies have a very different conception of specifiers, this PR updates how specifiers are displayed and how they may be edited as a separate Vue component (#148). This closes #17, closes #30, closes #11 and closes #95.

I'd previously planned to separate out the implementation of nomenclatural codes into a separate PR, but it didn't make sense to leave an incomplete implementation in here, so that's a part of this as well now. Closes #143.

I also noticed a minor bug in where reasoning in reset, which is also fixed here.

This should be merged after #151 has been merged.