### PR TITLE
Fix bugs in setting a default nomenclatural code

### DIFF
--- a/src/components/specifiers/Specifier.vue
+++ b/src/components/specifiers/Specifier.vue
@@ -407,7 +407,7 @@ export default {
   computed: {
     nomenCodes: () => TaxonNameWrapper.getNomenclaturalCodes(),
     nomenclaturalCodeObj() {
-      return TaxonNameWrapper.getNomenCodeAsObject(this.enteredNomenclaturalCode || TaxonNameWrapper.NAME_IN_UNKNOWN_CODE);
+      return TaxonNameWrapper.getNomenCodeAsObject(this.enteredNomenclaturalCode);
     },
     specifier() {
       // Check the specifierClass before we figure out how to construct the

--- a/src/components/specifiers/Specifier.vue
+++ b/src/components/specifiers/Specifier.vue
@@ -399,7 +399,7 @@ export default {
       specifierClass: undefined,
       specimenWrapped: undefined,
       taxonNameWrapped: undefined,
-      enteredNomenclaturalCode: undefined,
+      enteredNomenclaturalCode: this.$store.getters.getDefaultNomenCodeURI,
       enteredVerbatimLabel: undefined,
       externalReference: undefined,
     };
@@ -578,9 +578,6 @@ export default {
     recalculateEntered() {
       console.log("Recalculating entered values from: ", this.remoteSpecifier);
 
-      // Set some defaults.
-      this.enteredNomenclaturalCode = this.$store.getters.getDefaultNomenCodeURI;
-
       // Recalculate the entered values.
       const tunit = new TaxonomicUnitWrapper(cloneDeep(this.remoteSpecifier || {}));
 
@@ -599,7 +596,8 @@ export default {
       const taxonConceptWrapped = new TaxonConceptWrapper(tunit.taxonConcept)
       if (taxonConceptWrapped && taxonConceptWrapped.taxonName) {
         this.taxonNameWrapped = new TaxonNameWrapper(taxonConceptWrapped.taxonName);
-        this.enteredNomenclaturalCode = this.taxonNameWrapped.nomenclaturalCode;
+        this.enteredNomenclaturalCode = this.taxonNameWrapped.nomenclaturalCode ||
+          this.enteredNomenclaturalCode;
       }
 
       if (tunit.specimen) {

--- a/src/components/specifiers/Specifier.vue
+++ b/src/components/specifiers/Specifier.vue
@@ -578,6 +578,9 @@ export default {
     recalculateEntered() {
       console.log("Recalculating entered values from: ", this.remoteSpecifier);
 
+      // Set some defaults.
+      this.enteredNomenclaturalCode = this.$store.getters.getDefaultNomenCodeURI;
+
       // Recalculate the entered values.
       const tunit = new TaxonomicUnitWrapper(cloneDeep(this.remoteSpecifier || {}));
 
@@ -596,8 +599,7 @@ export default {
       const taxonConceptWrapped = new TaxonConceptWrapper(tunit.taxonConcept)
       if (taxonConceptWrapped && taxonConceptWrapped.taxonName) {
         this.taxonNameWrapped = new TaxonNameWrapper(taxonConceptWrapped.taxonName);
-        this.enteredNomenclaturalCode = this.taxonNameWrapped.nomenclaturalCode ||
-          this.$store.getters.getDefaultNomenCodeURI;
+        this.enteredNomenclaturalCode = this.taxonNameWrapped.nomenclaturalCode;
       }
 
       if (tunit.specimen) {

--- a/src/store/modules/phyx.js
+++ b/src/store/modules/phyx.js
@@ -6,6 +6,7 @@
  */
 
 import Vue from 'vue';
+import { TaxonNameWrapper } from '@phyloref/phyx';
 import { has, cloneDeep } from 'lodash';
 
 export default {
@@ -26,7 +27,7 @@ export default {
   getters: {
     getDefaultNomenCodeURI(state) {
       return state.currentPhyx.defaultNomenclaturalCodeURI
-        || 'http://purl.obolibrary.org/obo/NOMEN_0000036'; // NOMEN:scientific name.
+        || TaxonNameWrapper.NAME_IN_UNKNOWN_CODE;
     },
   },
   mutations: {

--- a/src/store/modules/phyx.js
+++ b/src/store/modules/phyx.js
@@ -23,6 +23,12 @@ export default {
       phylogenies: [],
     },
   },
+  getters: {
+    getDefaultNomenCodeURI(state) {
+      return state.currentPhyx.defaultNomenclaturalCodeURI
+        || 'http://purl.obolibrary.org/obo/NOMEN_0000036'; // NOMEN:scientific name.
+    },
+  },
   mutations: {
     setCurrentPhyx(state, phyx) {
       // Replace the current Phyx file using an object. This method does NOT


### PR DESCRIPTION
A previous commit (96d8dbce6e38 from PR #150) had partially removed one part of the default nomenclatural code system, causing it to stop working. This PR restores that and changes where the default nomenclatural code is set up in the Specifier component, so it actually work correctly now.