### PR TITLE
Removed redundant deployment via Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,14 +14,3 @@ cache:
     - node_modules
 
 sudo: false
-
-script: npm run build
-deploy:
-  provider: pages
-  skip_cleanup: true
-  github_token: $PHYLOREFBOT_GITHUB_TOKEN
-  keep_history: true
-  local_dir: docs
-  committer_from_gh: true
-  on:
-    branch: master


### PR DESCRIPTION
Back in PR #174, I implemented deployment to GitHub Pages in Travis CI. This was right before I moved to North Carolina, so it looks like I implemented the deployment but never changed the settings to use the `gh-pages` branch instead of the `master` branch. Consequently, I forgot that this code had already been included and so reimplemented it in GitHub Actions in PR #188. This PR removes the previously implemented Travis CI implementation so we rely solely on GitHub Actions for deployment to GitHub Pages.

It's worth mentioning that the Travis CI system would sometimes fail unexpectedly with an error (e.g. https://travis-ci.org/phyloref/curation-tool/jobs/632392385#L2785-L2800, https://travis-ci.org/phyloref/curation-tool/jobs/644025599#L2785-L2799), so it's probably a good thing that we've (1) moved over to GitHub Actions, and (2) set it up to be triggered on a release rather than triggered every time a PR is merged into master. If there ends up being any reason to go back to Travis CI for deployment, we can always resuscitate this code later.