### PR TITLE
Deploy to GitHub pages via Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,5 +22,6 @@ deploy:
   github_token: $PHYLOREFBOT_GITHUB_TOKEN
   keep_history: true
   local_dir: docs
+  committer_from_gh: true
   on:
     branch: master

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,3 +14,13 @@ cache:
     - node_modules
 
 sudo: false
+
+script: npm run build
+deploy:
+  provider: pages
+  skip_cleanup: true
+  github_token: $PHYLOREFBOT_GITHUB_TOKEN
+  keep_history: true
+  local_dir: dist
+  on:
+    branch: master

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,4 +23,4 @@ deploy:
   keep_history: true
   local_dir: docs
   on:
-    branch: master
+    branch: deploy-to-github-pages-via-travis

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,4 +23,4 @@ deploy:
   keep_history: true
   local_dir: docs
   on:
-    branch: deploy-to-github-pages-via-travis
+    branch: master

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,6 @@ deploy:
   skip_cleanup: true
   github_token: $PHYLOREFBOT_GITHUB_TOKEN
   keep_history: true
-  local_dir: dist
+  local_dir: docs
   on:
     branch: master


### PR DESCRIPTION
This PR updates Travis CI settings so that it will automatically deploy the master branch to Github Pages by adding commits to the [`gh-pages` branch](https://github.com/phyloref/curation-tool/tree/gh-pages). It does that using the Github  token from the [PhylorefBot](http://github.com/phylorefbot) user account, which only has write access to the Curation Tool repository. Changes will appear to be made by @phylorefbot.