### PR TITLE
Updated JPhyloRef submission URL to reasoner.phyloref.org.

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -1,6 +1,6 @@
 module.exports = {
   // URL for submitting jobs to JPhyloRef for processing.
-  JPHYLOREF_SUBMISSION_URL: 'http://reasoner.phyloref.org/reason',
+  JPHYLOREF_SUBMISSION_URL: 'https://reasoner.phyloref.org/reason',
 
   // X-Hub-Signature secret used to communicate with JPhyloRef.
   JPHYLOREF_X_HUB_SIGNATURE_SECRET: 'undefined',

--- a/src/config.js
+++ b/src/config.js
@@ -1,6 +1,6 @@
 module.exports = {
   // URL for submitting jobs to JPhyloRef for processing.
-  JPHYLOREF_SUBMISSION_URL: 'http://phyloref.ggvaidya.com/reason',
+  JPHYLOREF_SUBMISSION_URL: 'http://reasoner.phyloref.org/reason',
 
   // X-Hub-Signature secret used to communicate with JPhyloRef.
   JPHYLOREF_X_HUB_SIGNATURE_SECRET: 'undefined',


### PR DESCRIPTION
This PR standardizes the JPhyloRef submission URL to https://reasoner.phyloref.org. The plan going forward is to leave this URL unchanged in the configuration, and to modify the DNS settings of that domain so that it points to an HTTPS server capable of reasoning over phyloreferences.