### PR TITLE
Rename Curation Tool to Klados

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
-# Change log for the Curation tool
+# Change log for Klados
 
 Based on the suggestion at https://keepachangelog.com/en/1.0.0/.
 
 ## [Unreleased]
+- Rename Curation Tool to Klados ([#161](https://github.com/phyloref/curation-tool/issues/161))
 - Rewrote Curation Tool using Vue CLI to break it up into components.
 
 ## 0.1.0 - 2018-05-21

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Klados
 
-Klados is designed to allow users to curate [phyloreferences]
+Klados allows users to curate [phyloreferences]
 side-by-side with the phylogenies they were originally defined on. The curated phylogenies
 are stored in the [Phyx format], which can be downloaded as an [OWL 2 ontology]
 in the [JSON-LD format]. Phyx files can be incorporated into the [Clade Ontology].

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Phyloreferencing Curation Tool
+# Klados
 
-The Phyloreferencing Curation Tool is designed to allow users to curate [phyloreferences]
+Klados is designed to allow users to curate [phyloreferences]
 side-by-side with the phylogenies they were originally defined on. The curated phylogenies
 are stored in the [Phyx format], which can be downloaded as an [OWL 2 ontology]
 in the [JSON-LD format]. Phyx files can be incorporated into the [Clade Ontology].

--- a/public/index.html
+++ b/public/index.html
@@ -16,7 +16,7 @@
   </head>
   <body>
     <noscript>
-      <strong>We're sorry but Klados doesn't work properly without JavaScript enabled. Please enable it to continue.</strong>
+      <strong>To work properly Klados requires JavaScript. Please enable it to continue.</strong>
     </noscript>
     <div id="app"></div>
     <!-- built files will be auto injected -->

--- a/public/index.html
+++ b/public/index.html
@@ -12,11 +12,11 @@
     <script src="./phylotree.js/phylotree.js"></script>
     <link rel="stylesheet" href="./phylotree.js/phylotree.css" />
 
-    <title>Phyloreferencing Curation Tool</title>
+    <title>Klados</title>
   </head>
   <body>
     <noscript>
-      <strong>We're sorry but curation-tool doesn't work properly without JavaScript enabled. Please enable it to continue.</strong>
+      <strong>We're sorry but Klados doesn't work properly without JavaScript enabled. Please enable it to continue.</strong>
     </noscript>
     <div id="app"></div>
     <!-- built files will be auto injected -->

--- a/src/App.vue
+++ b/src/App.vue
@@ -78,7 +78,7 @@ export default {
     // browsers do not display this message, but provide a generic
     // "content has changed" dialog instead.
     $(window).on('beforeunload', () => {
-      const confirmationMessage = 'Your modifications have not been saved and will be lost if you close the Curation Tool. Confirm to discard your changes, or cancel to return to the Curation Tool.';
+      const confirmationMessage = 'Your modifications have not been saved and will be lost if you close Klados. Confirm to discard your changes, or cancel to return to Klados.';
 
       if (!isEqual(this.loadedPhyx, this.currentPhyx)) return confirmationMessage;
       return false;

--- a/src/components/modals/AboutCurationToolModal.vue
+++ b/src/components/modals/AboutCurationToolModal.vue
@@ -31,7 +31,7 @@
         <!-- Body of the about-us modal dialog -->
         <div class="modal-body col-md-12">
           <p>
-            The Phyloreferencing Curation Tool was built as part of the
+            Klados was built as part of the
             <a href="https://www.phyloref.org">
               Phyloreferencing project
             </a>,
@@ -47,7 +47,7 @@
             </a> for details.
           </p>
 
-          <p>The Curation Tool uses a number of open-source libraries, including:</p>
+          <p>Klados uses a number of open-source libraries, including:</p>
 
           <ul>
             <li>
@@ -113,7 +113,7 @@
 
 <script>
 /*
- * A modal for displaying information about the Curation Tool
+ * A modal for displaying information about Klados
  */
 
 export default {

--- a/vue.config.js
+++ b/vue.config.js
@@ -1,6 +1,6 @@
 module.exports = {
   // Set a prefix so we can host this on Github Pages.
-  publicPath: '/curation-tool/',
+  publicPath: '/klados/',
 
   // Write out to ./docs so we can host on Github Pages without
   // deploying separately to gh-pages.


### PR DESCRIPTION
This PR renames the Curation Tool to Klados and changes the public path to /klados/. Once it has been merged, the repository will need to be renamed to Klados as well. Closes #161.