### PR TITLE
Fix discrepancy in phyloref numbering

### DIFF
--- a/public/examples/brochu_2003.json
+++ b/public/examples/brochu_2003.json
@@ -77,6 +77,7 @@
             ]
         },
         {
+            "@id": "#crocodylia",
             "label": "Crocodylia",
             "cladeDefinition": "Crocodylia (Gmelin 1789). Amended definition.\n\nLast common ancestor of Gavialis gangeticus, Alligator mississippiensis, and Crocodylus niloticus and all of its\t descendents.",
             "internalSpecifiers": [

--- a/src/store/modules/resolution.js
+++ b/src/store/modules/resolution.js
@@ -6,7 +6,7 @@
 import Vue from 'vue';
 import { has, cloneDeep } from 'lodash';
 
-import { PhylogenyWrapper } from '@phyloref/phyx';
+import { PhyxWrapper, PhylogenyWrapper } from '@phyloref/phyx';
 
 export default {
   state: {
@@ -15,9 +15,9 @@ export default {
   },
   getters: {
     // Return a base URI for a given phylogeny.
-    getBaseURIForPhylogeny: (state, getters, rootState) => phylogeny => `#phylogeny${rootState.phyx.currentPhyx.phylogenies.indexOf(phylogeny) + 1}`,
+    getBaseURIForPhylogeny: (state, getters, rootState) => phylogeny => PhyxWrapper.getBaseURIForPhylogeny(rootState.phyx.currentPhyx.phylogenies.indexOf(phylogeny)),
     // Return a base URI for a given phyloreference.
-    getBaseURIForPhyloref: (state, getters, rootState) => phyloref => `#phyloref${rootState.phyx.currentPhyx.phylorefs.indexOf(phyloref) + 1}`,
+    getBaseURIForPhyloref: (state, getters, rootState) => phyloref => PhyxWrapper.getBaseURIForPhyloref(rootState.phyx.currentPhyx.phylorefs.indexOf(phyloref)),
     // Return the identifier for a given phylogeny. We will use getBaseURIForPhylogeny()
     // unless one has already been set.
     getPhylogenyId: (state, getters) => (phylogeny) => {


### PR DESCRIPTION
I noticed an off-by-one bug in the phyloreferencing results, and realized it was because the Curation Tool and Phyx.js were numbering phyloreferences differently, with the result that reasoning results from the server pointed to the wrong phylorefs. This PR fixes that bug.