### PR TITLE
Fix modified icons

### DIFF
--- a/src/components/cards/ModifiedCard.vue
+++ b/src/components/cards/ModifiedCard.vue
@@ -3,10 +3,7 @@
     v-if="dataChanged"
     class="card mb-2 border-dark"
   >
-    <div class="card-header bg-warning">
-      Warning!
-    </div>
-    <div class="card-body">
+    <div class="card-body bg-warning">
       {{ message }}
     </div>
   </div>

--- a/src/components/phylogeny/PhylogenyView.vue
+++ b/src/components/phylogeny/PhylogenyView.vue
@@ -2,7 +2,7 @@
   <div>
     <!-- Add a warning if this phylogeny has changed -->
     <ModifiedCard
-      message="This phylogeny has been modified since being loaded. Use 'Save as JSON' to save your changes."
+      message="This phylogeny has been modified since being loaded. Use 'Save' to save your changes."
       :compare="selectedPhylogeny"
       :compare-to="loadedPhyx.phylogenies[currentPhyx.phylogenies.indexOf(selectedPhylogeny)]"
     />

--- a/src/components/phyloref/PhylorefView.vue
+++ b/src/components/phyloref/PhylorefView.vue
@@ -2,7 +2,7 @@
   <div>
     <!-- Add a warning if this phyloreference has changed -->
     <ModifiedCard
-      message="This phyloreference has been modified since being loaded! Use 'Save as JSON' to save your changes."
+      message="This phyloreference has been modified since being loaded! Use 'Save' to save your changes."
       :compare="selectedPhyloref"
       :compare-to="currentPhyx.phylorefs[currentPhyx.phylorefs.indexOf(selectedPhyloref)]"
     />

--- a/src/components/phyloref/PhylorefView.vue
+++ b/src/components/phyloref/PhylorefView.vue
@@ -4,7 +4,7 @@
     <ModifiedCard
       message="This phyloreference has been modified since being loaded! Use 'Save' to save your changes."
       :compare="selectedPhyloref"
-      :compare-to="currentPhyx.phylorefs[currentPhyx.phylorefs.indexOf(selectedPhyloref)]"
+      :compare-to="loadedPhyx.phylorefs[currentPhyx.phylorefs.indexOf(selectedPhyloref)]"
     />
 
     <!-- Phyloreference information -->

--- a/src/components/sidebar/Sidebar.vue
+++ b/src/components/sidebar/Sidebar.vue
@@ -56,7 +56,7 @@
         >
           Save
           <ModifiedIcon
-            message="This Phyx file has been modified since it was loaded! Use 'Save' to save your changes."
+            message="This Phyx file has been modified after it was loaded! Use 'Save' to save your changes."
             :compare="currentPhyx"
             :compare-to="loadedPhyx"
           />
@@ -127,7 +127,7 @@
 
             <!-- Add a warning if this phyloreference has changed -->
             <ModifiedIcon
-              message="This phyloreference has been modified since being loaded! Use 'Save' to save your changes."
+              message="This phyloreference has been modified after it was loaded! Use 'Save' to save your changes."
               :compare="phyloref"
               :compare-to="loadedPhyx.phylorefs[phylorefIndex]"
             />
@@ -195,7 +195,7 @@
 
           <!-- Add a warning if this phylogeny has changed -->
           <ModifiedIcon
-            message="This phylogeny has been modified since being loaded! Use 'Save' to save your changes."
+            message="This phylogeny has been modified after it was loaded! Use 'Save' to save your changes."
             :compare="phylogeny"
             :compare-to="loadedPhyx.phylogenies[phylogenyIndex]"
           />

--- a/src/components/sidebar/Sidebar.vue
+++ b/src/components/sidebar/Sidebar.vue
@@ -285,7 +285,13 @@ export default {
 
     loadPhyxFromURL(url) {
       // Change the current PHYX to that in the provided URL.
-      // Will ask the user to confirm before replacing it.
+
+      // Is the user sure that they want to do this?
+      if(this.$store.getters.loadedPhyxChanged) {
+        if(!confirm('The current Phyx file has been modified! Are you sure you want to discard these changes by loading another file?')) {
+          return;
+        }
+      }
 
       $.getJSON(url)
         .done((data) => {
@@ -331,6 +337,13 @@ export default {
       if (!$fileInput.prop('files')[0]) {
         alert('Please select a file before attempting to load it.');
         return;
+      }
+
+      // Is the user sure that they want to do this?
+      if(this.$store.getters.loadedPhyxChanged) {
+        if(!confirm('The current Phyx file has been modified! Are you sure you want to discard these changes by loading another file?')) {
+          return;
+        }
       }
 
       const [file] = $fileInput.prop('files');

--- a/src/components/sidebar/Sidebar.vue
+++ b/src/components/sidebar/Sidebar.vue
@@ -127,7 +127,7 @@
 
             <!-- Add a warning if this phyloreference has changed -->
             <ModifiedIcon
-              message="This phyloreference has been modified since being loaded! Use 'Save as JSON' to save your changes."
+              message="This phyloreference has been modified since being loaded! Use 'Save' to save your changes."
               :compare="phyloref"
               :compare-to="loadedPhyx.phylorefs[phylorefIndex]"
             />
@@ -195,7 +195,7 @@
 
           <!-- Add a warning if this phylogeny has changed -->
           <ModifiedIcon
-            message="This phylogeny has been modified since being loaded! Use 'Save as JSON' to save your changes."
+            message="This phylogeny has been modified since being loaded! Use 'Save' to save your changes."
             :compare="phylogeny"
             :compare-to="loadedPhyx.phylogenies[phylogenyIndex]"
           />

--- a/src/components/sidebar/Sidebar.vue
+++ b/src/components/sidebar/Sidebar.vue
@@ -55,6 +55,11 @@
           @click="downloadAsJSON()"
         >
           Save
+          <ModifiedIcon
+            message="This Phyx file has been modified since it was loaded! Use 'Save' to save your changes."
+            :compare="currentPhyx"
+            :compare-to="loadedPhyx"
+          />
         </a>
 
         <a

--- a/src/store/modules/phyx.js
+++ b/src/store/modules/phyx.js
@@ -6,7 +6,7 @@
  */
 
 import Vue from 'vue';
-import { has, cloneDeep } from 'lodash';
+import { has, cloneDeep, isEqual } from 'lodash';
 
 export default {
   state: {
@@ -21,6 +21,11 @@ export default {
     loadedPhyx: {
       phylorefs: [],
       phylogenies: [],
+    },
+  },
+  getters: {
+    loadedPhyxChanged(state) {
+      return !isEqual(state.currentPhyx, state.loadedPhyx);
     },
   },
   mutations: {


### PR DESCRIPTION
This PR fixes some issues with modified icons and cards, reactivating the modified card at the top of the page (#166) and correcting some of the text we use. It also fixes a bug that prevented the "Are you sure you want to leave this page?" warning from popping up correctly and adds a modified icon next to the "Save" button on the sidebar when the phyloreference has been saved.