### PR TITLE
Several minor fixes to the Curation Tool

### DIFF
--- a/src/components/phyloref/PhylorefView.vue
+++ b/src/components/phyloref/PhylorefView.vue
@@ -109,7 +109,7 @@
       </h5>
       <div class="card-body">
         <form>
-          <!-- Phyx collection name (if we have more than one phyloref!) -->
+          <!-- Phyloreference type -->
           <div class="form-group row">
             <label
               for="phyloref-type"
@@ -129,7 +129,7 @@
           </div>
         </form>
 
-        <h6>Internal specifiers</h6>
+        <h5>Internal specifiers</h5>
 
         <template v-if="!selectedPhyloref.internalSpecifiers || selectedPhyloref.internalSpecifiers.length === 0">
           <p><em>No internal specifiers in this phyloreference.</em></p>
@@ -146,7 +146,7 @@
           />
         </div>
 
-        <h6 class="mt-2">External specifiers</h6>
+        <h5 class="mt-2">External specifiers</h5>
 
         <template v-if="!selectedPhyloref.externalSpecifiers  || selectedPhyloref.externalSpecifiers.length === 0">
           <p><em>No external specifiers in this phyloreference.</em></p>

--- a/src/components/phyx/PhyxView.vue
+++ b/src/components/phyx/PhyxView.vue
@@ -294,7 +294,7 @@ export default {
     },
     getPhylorefLabel(phyloref) {
       return new PhylorefWrapper(phyloref).label ||
-        `Phyloref ${this.phylogenies.indexOf(phyloref) + 1}`;
+        `Phyloref ${this.phylorefs.indexOf(phyloref) + 1}`;
     },
     hasReasoningResults(phyloref) {
       if (!has(this.$store.state.resolution.reasoningResults, 'phylorefs')) return false;

--- a/src/components/specifiers/Specifier.vue
+++ b/src/components/specifiers/Specifier.vue
@@ -481,18 +481,16 @@ export default {
         switch (this.specifierClass) {
           case 'Taxon':
             // Try to extract a taxon name from this.
-            const taxonNameWrapped = TaxonNameWrapper.fromVerbatimName(
+            this.taxonNameWrapped = TaxonNameWrapper.fromVerbatimName(
               label,
               this.enteredNomenclaturalCode
             );
-            if (taxonNameWrapped) this.taxonNameWrapped = taxonNameWrapped;
             break;
 
           case 'Specimen':
-            const specimenWrapped = SpecimenWrapper.fromOccurrenceID(
+            this.specimenWrapped = SpecimenWrapper.fromOccurrenceID(
               label
             );
-            if (specimenWrapped) this.specimenWrapped = specimenWrapped;
             break;
 
           case 'Apomorphy':


### PR DESCRIPTION
This PR fixes four issues related generally to the user interface:
- Taxon name or specimen identifiers that can't be parsed no longer replace the existing taxon name or specifier identifier.
- Tried to look up the index of a phyloreference in the list of phylogenies rather than phyloreferences; fixed.
- Makes "Internal specifiers"/"External specifiers" section headers smaller (h5 to h6).
- Fixes an incorrect HTML comment.